### PR TITLE
fix: apply Pitch caption to the production report code path

### DIFF
--- a/worker_plan/worker_plan_internal/plan/nodes/report.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/report.py
@@ -71,7 +71,7 @@ class ReportTask(PlanTask):
         rg = ReportGenerator()
         rg.append_markdown('Executive Summary', self.input()['executive_summary']['markdown'].path)
         rg.append_html('Gantt Interactive', self.input()['create_schedule']['dhtmlx_html'].path)
-        rg.append_markdown('Pitch', self.input()['pitch_markdown']['markdown'].path)
+        rg.append_markdown('Pitch', self.input()['pitch_markdown']['markdown'].path, caption_html='<p>Persuasive elevator pitch.</p>')
         rg.append_markdown('Project Plan', self.input()['project_plan']['markdown'].path)
         rg.append_markdown('Strategic Decisions', self.input()['strategic_decisions_markdown']['markdown'].path)
         rg.append_markdown('Scenarios', self.input()['scenarios_markdown']['markdown'].path)


### PR DESCRIPTION
## Summary
PR #587 added `caption_html='<p>Persuasive elevator pitch.</p>'` to `report_generator.py::main()`, but that `main()` is only used for manual CLI/testing. The production pipeline renders reports via `plan/nodes/report.py::run_inner()`, which has its own `rg.append_markdown('Pitch', ...)` call at line 74. That production call was not updated, so rendered HTML reports still showed the Pitch section without the caption.

This PR applies the same `caption_html` argument to the production call site.

## Test plan
- [ ] Generate a report via the production pipeline and confirm "Persuasive elevator pitch." now renders directly under the Pitch section header.

## Root cause / lesson
`report_generator.py::main()` and `plan/nodes/report.py::run_inner()` independently construct a `ReportGenerator` and call the same helper methods. Any visual change to the report needs to be applied in both places (or the two should eventually be unified — out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)