### PR TITLE
chore: drop unused pypdf dependency

### DIFF
--- a/worker_plan/pyproject.toml
+++ b/worker_plan/pyproject.toml
@@ -85,7 +85,6 @@ dependencies = [
     "pydantic_core==2.41.5",
     "pydub==0.25.1",
     "Pygments==2.19.2",
-    "pypdf==6.7.5",
     "python-daemon==3.1.2",
     "python-dateutil==2.9.0.post0",
     "python-dotenv==1.2.2",


### PR DESCRIPTION
## Summary
`pypdf==6.7.5` is listed in `worker_plan/pyproject.toml` but not imported anywhere in the codebase. PlanExe does not process PDFs.

Verified with \`grep -rni 'import pypdf\|from pypdf\|PdfReader\|PdfWriter'\` — zero hits.

## Test plan
- [ ] CI lint / tests / typecheck pass (they don't need pypdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)