### PR TITLE
Fix MCP plan_create: write plan_raw.json instead of plan.txt

### DIFF
--- a/worker_plan_database/app.py
+++ b/worker_plan_database/app.py
@@ -1399,7 +1399,7 @@ def process_pending_tasks() -> bool:
 
     # write the task prompt to the run_id_dir
     plan_file = PlanFile.create(vague_plan_description=prompt, start_time=start_time)
-    plan_file.save(str(run_id_dir / FilenameEnum.INITIAL_PLAN.value))
+    plan_file.save(str(run_id_dir / FilenameEnum.INITIAL_PLAN_RAW.value))
 
     with app.app_context():
         event_context = {


### PR DESCRIPTION
## Summary

- `worker_plan_database/app.py` was still writing `plan.txt` directly instead of `plan_raw.json`
- This caused `SetupTask` to fail with "plan_raw.json does not exist" when plans were created via MCP `plan_create`
- One-line fix: `INITIAL_PLAN` → `INITIAL_PLAN_RAW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)