### PR TITLE
feat: prefix pitch markdown with 'Persuasive elevator pitch.' caption

### DIFF
--- a/worker_plan/worker_plan_internal/pitch/convert_pitch_to_markdown.py
+++ b/worker_plan/worker_plan_internal/pitch/convert_pitch_to_markdown.py
@@ -107,10 +107,11 @@ class ConvertPitchToMarkdown:
             markdown_content = response_content  # Use the entire content if delimiters are missing
             logger.warning("Output delimiters not found in LLM response.")
 
-        # The bullet lists are supposed to be preceded by 2 newlines. 
-        # However often there is just 1 newline. 
+        # The bullet lists are supposed to be preceded by 2 newlines.
+        # However often there is just 1 newline.
         # This fix makes sure there are 2 newlines before bullet lists.
         markdown_content = fix_bullet_lists(markdown_content)
+        markdown_content = "Persuasive elevator pitch.\n\n" + markdown_content
 
         json_response = {}
         json_response['response_content'] = response_content

--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -110,15 +110,13 @@ class ReportGenerator:
         html = markdown.markdown(markdown_content, extensions=['fenced_code'])
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
         
-    def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = [], caption_html: Optional[str] = None):
+    def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = []):
         """Append a markdown document to the report."""
         md_data = self.read_markdown_file(file_path)
         if md_data is None:
             logging.warning(f"Document: '{document_title}'. Could not read markdown file: {file_path}")
             return
         html = markdown.markdown(md_data)
-        if caption_html:
-            html = caption_html + html
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
     
     def append_markdown_with_tables(self, document_title: str, file_path: Path, css_classes: list[str] = []):
@@ -353,7 +351,7 @@ def main():
     
     report_generator = ReportGenerator()
     report_generator.append_markdown('Initial Plan', input_path / FilenameEnum.INITIAL_PLAN.value)
-    report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value, caption_html='<p>Persuasive elevator pitch.</p>')
+    report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value)
     report_generator.append_markdown('Assumptions', input_path / FilenameEnum.CONSOLIDATE_ASSUMPTIONS_FULL_MARKDOWN.value)
     report_generator.append_markdown('SWOT Analysis', input_path / FilenameEnum.SWOT_MARKDOWN.value)
     report_generator.append_markdown('Team', input_path / FilenameEnum.TEAM_MARKDOWN.value)


### PR DESCRIPTION
## Summary
Two coupled changes:
1. **Add the caption at the markdown source.** In `ConvertPitchToMarkdown.execute()` (immediately after `fix_bullet_lists()`), prefix `"Persuasive elevator pitch.\n\n"` to the pitch markdown. The caption travels with the content, so every consumer that renders the pitch gets it automatically.
2. **Revert the unused helper surface from PR #587** (merge `b970b82d`): remove the `caption_html` parameter on `ReportGenerator.append_markdown` and its use in `report_generator.main()`. With the caption at the markdown source, the parameter has no callers — leaving it in would cause `main()` to emit the caption twice.

## Why the markdown-source location
PR #587 added the caption via a `caption_html` argument to `report_generator.py::main()`. That `main()` is only used for manual CLI testing — the production pipeline renders the pitch via `plan/nodes/report.py::run_inner()` at `rg.append_markdown('Pitch', ...)`, which was never updated, so the caption didn't appear in real reports. Putting it at the markdown-source layer removes the dual-code-path maintenance burden: any future consumer that reads the pitch markdown gets the caption without per-callsite wiring.

## Test plan
- [ ] Generate a report via the production pipeline and confirm "Persuasive elevator pitch." renders directly under the Pitch section header, above the pitch body.
- [ ] Grep `worker_plan/` for `caption_html` — should return zero matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)