### PR TITLE
fix: make ConstraintCheckResult.summary optional to silence schema noise

### DIFF
--- a/worker_plan/worker_plan_internal/diagnostics/constraint_checker.py
+++ b/worker_plan/worker_plan_internal/diagnostics/constraint_checker.py
@@ -57,7 +57,8 @@ class ConstraintCheckResult(BaseModel):
         )
     )
     summary: str = Field(
-        description="1-3 sentence summary of the constraint check results."
+        default="",
+        description="Optional 1-3 sentence summary of the constraint check results.",
     )
 
 

--- a/worker_plan/worker_plan_internal/diagnostics/tests/test_constraint_checker.py
+++ b/worker_plan/worker_plan_internal/diagnostics/tests/test_constraint_checker.py
@@ -140,6 +140,16 @@ class TestConstraintCheckResultModel(unittest.TestCase):
         self.assertIn("overall_status", d)
         self.assertIn("summary", d)
 
+    def test_summary_is_optional(self):
+        # Some models (e.g. openrouter-elephant-alpha) consistently omit
+        # `summary` when producing structured output. summary is not consumed
+        # downstream, so the field defaults to "" rather than raising.
+        obj = ConstraintCheckResult.model_validate_json(
+            '{"constraint_violations": [], "overall_status": "pass"}'
+        )
+        self.assertEqual(obj.summary, "")
+        self.assertEqual(obj.overall_status, "pass")
+
 
 class TestConstraintCheckerDataclass(unittest.TestCase):
     """Unit tests for the ConstraintChecker dataclass methods."""


### PR DESCRIPTION
## Summary
- `openrouter-elephant-alpha` consistently omits the `summary` field from its structured `ConstraintCheckResult` output, causing `pydantic_core.ValidationError: 1 validation error for ConstraintCheckResult\nsummary\n  Field required` and a lengthy `LLMChatError` stack every time it runs.
- `LLMExecutor` retries across the other models (gemini-2.0-flash-001, gpt-4o-mini, qwen3-30b-a3b) and the check eventually succeeds — this has never been a correctness failure, just log spam plus the per-attempt latency of the first failed model before retry.
- `summary` is not consumed anywhere in `worker_plan`: it's written by the LLM, dumped to the raw JSON via `save_raw`, and never read. Making it optional with `default=""` eliminates the error class without relying on LLM schema compliance.
- Compliant models still populate `summary` as before; non-compliant models get `""`. No prompt change, no downstream behavior change.

## Test plan
- [x] `pytest worker_plan_internal/diagnostics/tests/test_constraint_checker.py` — 15 passed, 4 LLM integration tests skipped (no `RUN_LLM_TESTS` env).
- [x] New test `test_summary_is_optional` asserts `ConstraintCheckResult.model_validate_json('{\"constraint_violations\": [], \"overall_status\": \"pass\"}')` yields an instance with `summary == \"\"`.
- [ ] Re-run the Denmark euro-adoption plan in Docker and confirm worker logs no longer show `ValidationError: summary Field required` stacks from elephant-alpha.

## Relationship to PR #583
Independent fix. PR #583 addresses a crash (constraint-filter producing <5 levers), this one silences a noisy-but-recovered error. The two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)