### PR TITLE
Fix copy button missing for newly created API key

### DIFF
--- a/frontend_multi_user/templates/account.html
+++ b/frontend_multi_user/templates/account.html
@@ -571,8 +571,9 @@
                                 <td>
                                     <span class="key-secret-full">
                                         <code class="key-prefix">{{ key.key_prefix }}...</code>
-                                        {% if key.key_plaintext %}
-                                        <button type="button" class="key-copy-btn" title="Copy" onclick="copyKeySecret(this, '{{ key.key_plaintext }}')">
+                                        {% set copyable_key = key.key_plaintext or (new_api_key if new_api_key and new_api_key.startswith(key.key_prefix) else None) %}
+                                        {% if copyable_key %}
+                                        <button type="button" class="key-copy-btn" title="Copy" onclick="copyKeySecret(this, '{{ copyable_key }}')">
                                             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                                         </button>
                                         {% endif %}


### PR DESCRIPTION
## Summary

- The copy-to-clipboard button was missing for the top row in the API keys table on the /account page
- When `api_key_show_once` is enabled, `key_plaintext` is `None` in the DB, so the `{% if key.key_plaintext %}` check skipped the button
- Now falls back to `new_api_key` (from session flash) when the key prefix matches, so the copy button appears on the first render after creation

## Test plan

- [x] Create a new API key, verify copy button appears in both the flash banner and the table row
- [x] Refresh page, verify the copy button disappears (show-once behavior preserved)
- [x] Other rows with `key_plaintext` still show their copy buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)