### PR TITLE
Fix schedule CSV sorting bug

### DIFF
--- a/src/schedule/schedule.py
+++ b/src/schedule/schedule.py
@@ -297,7 +297,11 @@ class ProjectSchedule:
                 return format(val.normalize(), "f")  # fixed‑point, no exponent
             return str(val)
 
-        if sort_by not in Activity.__dict__ and sort_by != "id":
+        # ``Activity`` is a dataclass so most attributes are stored in
+        # ``Activity.__dataclass_fields__`` rather than ``Activity.__dict__``.
+        # Using ``__dict__`` means valid fields like ``duration`` are rejected.
+        valid_fields = set(Activity.__dataclass_fields__.keys()) | {"id"}
+        if sort_by not in valid_fields:
             raise ValueError(f"Unknown sort key: {sort_by!r}")
 
         acts = sorted(self.activities.values(), key=lambda a: getattr(a, sort_by))

--- a/src/schedule/tests/test_schedule.py
+++ b/src/schedule/tests/test_schedule.py
@@ -281,5 +281,19 @@ class TestSchedule(unittest.TestCase):
         self.assertEqual(project_schedule.project_duration, D("6"))
         self.assertListEqual(project_schedule.obtain_critical_path(), ["A", "B"])
 
+    def test_to_csv_sort_by_duration(self):
+        """Ensure sorting by dataclass field like 'duration' works."""
+        input = dedent_strip("""
+            Activity;Predecessor;Duration
+            A;-;2
+            B;-;5
+            C;-;3
+        """)
+
+        project_schedule = ProjectSchedule.create(parse_schedule_input_data(input))
+        csv_output = project_schedule.to_csv(sort_by="duration")
+        durations = [line.split(";")[1] for line in csv_output.splitlines()[1:]]
+        self.assertEqual(durations, ["2", "3", "5"])
+
 if __name__ == "__main__":
     unittest.main(argv=["first-arg-is-ignored"], exit=False)


### PR DESCRIPTION
## Summary
- fix schedule.to_csv to recognize dataclass fields
- test sorting by duration

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3b2c95d4832d971f398d1ece7cfa