### PR TITLE
docs: add self_audit direction notes to module docstring

### DIFF
--- a/worker_plan/worker_plan_internal/self_audit/self_audit.py
+++ b/worker_plan/worker_plan_internal/self_audit/self_audit.py
@@ -9,6 +9,26 @@ The Secondary Reader (The Project Manager/Lead): This is the person tasked with 
 
     Value: It serves as a prioritized "fix-it" list. It tells the project manager which fires are the biggest. They don't need to worry about the team size (a ⚠️ Medium risk) if the entire project is a 🛑 High "Legal Minefield." It focuses their attention on the foundational, existential threats to the project's success.
 
+
+The "violates known physics" detection is often gets triggered, freaking out about "faster than light travel" on documents that have nothing to do with FTL.
+The "elephant-alpha" model especially struggle with detecting that, when it otherwise does an ok job at everything else.
+I'm considering making a dedicated system prompt only for VIOLATES_KNOWN_PHYSICS, that is have lower rate of false positives.
+
+Adding a new checklist item:
+Find fabricated evidence. Where things aren't true.
+When it hallucinates laws or articles that are non-existing.
+
+Adding a new checklist item:
+Calling out fake confidence in the plan, where there isn’t sufficient evidence.
+
+Adding a new checklist item:
+attack on vague filler language.
+It's filler language when the document repeatedly says 
+- “develop a robust strategy”
+- “implement a communication strategy,” 
+Without specify the actual strategy. 
+that is placeholder language.
+
 Calibation. Skewed distribution: 16 “High” flags out of 20 reads like alarm fatigue. 
 Yes, the majority may be red. Holding the items up against each other is not the job for this checklist. It's further downstream.
 I'm not going to reserve High for the most significant issues.


### PR DESCRIPTION
## Summary
Adds notes to the top-of-module docstring in `self_audit.py` capturing directions worth exploring:

- **Dedicated VIOLATES_KNOWN_PHYSICS prompt.** Observation: `elephant-alpha` in particular flags non-physics plans as physics violations ("faster than light travel" on documents unrelated to FTL), while doing fine on other checklist items. A separate tailored prompt might reduce false positives without disturbing the rest of the audit.
- **New checklist item — Fabricated evidence.** Flag hallucinated laws, articles, or citations that don't exist.
- **New checklist item — Fake confidence.** Flag assertions made without sufficient evidence to back them.
- **New checklist item — Vague filler language.** Flag placeholder phrases like "develop a robust strategy" or "implement a communication strategy" where the actual strategy is never specified.

## Why commit these as a docstring
Keeps future-direction notes co-located with the code they affect, so anyone touching `self_audit.py` sees them immediately. These are deliberately notes, not implementation — related PR #585 covers the ongoing work on the physics false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)