### PR TITLE
chore: drop explicit nltk pin (transitive via llama-index-core)

### DIFF
--- a/worker_plan/pyproject.toml
+++ b/worker_plan/pyproject.toml
@@ -72,7 +72,6 @@ dependencies = [
     "mypy-extensions==1.1.0",
     "nest-asyncio==1.6.0",
     "networkx==3.6.1",
-    "nltk==3.9.3",
     "numpy==2.4.0",
     "ollama==0.6.1",
     "openai==2.14.0",


### PR DESCRIPTION
## Summary
Nothing in PlanExe imports \`nltk\` directly. It's already pulled in transitively by \`llama-index-core\` (\`Requires-Dist: nltk>3.8.1\`), so the explicit \`nltk==3.9.3\` pin in \`worker_plan/pyproject.toml\` was only adding manifest noise and Dependabot surface.

The three open nltk alerts are all for the standalone \`wordnet_app\` web demo and a \`JSONTaggedDecoder\` path that neither PlanExe nor llama-index invoke — dropping the explicit pin does not change runtime exposure.

## Test plan
- [ ] CI lint / tests / typecheck pass
- [ ] Install still resolves (nltk comes in via llama-index-core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)