### PR TITLE
chore: revert unused caption_html parameter from append_markdown

### DIFF
--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -110,15 +110,13 @@ class ReportGenerator:
         html = markdown.markdown(markdown_content, extensions=['fenced_code'])
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
         
-    def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = [], caption_html: Optional[str] = None):
+    def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = []):
         """Append a markdown document to the report."""
         md_data = self.read_markdown_file(file_path)
         if md_data is None:
             logging.warning(f"Document: '{document_title}'. Could not read markdown file: {file_path}")
             return
         html = markdown.markdown(md_data)
-        if caption_html:
-            html = caption_html + html
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
     
     def append_markdown_with_tables(self, document_title: str, file_path: Path, css_classes: list[str] = []):
@@ -353,7 +351,7 @@ def main():
     
     report_generator = ReportGenerator()
     report_generator.append_markdown('Initial Plan', input_path / FilenameEnum.INITIAL_PLAN.value)
-    report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value, caption_html='<p>Persuasive elevator pitch.</p>')
+    report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value)
     report_generator.append_markdown('Assumptions', input_path / FilenameEnum.CONSOLIDATE_ASSUMPTIONS_FULL_MARKDOWN.value)
     report_generator.append_markdown('SWOT Analysis', input_path / FilenameEnum.SWOT_MARKDOWN.value)
     report_generator.append_markdown('Team', input_path / FilenameEnum.TEAM_MARKDOWN.value)


### PR DESCRIPTION
## Summary
Reverts the two additions from PR #587 (merge commit `b970b82d`) that are now unused:
1. `caption_html: Optional[str] = None` parameter on `ReportGenerator.append_markdown`
2. The `caption_html='<p>Persuasive elevator pitch.</p>'` argument passed from `report_generator.main()`

## Why
PR #589 moves the pitch caption into the pitch markdown itself (via `ConvertPitchToMarkdown.execute()`), so:
- No caller uses `caption_html` anymore.
- If PR #589 lands with this parameter still in place, `main()` would emit the caption twice (once via `caption_html`, once via the markdown prefix).

## Dependency
Should land alongside or after #589. Independently safe — restores `append_markdown` to its three-parameter signature, which is how every other caller already invokes it.

## Test plan
- [ ] `append_markdown` signature returns to pre-#587 shape; grep for `caption_html` in `worker_plan/` returns zero matches.
- [ ] Report rendering from the production pipeline is unaffected (the Pitch section still renders correctly via `plan/nodes/report.py::run_inner()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)