### PR TITLE
feat: add 'Why this fails.' caption under Premise Attack header

### DIFF
--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -239,6 +239,7 @@ class ReportGenerator:
         <h2>Redline Gate</h2>
         {redline_gate_html}
         <h2>Premise Attack</h2>
+        <p>Why this fails.</p>
         {premise_attack_html}
         """
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))


### PR DESCRIPTION
## Summary
Adds a short caption paragraph `<p>Why this fails.</p>` immediately below the `<h2>Premise Attack</h2>` in the report HTML.

## Change
Single-line addition in `worker_plan/worker_plan_internal/report/report_generator.py:241`.

## Test plan
- [ ] Generate a report HTML and confirm the caption renders immediately under the Premise Attack heading, above the existing `premise_attack_html` content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)