### PR TITLE
feat: add 'Persuasive elevator pitch.' caption under Pitch section

### DIFF
--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -110,13 +110,15 @@ class ReportGenerator:
         html = markdown.markdown(markdown_content, extensions=['fenced_code'])
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
         
-    def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = []):
+    def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = [], caption_html: Optional[str] = None):
         """Append a markdown document to the report."""
         md_data = self.read_markdown_file(file_path)
         if md_data is None:
             logging.warning(f"Document: '{document_title}'. Could not read markdown file: {file_path}")
             return
         html = markdown.markdown(md_data)
+        if caption_html:
+            html = caption_html + html
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
     
     def append_markdown_with_tables(self, document_title: str, file_path: Path, css_classes: list[str] = []):
@@ -351,7 +353,7 @@ def main():
     
     report_generator = ReportGenerator()
     report_generator.append_markdown('Initial Plan', input_path / FilenameEnum.INITIAL_PLAN.value)
-    report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value)
+    report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value, caption_html='<p>Persuasive elevator pitch.</p>')
     report_generator.append_markdown('Assumptions', input_path / FilenameEnum.CONSOLIDATE_ASSUMPTIONS_FULL_MARKDOWN.value)
     report_generator.append_markdown('SWOT Analysis', input_path / FilenameEnum.SWOT_MARKDOWN.value)
     report_generator.append_markdown('Team', input_path / FilenameEnum.TEAM_MARKDOWN.value)


### PR DESCRIPTION
## Summary
Adds a short caption paragraph `<p>Persuasive elevator pitch.</p>` immediately below the Pitch section header.

## Change
Pitch is attached via `append_markdown('Pitch', ...)`, not inline HTML (unlike the Premise Attack case in PR #586). Two small edits:
1. `append_markdown` gains an optional `caption_html` parameter that, when set, is prepended to the rendered markdown HTML before the `ReportDocumentItem` is appended.
2. The Pitch call site passes `caption_html='<p>Persuasive elevator pitch.</p>'`.

Same mechanism can be reused for future captions on other `append_markdown` sections (Assumptions, SWOT, Team, Expert Criticism) without further helper changes.

## Test plan
- [ ] Generate a report HTML and confirm the caption renders directly under the Pitch section header, above the pitch markdown body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)