### PR TITLE
feat: add openrouter-elephant-alpha model to baseline config

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -42,6 +42,28 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-elephant-alpha": {
+        "comment": "Released Apr 13, 2026. 262,144 context. $0/M input tokens. $0/M output tokens",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/openrouter/elephant-alpha",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "openrouter/elephant-alpha",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 1048576,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8192,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-gemini-2.0-flash-001": {
         "comment": "This is very fast. Created Feb 25, 2025. 1,048,576 context. $0.075/M input tokens. $0.30/M output tokens.",
         "priority": 1,


### PR DESCRIPTION
## Summary
- Add `openrouter-elephant-alpha` to `llm_config/baseline.json`
- Released Apr 13, 2026. 262K context, free tier pricing, no function calling
- No priority set — available for explicit selection but not in the default rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)