### PR TITLE
Add support for HuggingFace GGUF models in Ollama

### DIFF
--- a/src/llm_util/ollama_info.py
+++ b/src/llm_util/ollama_info.py
@@ -2,6 +2,7 @@
 PROMPT> python -m src.llm_util.ollama_info
 """
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class OllamaInfo:
@@ -11,7 +12,7 @@ class OllamaInfo:
     """
     model_names: list[str]
     is_running: bool
-    error_message: str = None
+    error_message: Optional[str] = None
 
     @classmethod
     def obtain_info(cls) -> 'OllamaInfo':
@@ -34,7 +35,23 @@ class OllamaInfo:
         return OllamaInfo(model_names=model_names, is_running=True, error_message=None)
     
     def is_model_available(self, find_model: str) -> bool:
-        """Checks if a specific model is available in the list of model names."""
+        """
+        Checks if a specific model is available.
+        
+        Args:
+            find_model: Name of the model to check. Can be either a local Ollama model
+                       or a HuggingFace GGUF model (prefixed with 'hf.co/').
+
+        Returns:
+            bool: True if the model is available or is a valid GGUF model path.
+        """
+        if not find_model:
+            return False
+            
+        # Support direct use of GGUF models from HuggingFace
+        if find_model.startswith("hf.co/"):
+            return True
+            
         return find_model in self.model_names
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Add support for HuggingFace GGUF models in Ollama

## Description
This PR adds support for running GGUF models directly from HuggingFace through Ollama using the `hf.co/` prefix in model configurations. This enables users to leverage a wider range of models without requiring manual model installation.

## Changes
- Updated `OllamaInfo.is_model_available()` to recognize HuggingFace GGUF model paths
- Added documentation and examples for using GGUF models
- Added test case for GGUF model path validation

## Example Configuration
```json
{
    "lmstudio-qwen2.5-7b-instruct-1m-gguf": {
        "comment": "This runs on your own computer via Ollama using GGUF models from HuggingFace.",
        "class": "Ollama",
        "arguments": {
            "model": "hf.co/lmstudio-community/Qwen2.5-7B-Instruct-1M-GGUF:Q6_K",
            "temperature": 0.5,
            "request_timeout": 120.0,
            "is_function_calling_model": false
        }
    }
}
```