### PR TITLE
fix: add trigger_source to PlanItem parameters for iframe users

### DIFF
--- a/frontend_multi_user/src/plan_routes.py
+++ b/frontend_multi_user/src/plan_routes.py
@@ -626,6 +626,9 @@ def run():
 
     is_authenticated = current_user.is_authenticated
 
+    if not is_authenticated:
+        parameters["trigger_source"] = "mach-ai iframe"
+
     if is_authenticated:
         if current_user.is_admin:
             if not user_id_param:


### PR DESCRIPTION
## Summary
- Set `"trigger_source": "mach-ai iframe"` in PlanItem parameters when the plan is created by an unauthenticated iframe user
- Makes iframe-created plans easy to identify in the database, consistent with MCP plans which already set `"trigger_source": "mcp plan_create"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)