### PR TITLE
Fix Gradio UI freezing when switching tabs

### DIFF
--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,27 +857,7 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: .load with minimal outputs (no settings components).
-    def initialize_browser_settings_minimal(browser_state, session_state: SessionState):
-        try:
-            settings = json.loads(browser_state) if browser_state else {}
-        except Exception:
-            settings = {}
-        session_state.openrouter_api_key = settings.get("openrouter_api_key_text", "")
-        session_state.llm_model = settings.get("model_radio", default_model_value)
-        session_state.speedvsdetail = settings.get("speedvsdetail_radio", SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW)
-        session_state.model_profile = settings.get("model_profile_radio", ModelProfileEnum.BASELINE.value)
-        return session_state
-
-    demo_text2plan.load(
-        fn=initialize_browser_settings_minimal,
-        inputs=[browser_state, session_state],
-        outputs=[session_state]
-    ).then(
-        fn=check_api_key,
-        inputs=[session_state],
-        outputs=[api_key_warning]
-    )
+    # DEBUG: Only open_dir .load — no browser_state involved.
     demo_text2plan.load(
         fn=update_open_dir_button_visibility,
         outputs=[open_dir_btn]

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,10 +857,9 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: Only open_dir .load — testing if a single .load works.
+    # DEBUG: .load with a no-op function, no outputs.
     demo_text2plan.load(
-        fn=update_open_dir_button_visibility,
-        outputs=[open_dir_btn]
+        fn=lambda: None,
     )
 
 def run_app():

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,13 +857,20 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: All settings callbacks, .load handlers disabled to isolate hang.
-    # purge_button.click(...)
-    # openrouter_api_key_text.change(...)
-    # model_radio.change(...)
-    # speedvsdetail_radio.change(...)
-    # model_profile_radio.change(...)
-    # demo_text2plan.load(...)
+    # DEBUG: Only .load handlers re-enabled.
+    demo_text2plan.load(
+        fn=initialize_browser_settings,
+        inputs=[browser_state, session_state],
+        outputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, browser_state, session_state]
+    ).then(
+        fn=check_api_key,
+        inputs=[session_state],
+        outputs=[api_key_warning]
+    )
+    demo_text2plan.load(
+        fn=update_open_dir_button_visibility,
+        outputs=[open_dir_btn]
+    )
 
 def run_app():
     # print("Environment variables Gradio:\n" + get_env_as_string() + "\n\n\n")

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -751,68 +751,33 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
                 )
 
     with gr.Tab("Settings"):
-        speedvsdetail_items = [
-            ("Ping", SpeedVsDetailEnum.PING_LLM),
-            ("All details, but slow", SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW),
-            ("Fast, but few details", SpeedVsDetailEnum.FAST_BUT_SKIP_DETAILS),
-        ]
+        gr.Markdown("Settings tab placeholder — testing if tab opens without hanging.")
         speedvsdetail_radio = gr.Radio(
-            speedvsdetail_items,
+            [("All details, but slow", SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW)],
             value=SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW,
             label="Speed vs Detail",
-            interactive=True 
+            interactive=True,
+            visible=False,
         )
-
-        if CONFIG.visible_llm_info:
-            if llm_info.ollama_status == OllamaStatus.ollama_not_running:
-                gr.Markdown("**Ollama is not running**, so Ollama models are unavailable. Please start Ollama to use them.")
-            elif llm_info.ollama_status == OllamaStatus.mixed:
-                gr.Markdown("**Mixed. Some Ollama models are running, but some are NOT running.**, You may have to start the ones that aren't running.")
-
-            if len(llm_info.error_message_list) > 0:
-                gr.Markdown("**Error messages:**")
-                for error_message in llm_info.error_message_list:
-                    gr.Markdown(f"- {error_message}")
-
         model_radio = gr.Radio(
-            available_model_names,
+            available_model_names[:1] if available_model_names else [("default", "default")],
             value=default_model_value,
             label="Model",
-            interactive=True 
+            interactive=True,
+            visible=False,
         )
-
         model_profile_radio = gr.Radio(
-            [
-                ("Baseline", ModelProfileEnum.BASELINE.value),
-                ("Premium", ModelProfileEnum.PREMIUM.value),
-                ("Frontier", ModelProfileEnum.FRONTIER.value),
-                ("Custom", ModelProfileEnum.CUSTOM.value),
-            ],
+            [("Baseline", ModelProfileEnum.BASELINE.value)],
             value=ModelProfileEnum.BASELINE.value,
             label="Model Profile",
-            info="Select which profile file is used by auto model selection.",
             interactive=True,
+            visible=False,
         )
-        gr.Markdown(
-            "\n".join(
-                [
-                    "**Profile details**",
-                    "- `baseline` -> `llm_config/baseline.json` (default balanced profile).",
-                    "- `premium` -> `llm_config/premium.json` (higher-cost model ordering).",
-                    "- `frontier` -> `llm_config/frontier.json` (most capable model ordering).",
-                    "- `custom` -> `llm_config/custom.json` or `PLANEXE_LLM_CONFIG_CUSTOM_FILENAME` (filename only, e.g. `custom.json`).",
-                    "- The exact models come from the selected JSON file priorities.",
-                ]
-            )
-        )
-        profile_models_markdown = gr.Markdown(_profile_models_markdown(ModelProfileEnum.BASELINE.value))
-
+        profile_models_markdown = gr.Markdown("", visible=False)
         openrouter_api_key_text = gr.Textbox(
             label="OpenRouter API Key",
             type="password",
-            placeholder="Enter your OpenRouter API key (required)",
-            info="Sign up at [OpenRouter](https://openrouter.ai/) to get an API key. A small top-up (e.g. 5 USD) is needed to access paid models.",
-            visible=CONFIG.visible_openrouter_api_key_textbox
+            visible=False,
         )
 
     with gr.Tab("Advanced"):

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -745,40 +745,74 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
                 download_output = gr.File(label="Download latest output (excluding log.txt) as zip")
 
             with gr.Column(scale=1, min_width=300):
-                gr.Markdown("*(Examples disabled for debugging)*")
-                # examples = gr.Examples(
-                #     examples=gradio_examples,
-                #     inputs=[prompt_input],
-                # )
+                examples = gr.Examples(
+                    examples=gradio_examples,
+                    inputs=[prompt_input],
+                )
 
     with gr.Tab("Settings"):
-        gr.Markdown("Settings tab placeholder — testing if tab opens without hanging.")
+        speedvsdetail_items = [
+            ("Ping", SpeedVsDetailEnum.PING_LLM),
+            ("All details, but slow", SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW),
+            ("Fast, but few details", SpeedVsDetailEnum.FAST_BUT_SKIP_DETAILS),
+        ]
         speedvsdetail_radio = gr.Radio(
-            [("All details, but slow", SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW)],
+            speedvsdetail_items,
             value=SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW,
             label="Speed vs Detail",
-            interactive=True,
-            visible=False,
+            interactive=True
         )
+
+        if CONFIG.visible_llm_info:
+            if llm_info.ollama_status == OllamaStatus.ollama_not_running:
+                gr.Markdown("**Ollama is not running**, so Ollama models are unavailable. Please start Ollama to use them.")
+            elif llm_info.ollama_status == OllamaStatus.mixed:
+                gr.Markdown("**Mixed. Some Ollama models are running, but some are NOT running.**, You may have to start the ones that aren't running.")
+
+            if len(llm_info.error_message_list) > 0:
+                gr.Markdown("**Error messages:**")
+                for error_message in llm_info.error_message_list:
+                    gr.Markdown(f"- {error_message}")
+
         model_radio = gr.Radio(
-            available_model_names[:1] if available_model_names else [("default", "default")],
+            available_model_names,
             value=default_model_value,
             label="Model",
-            interactive=True,
-            visible=False,
+            interactive=True
         )
+
         model_profile_radio = gr.Radio(
-            [("Baseline", ModelProfileEnum.BASELINE.value)],
+            [
+                ("Baseline", ModelProfileEnum.BASELINE.value),
+                ("Premium", ModelProfileEnum.PREMIUM.value),
+                ("Frontier", ModelProfileEnum.FRONTIER.value),
+                ("Custom", ModelProfileEnum.CUSTOM.value),
+            ],
             value=ModelProfileEnum.BASELINE.value,
             label="Model Profile",
+            info="Select which profile file is used by auto model selection.",
             interactive=True,
-            visible=False,
         )
-        profile_models_markdown = gr.Markdown("", visible=False)
+        gr.Markdown(
+            "\n".join(
+                [
+                    "**Profile details**",
+                    "- `baseline` -> `llm_config/baseline.json` (default balanced profile).",
+                    "- `premium` -> `llm_config/premium.json` (higher-cost model ordering).",
+                    "- `frontier` -> `llm_config/frontier.json` (most capable model ordering).",
+                    "- `custom` -> `llm_config/custom.json` or `PLANEXE_LLM_CONFIG_CUSTOM_FILENAME` (filename only, e.g. `custom.json`).",
+                    "- The exact models come from the selected JSON file priorities.",
+                ]
+            )
+        )
+        profile_models_markdown = gr.Markdown(_profile_models_markdown(ModelProfileEnum.BASELINE.value))
+
         openrouter_api_key_text = gr.Textbox(
             label="OpenRouter API Key",
             type="password",
-            visible=False,
+            placeholder="Enter your OpenRouter API key (required)",
+            info="Sign up at [OpenRouter](https://openrouter.ai/) to get an API key. A small top-up (e.g. 5 USD) is needed to access paid models.",
+            visible=CONFIG.visible_openrouter_api_key_textbox
         )
 
     with gr.Tab("Advanced"):
@@ -856,6 +890,48 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
         outputs=[status_markdown, session_state]
     )
     # The download file value is updated by run_planner generator outputs.
+
+    # Settings change callbacks — update session_state and profile display.
+    settings_change_inputs = [openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, session_state]
+    settings_change_outputs = [profile_models_markdown, active_config_markdown, session_state]
+
+    def update_settings_on_change(openrouter_api_key, model, speedvsdetail, model_profile, session_state: SessionState):
+        session_state.openrouter_api_key = openrouter_api_key
+        session_state.llm_model = model
+        session_state.speedvsdetail = speedvsdetail
+        session_state.model_profile = model_profile
+        profile_markdown = _profile_models_markdown(model_profile)
+        return profile_markdown, "", session_state
+
+    openrouter_api_key_text.change(
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
+
+    model_radio.change(
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
+
+    speedvsdetail_radio.change(
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
+
+    model_profile_radio.change(
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
+
+    purge_button.click(
+        fn=trigger_purge_runs,
+        inputs=[purge_max_age_hours, session_state],
+        outputs=[purge_status, session_state]
+    )
 
     # Restore settings from BrowserState when it loads from localStorage.
     # We use browser_state.change instead of demo_text2plan.load because

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,8 +857,11 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: All .load handlers disabled.
-    pass
+    # DEBUG: Only open_dir .load — testing if a single .load works.
+    demo_text2plan.load(
+        fn=update_open_dir_button_visibility,
+        outputs=[open_dir_btn]
+    )
 
 def run_app():
     # print("Environment variables Gradio:\n" + get_env_as_string() + "\n\n\n")

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,11 +857,22 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: Only .load handlers re-enabled.
+    # DEBUG: .load with minimal outputs (no settings components).
+    def initialize_browser_settings_minimal(browser_state, session_state: SessionState):
+        try:
+            settings = json.loads(browser_state) if browser_state else {}
+        except Exception:
+            settings = {}
+        session_state.openrouter_api_key = settings.get("openrouter_api_key_text", "")
+        session_state.llm_model = settings.get("model_radio", default_model_value)
+        session_state.speedvsdetail = settings.get("speedvsdetail_radio", SpeedVsDetailEnum.ALL_DETAILS_BUT_SLOW)
+        session_state.model_profile = settings.get("model_profile_radio", ModelProfileEnum.BASELINE.value)
+        return session_state
+
     demo_text2plan.load(
-        fn=initialize_browser_settings,
+        fn=initialize_browser_settings_minimal,
         inputs=[browser_state, session_state],
-        outputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, browser_state, session_state]
+        outputs=[session_state]
     ).then(
         fn=check_api_key,
         inputs=[session_state],

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,10 +857,17 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: .load outputting to a markdown component.
-    demo_text2plan.load(
-        fn=lambda: "loaded",
-        outputs=[status_markdown]
+    # Restore settings from BrowserState when it loads from localStorage.
+    # We use browser_state.change instead of demo_text2plan.load because
+    # Gradio 6.11 has a bug where .load with outputs breaks tab switching.
+    browser_state.change(
+        fn=initialize_browser_settings,
+        inputs=[browser_state, session_state],
+        outputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, browser_state, session_state]
+    ).then(
+        fn=check_api_key,
+        inputs=[session_state],
+        outputs=[api_key_warning]
     )
 
 def run_app():

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,9 +857,10 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: .load with a no-op function, no outputs.
+    # DEBUG: .load outputting to a markdown component.
     demo_text2plan.load(
-        fn=lambda: None,
+        fn=lambda: "loaded",
+        outputs=[status_markdown]
     )
 
 def run_app():

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -745,10 +745,11 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
                 download_output = gr.File(label="Download latest output (excluding log.txt) as zip")
 
             with gr.Column(scale=1, min_width=300):
-                examples = gr.Examples(
-                    examples=gradio_examples,
-                    inputs=[prompt_input],
-                )
+                gr.Markdown("*(Examples disabled for debugging)*")
+                # examples = gr.Examples(
+                #     examples=gradio_examples,
+                #     inputs=[prompt_input],
+                # )
 
     with gr.Tab("Settings"):
         gr.Markdown("Settings tab placeholder — testing if tab opens without hanging.")

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,68 +857,13 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # Unified change callbacks for settings.
-    # NOTE: trigger="change" is Gradio's default. We must NOT output back to
-    # any component that is also an input — that would create an infinite
-    # client-side event loop (component changes → callback → component changes → …).
-    # We also avoid outputting to browser_state here; BrowserState updates
-    # can re-trigger .load in some Gradio versions, causing a cascade.
-    # Instead, browser_state is only written by initialize_browser_settings on load.
-    settings_change_inputs = [openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, session_state]
-    settings_change_outputs = [profile_models_markdown, active_config_markdown, session_state]
-
-    def update_settings_on_change(openrouter_api_key, model, speedvsdetail, model_profile, session_state: SessionState):
-        session_state.openrouter_api_key = openrouter_api_key
-        session_state.llm_model = model
-        session_state.speedvsdetail = speedvsdetail
-        session_state.model_profile = model_profile
-        profile_markdown = _profile_models_markdown(model_profile)
-        return profile_markdown, "", session_state
-
-    openrouter_api_key_text.change(
-        fn=update_settings_on_change,
-        inputs=settings_change_inputs,
-        outputs=settings_change_outputs,
-    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
-
-    model_radio.change(
-        fn=update_settings_on_change,
-        inputs=settings_change_inputs,
-        outputs=settings_change_outputs,
-    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
-
-    speedvsdetail_radio.change(
-        fn=update_settings_on_change,
-        inputs=settings_change_inputs,
-        outputs=settings_change_outputs,
-    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
-
-    model_profile_radio.change(
-        fn=update_settings_on_change,
-        inputs=settings_change_inputs,
-        outputs=settings_change_outputs,
-    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
-
-    purge_button.click(
-        fn=trigger_purge_runs,
-        inputs=[purge_max_age_hours, session_state],
-        outputs=[purge_status, session_state]
-    )
-
-    # Initialize settings on load from persistent browser_state.
-    demo_text2plan.load(
-        fn=initialize_browser_settings,
-        inputs=[browser_state, session_state],
-        outputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, browser_state, session_state]
-    ).then(
-        fn=check_api_key,
-        inputs=[session_state],
-        outputs=[api_key_warning]
-    )
-    demo_text2plan.load(
-        fn=update_open_dir_button_visibility,
-        outputs=[open_dir_btn]
-    )
+    # DEBUG: All settings callbacks, .load handlers disabled to isolate hang.
+    # purge_button.click(...)
+    # openrouter_api_key_text.change(...)
+    # model_radio.change(...)
+    # speedvsdetail_radio.change(...)
+    # model_profile_radio.change(...)
+    # demo_text2plan.load(...)
 
 def run_app():
     # print("Environment variables Gradio:\n" + get_env_as_string() + "\n\n\n")

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -382,7 +382,8 @@ def initialize_browser_settings(browser_state, session_state: SessionState):
     session_state.speedvsdetail = speedvsdetail
     session_state.model_profile = model_profile
     profile_markdown = _profile_models_markdown(model_profile)
-    return openrouter_api_key, model, speedvsdetail, model_profile, profile_markdown, "", browser_state, session_state
+    open_dir_visible = gr.update(visible=is_open_dir_service_running())
+    return openrouter_api_key, model, speedvsdetail, model_profile, profile_markdown, "", open_dir_visible, browser_state, session_state
 
 def save_browser_settings_callback(openrouter_api_key, model, speedvsdetail, model_profile, browser_state):
     """Persist current settings to BrowserState. Called on submit/retry, not on every change."""
@@ -939,7 +940,7 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     browser_state.change(
         fn=initialize_browser_settings,
         inputs=[browser_state, session_state],
-        outputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, browser_state, session_state]
+        outputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, open_dir_btn, browser_state, session_state]
     ).then(
         fn=check_api_key,
         inputs=[session_state],

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -857,11 +857,8 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     )
     # The download file value is updated by run_planner generator outputs.
 
-    # DEBUG: Only open_dir .load — no browser_state involved.
-    demo_text2plan.load(
-        fn=update_open_dir_button_visibility,
-        outputs=[open_dir_btn]
-    )
+    # DEBUG: All .load handlers disabled.
+    pass
 
 def run_app():
     # print("Environment variables Gradio:\n" + get_env_as_string() + "\n\n\n")

--- a/frontend_single_user/app.py
+++ b/frontend_single_user/app.py
@@ -384,7 +384,8 @@ def initialize_browser_settings(browser_state, session_state: SessionState):
     profile_markdown = _profile_models_markdown(model_profile)
     return openrouter_api_key, model, speedvsdetail, model_profile, profile_markdown, "", browser_state, session_state
 
-def update_browser_settings_callback(openrouter_api_key, model, speedvsdetail, model_profile, browser_state, session_state: SessionState):
+def save_browser_settings_callback(openrouter_api_key, model, speedvsdetail, model_profile, browser_state):
+    """Persist current settings to BrowserState. Called on submit/retry, not on every change."""
     try:
         settings = json.loads(browser_state) if browser_state else {}
     except Exception:
@@ -393,13 +394,7 @@ def update_browser_settings_callback(openrouter_api_key, model, speedvsdetail, m
     settings["model_radio"] = model
     settings["speedvsdetail_radio"] = speedvsdetail
     settings["model_profile_radio"] = model_profile
-    updated_browser_state = json.dumps(settings)
-    session_state.openrouter_api_key = openrouter_api_key
-    session_state.llm_model = model
-    session_state.speedvsdetail = speedvsdetail
-    session_state.model_profile = model_profile
-    profile_markdown = _profile_models_markdown(model_profile)
-    return updated_browser_state, openrouter_api_key, model, speedvsdetail, model_profile, profile_markdown, "", session_state
+    return json.dumps(settings)
 
 def run_planner(submit_or_retry_button, plan_prompt, browser_state, session_state: SessionState):
     """
@@ -849,6 +844,10 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
         inputs=session_state,
         outputs=[status_markdown, session_state]
     ).then(
+        fn=save_browser_settings_callback,
+        inputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, browser_state],
+        outputs=[browser_state]
+    ).then(
         fn=run_planner,
         inputs=[submit_btn, prompt_input, browser_state, session_state],
         outputs=[output_markdown, download_output, session_state]
@@ -861,6 +860,10 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
         fn=clear_status,
         inputs=session_state,
         outputs=[status_markdown, session_state]
+    ).then(
+        fn=save_browser_settings_callback,
+        inputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, browser_state],
+        outputs=[browser_state]
     ).then(
         fn=run_planner,
         inputs=[retry_btn, prompt_input, browser_state, session_state],
@@ -889,45 +892,46 @@ with gr.Blocks(title="PlanExe") as demo_text2plan:
     # The download file value is updated by run_planner generator outputs.
 
     # Unified change callbacks for settings.
+    # NOTE: trigger="change" is Gradio's default. We must NOT output back to
+    # any component that is also an input — that would create an infinite
+    # client-side event loop (component changes → callback → component changes → …).
+    # We also avoid outputting to browser_state here; BrowserState updates
+    # can re-trigger .load in some Gradio versions, causing a cascade.
+    # Instead, browser_state is only written by initialize_browser_settings on load.
+    settings_change_inputs = [openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, session_state]
+    settings_change_outputs = [profile_models_markdown, active_config_markdown, session_state]
+
+    def update_settings_on_change(openrouter_api_key, model, speedvsdetail, model_profile, session_state: SessionState):
+        session_state.openrouter_api_key = openrouter_api_key
+        session_state.llm_model = model
+        session_state.speedvsdetail = speedvsdetail
+        session_state.model_profile = model_profile
+        profile_markdown = _profile_models_markdown(model_profile)
+        return profile_markdown, "", session_state
+
     openrouter_api_key_text.change(
-        fn=update_browser_settings_callback,
-        inputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, browser_state, session_state],
-        outputs=[browser_state, openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, session_state]
-    ).then(
-        fn=check_api_key,
-        inputs=[session_state],
-        outputs=[api_key_warning]
-    )
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
 
     model_radio.change(
-        fn=update_browser_settings_callback,
-        inputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, browser_state, session_state],
-        outputs=[browser_state, openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, session_state]
-    ).then(
-        fn=check_api_key,
-        inputs=[session_state],
-        outputs=[api_key_warning]
-    )
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
 
     speedvsdetail_radio.change(
-        fn=update_browser_settings_callback,
-        inputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, browser_state, session_state],
-        outputs=[browser_state, openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, session_state]
-    ).then(
-        fn=check_api_key,
-        inputs=[session_state],
-        outputs=[api_key_warning]
-    )
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
 
     model_profile_radio.change(
-        fn=update_browser_settings_callback,
-        inputs=[openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, browser_state, session_state],
-        outputs=[browser_state, openrouter_api_key_text, model_radio, speedvsdetail_radio, model_profile_radio, profile_models_markdown, active_config_markdown, session_state]
-    ).then(
-        fn=check_api_key,
-        inputs=[session_state],
-        outputs=[api_key_warning]
-    )
+        fn=update_settings_on_change,
+        inputs=settings_change_inputs,
+        outputs=settings_change_outputs,
+    ).then(fn=check_api_key, inputs=[session_state], outputs=[api_key_warning])
 
     purge_button.click(
         fn=trigger_purge_runs,


### PR DESCRIPTION
## Summary

- The Gradio UI froze (100% CPU, browser unresponsive) when clicking any tab (Settings, Advanced, Join the community)
- **Root cause:** Gradio 6.11 has a bug where `demo.load()` with outputs breaks tab switching entirely. Any `.load` handler that outputs to a component causes an infinite client-side event loop.
- **Fix:** Replace all `demo_text2plan.load()` calls with `browser_state.change()`, which fires when BrowserState loads from localStorage on page load — same initialization, no `.load` bug.
- Additionally fixed `.change` callbacks that were outputting back to their trigger components (another potential infinite loop source) and removed `browser_state` from `.change` outputs.
- "Open Output Dir" button visibility check moved into the `browser_state.change` handler since `.load` can no longer be used.

## Changes

- `frontend_single_user/app.py`: Replace `.load` with `browser_state.change` for settings init, simplify `.change` callbacks, persist settings to `browser_state` only on submit/retry

## Test plan

- [x] Tab switching works (Settings, Advanced, Join the community)
- [x] Settings restore from localStorage on page load
- [x] Changing settings updates profile display
- [x] Submit/retry persists settings
- [x] "Open Output Dir" hidden when service not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)