### PR TITLE
fix: self-audit physics false positive on non-physics plans

### DIFF
--- a/worker_plan/worker_plan_internal/self_audit/self_audit.py
+++ b/worker_plan/worker_plan_internal/self_audit/self_audit.py
@@ -22,6 +22,12 @@ https://planexe.org/20260303_crate_recovery_campaign_report.html
 gemini-2.5-flash-lite-preview-09-2025, thought that the laws of physics were violated, because a plan mentioned "CSR driven logistics".
 corporate social responsibility (CSR), which has nothing to do with faster than light travel, but was flagged as "violates known physics".
 
+ISSUE: Violates Known Physics - false positive (Denmark euro adoption)
+A currency adoption plan (Denmark adopts the euro) was rated HIGH for "Violates Known Physics" with
+mentions of "FTL/reactionless propulsion" and "perpetual motion". The LLM confused legal/treaty "laws"
+(constitutional law, EU treaty law) with "laws of physics". Fix: instruction now explicitly distinguishes
+legal/regulatory "laws" from physics laws and requires naming a specific physical law that is violated.
+
 PROMPT> python -u -m worker_plan_internal.self_audit.self_audit | tee output.txt
 """
 import json
@@ -110,8 +116,8 @@ ALL_CHECKLIST_ITEMS = [
         "index": 1,
         "title": "Violates Known Physics",
         "subtitle": "Does the project require a major, unpredictable discovery in fundamental science to succeed?",
-        "instruction": "Scope: physics-only (e.g., perpetual motion, FTL, reactionless/anti-gravity, time travel). HIGH if success requires breaking physical laws; MEDIUM only if a physics-consistent but unproven physical effect at required scale is mandatory with no conventional fallback; otherwise LOW. Economics/crypto/tokenization/governance/AI/regulation/engineering-scale are out of scope—rate LOW. If you can’t name a specific law/limit, rate LOW. If LOW: Mitigation=None. If ≥ MEDIUM: ≤30-word justification + mitigation with Owner/Deliverable/Date.",
-        "comment": "If the initial prompt is vague/scifi/aggressive or asks for something that is physically impossible, then the generated plan usually end up with some fantasy parts, making the plan unrealistic."
+        "instruction": "Scope: fundamental physics ONLY (e.g., perpetual motion, faster-than-light travel, reactionless/anti-gravity propulsion, time travel). ‘Laws’ here means ONLY the laws of physics (thermodynamics, conservation of energy, relativity, etc.) — NOT legal statutes, treaty law, constitutional law, regulations, or policy. A plan involving legislation, treaties, currency adoption, governance reform, or any non-physics ‘laws’ does NOT violate physics — rate LOW. HIGH only if success literally requires breaking a named law of physics; MEDIUM only if a physics-consistent but unproven physical effect at required scale is mandatory with no conventional fallback; otherwise LOW. Economics/crypto/tokenization/governance/AI/regulation/policy/finance/engineering-scale are out of scope—rate LOW. If you cannot name a specific law of physics (e.g., second law of thermodynamics, speed of light) that is violated, rate LOW. If LOW: Mitigation=None. If ≥ MEDIUM: name the specific physical law violated, ≤30-word justification + mitigation with Owner/Deliverable/Date.",
+        "comment": "If the initial prompt is vague/scifi/aggressive or asks for something that is physically impossible, then the generated plan usually end up with some fantasy parts, making the plan unrealistic. Known false-positive: LLMs confuse ‘laws’ (legal/regulatory) with ‘laws of physics’ for plans about policy, currency adoption, governance, etc."
     },
     {
         "index": 2,

--- a/worker_plan/worker_plan_internal/self_audit/self_audit.py
+++ b/worker_plan/worker_plan_internal/self_audit/self_audit.py
@@ -17,17 +17,6 @@ The primary task with this checklist is to detect that there is something fundam
 Some of the checklist items overlaps with each other, and I don't care about things being mutually exclusive where things are not supposed to overlap.
 I care about what problems I observe in the generated reports.
 
-ISSUE: Violates Known Physics - false positive
-https://planexe.org/20260303_crate_recovery_campaign_report.html
-gemini-2.5-flash-lite-preview-09-2025, thought that the laws of physics were violated, because a plan mentioned "CSR driven logistics".
-corporate social responsibility (CSR), which has nothing to do with faster than light travel, but was flagged as "violates known physics".
-
-ISSUE: Violates Known Physics - false positive (Denmark euro adoption)
-A currency adoption plan (Denmark adopts the euro) was rated HIGH for "Violates Known Physics" with
-mentions of "FTL/reactionless propulsion" and "perpetual motion". The LLM confused legal/treaty "laws"
-(constitutional law, EU treaty law) with "laws of physics". Fix: instruction now explicitly distinguishes
-legal/regulatory "laws" from physics laws and requires naming a specific physical law that is violated.
-
 PROMPT> python -u -m worker_plan_internal.self_audit.self_audit | tee output.txt
 """
 import json


### PR DESCRIPTION
## Summary
- The "Violates Known Physics" checklist item in self-audit falsely rates non-physics plans as HIGH — e.g., a Denmark euro adoption plan was flagged for "FTL/reactionless propulsion" and "perpetual motion" because the LLM confused legal/treaty "laws" with "laws of physics."
- The instruction now explicitly distinguishes legal/regulatory/policy "laws" from physics laws, and requires naming a specific physical law (e.g., thermodynamics, speed of light) before rating above LOW.
- Removed resolved issue comments from the file header (the fix lives in the instruction text itself now).

## Test plan
- [x] Re-run self-audit on the Denmark euro adoption plan and verify item #1 rates LOW
- [ ] Verify physics-violating plans (e.g., perpetual motion machine) still rate HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)