### PR TITLE
Fix dimmed copy icon for legacy API keys missing plaintext

### DIFF
--- a/frontend_multi_user/templates/account.html
+++ b/frontend_multi_user/templates/account.html
@@ -576,6 +576,10 @@
                                         <button type="button" class="key-copy-btn" title="Copy" onclick="copyKeySecret(this, '{{ copyable_key }}')">
                                             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                                         </button>
+                                        {% else %}
+                                        <span class="key-copy-btn" title="Rotate this key to enable copy" style="opacity:0.3;cursor:default;">
+                                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                                        </span>
                                         {% endif %}
                                     </span>
                                 </td>


### PR DESCRIPTION
## Summary

- Keys created before the `key_plaintext` column migration have `NULL` plaintext — the copy button was completely hidden for these rows
- Now shows a dimmed copy icon with tooltip "Rotate this key to enable copy" so the user understands why and knows how to fix it
- Keys with stored plaintext continue to show the normal copy button

## Root cause

The `key_plaintext` column was added via migration. Keys created before the migration have `NULL` and the plaintext can't be recovered. Rotating the key generates a new one with `key_plaintext` stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)