### PR TITLE
fix: Add UTF-8 encoding for markdown file operations

### DIFF
--- a/src/plan/run_plan_pipeline.py
+++ b/src/plan/run_plan_pipeline.py
@@ -268,7 +268,8 @@ class SWOTAnalysisTask(PlanTask):
             json.dump(swot_raw_dict, f, indent=2)
 
         # Write the SWOT analysis as Markdown.
-        with self.output()['markdown'].open("w") as f:
+        markdown_path = self.output()['markdown'].path
+        with open(markdown_path, "w", encoding="utf-8") as f:
             f.write(swot_markdown)
 
         logger.info("SWOT analysis complete.")
@@ -310,7 +311,8 @@ class ExpertReviewTask(PlanTask):
             pre_project_assessment_dict = json.load(f)
         with self.input()['project_plan'].open("r") as f:
             project_plan_dict = json.load(f)
-        with self.input()['swot_analysis']['markdown'].open("r") as f:
+        swot_markdown_path = self.input()['swot_analysis']['markdown'].path
+        with open(swot_markdown_path, "r", encoding="utf-8") as f:
             swot_markdown = f.read()
 
         # Build the query.


### PR DESCRIPTION
Fixed UnicodeEncodeError in run_plan_pipeline.py by:
- Using UTF-8 encoding when writing SWOT analysis markdown file
- Using UTF-8 encoding when reading SWOT markdown in ExpertReviewTask
- Switched from luigi.LocalTarget.open() to built-in open() for encoding support

This resolves character encoding issues when handling non-ASCII text in markdown files.