### PR TITLE
fix: avoid min_length crash when constraint check filters levers below 5

### DIFF
--- a/worker_plan/worker_plan_internal/lever/identify_potential_levers.py
+++ b/worker_plan/worker_plan_internal/lever/identify_potential_levers.py
@@ -478,11 +478,11 @@ class IdentifyPotentialLevers:
                         f"Call {call_index}: {len(rejected_levers)} lever(s) rejected by constraint check, "
                         f"{len(accepted_levers)} accepted."
                     )
-                    # Replace the response's levers with only the accepted ones
-                    response_doc = DocumentDetails(
-                        strategic_rationale=response_doc.strategic_rationale,
-                        levers=accepted_levers,
-                    )
+                    # Use model_copy to skip revalidation: DocumentDetails.levers has
+                    # min_length=5 to enforce LLM output quality, but our post-filter
+                    # set may legitimately be smaller — the adaptive loop will top up
+                    # via additional calls until min_levers is met.
+                    response_doc = response_doc.model_copy(update={"levers": accepted_levers})
 
             generated_lever_names.extend(lever.name for lever in response_doc.levers)
             responses.append(response_doc)


### PR DESCRIPTION
## Summary
- `PotentialLeversTask` crashed in a Denmark euro-adoption run when ConstraintChecker rejected 2 of 6 generated levers, leaving 4 accepted.
- `identify_potential_levers.py:482` reconstructs `DocumentDetails(levers=accepted_levers)`, which re-triggers the `min_length=5` validator on the `levers` field (originally meant to enforce LLM output quality), raising `pydantic_core.ValidationError: List should have at least 5 items after validation, not 4` and aborting the task before the adaptive loop could top up.
- Fix: swap constructor for `response_doc.model_copy(update={...})` — preserves `strategic_rationale`, swaps in `accepted_levers`, skips revalidation. The `min_length=5` contract still applies to raw LLM output (`as_structured_llm(DocumentDetails)`); the adaptive loop (`max_calls=5`, `min_levers=15`) continues to fill the shortfall via subsequent calls.

## Not addressed in this PR
- `ConstraintChecker` schema non-compliance from `openrouter-elephant-alpha` (missing `summary` field) — the `CONSTRAINT_CHECKER_SYSTEM_PROMPT` doesn't explicitly list required fields. This produces log-noise `LLMChatError` entries but is recovered by `LLMExecutor` retries across models and the outer `try/except` at `identify_potential_levers.py:347-354`. Separate concern, worth a follow-up prompt tweak.

## Test plan
- [ ] Re-run the Denmark euro-adoption plan (or any plan whose constraint checks reject ≥1 lever on call 1) and confirm `PotentialLeversTask` completes, adaptive loop continues to call 2+ until ≥15 levers accumulate, downstream pipeline proceeds.
- [ ] Confirm `response_doc.strategic_rationale` is preserved across the copy (it's passed through `update` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)