### PR TITLE
chore: rename database table task_item -> plans

### DIFF
--- a/database_api/model_planitem.py
+++ b/database_api/model_planitem.py
@@ -41,7 +41,7 @@ class PlanState(enum.Enum):
 
 
 class PlanItem(db.Model):
-    __tablename__ = "task_item"
+    __tablename__ = "plans"
 
     # A unique identifier for the task.
     id = db.Column(UUIDType(binary=False), default=uuid.uuid4, primary_key=True)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -148,11 +148,6 @@ Verdict: Sub-Human. It provides the architecture for the math, but cannot execut
 
 # Secondary issues
 
-## Rename table name
-
-rename PlanItem (task_items) to (plan_items)
-
-
 ## Show commit id
 
 use the git commit + branch in the generated report, so I can troubleshoot what version of PlanExe was used.

--- a/frontend_multi_user/src/admin_routes.py
+++ b/frontend_multi_user/src/admin_routes.py
@@ -115,7 +115,7 @@ def _get_purge_activity_info() -> dict[str, Any]:
                 "SELECT count(*), "
                 "count(run_track_activity_jsonl), "
                 "coalesce(sum(octet_length(run_track_activity_jsonl)), 0) "
-                "FROM task_item"
+                "FROM plans"
             )).fetchone()
             if row:
                 info["total_rows"] = row[0]
@@ -125,10 +125,10 @@ def _get_purge_activity_info() -> dict[str, Any]:
             for keep_n in [10, 25, 50, 100, 250, 500]:
                 result = conn.execute(text(
                     "SELECT coalesce(sum(octet_length(run_track_activity_jsonl)), 0), count(*) "
-                    "FROM task_item "
+                    "FROM plans "
                     "WHERE run_track_activity_jsonl IS NOT NULL "
                     "AND id NOT IN ("
-                    "  SELECT id FROM task_item "
+                    "  SELECT id FROM plans "
                     "  ORDER BY timestamp_created DESC "
                     "  LIMIT :keep_n"
                     ")"
@@ -151,11 +151,11 @@ def _purge_activity_data(keep_n: int) -> dict[str, Any]:
     try:
         with db.engine.connect() as conn:
             row = conn.execute(text(
-                "UPDATE task_item "
+                "UPDATE plans "
                 "SET run_track_activity_jsonl = NULL, run_track_activity_bytes = NULL "
                 "WHERE run_track_activity_jsonl IS NOT NULL "
                 "AND id NOT IN ("
-                "  SELECT id FROM task_item "
+                "  SELECT id FROM plans "
                 "  ORDER BY timestamp_created DESC "
                 "  LIMIT :keep_n"
                 ")"
@@ -168,15 +168,15 @@ def _purge_activity_data(keep_n: int) -> dict[str, Any]:
     return result
 
 
-def _vacuum_task_item() -> dict[str, Any]:
+def _vacuum_plans() -> dict[str, Any]:
     result: dict[str, Any] = {"error": None}
     try:
         with db.engine.connect() as conn:
             conn.execution_options(isolation_level="AUTOCOMMIT").execute(
-                text("VACUUM FULL task_item")
+                text("VACUUM FULL plans")
             )
     except Exception as e:
-        logger.exception("Failed to vacuum task_item")
+        logger.exception("Failed to vacuum plans")
         result["error"] = str(e)
     return result
 
@@ -329,7 +329,7 @@ def admin_database():
                 keep_n = 50
             purge_result = _purge_activity_data(keep_n)
         elif action == "vacuum":
-            vacuum_result = _vacuum_task_item()
+            vacuum_result = _vacuum_plans()
     size_info = _get_database_size_info()
     purge_info = _get_purge_activity_info()
     admin_ext = current_app.extensions.get("admin", [None])

--- a/frontend_multi_user/src/app.py
+++ b/frontend_multi_user/src/app.py
@@ -691,7 +691,7 @@ class MyFlaskApp:
         self.admin = Admin(self.app, name='PlanExe Admin', index_view=MyAdminIndexView())
 
         # Add database tables to admin panel
-        self.admin.add_view(PlanItemView(model=PlanItem, session=self.db.session, name="Task"))
+        self.admin.add_view(PlanItemView(model=PlanItem, session=self.db.session, name="Plan"))
         self.admin.add_view(AdminOnlyModelView(model=EventItem, session=self.db.session, name="Event"))
         self.admin.add_view(WorkerItemView(model=WorkerItem, session=self.db.session, name="Worker"))
         self.admin.add_view(NonceItemView(model=NonceItem, session=self.db.session, name="Nonce"))

--- a/frontend_multi_user/src/app.py
+++ b/frontend_multi_user/src/app.py
@@ -373,26 +373,59 @@ class MyFlaskApp:
         self.db = db
         self.db.init_app(self.app)
 
+        def _ensure_plans_table_name() -> None:
+            """Rename legacy 'task_item' (and its indexes) to 'plans' (idempotent).
+
+            Serialized via a Postgres advisory lock so concurrent replicas do not
+            race. Must run before db.create_all() so SQLAlchemy does not create
+            a second empty 'plans' table alongside 'task_item'.
+            """
+            sql = """
+            DO $$
+            BEGIN
+                PERFORM pg_advisory_xact_lock(8462357421);
+                IF EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE table_schema = current_schema() AND table_name = 'task_item')
+                   AND NOT EXISTS (SELECT 1 FROM information_schema.tables
+                                   WHERE table_schema = current_schema() AND table_name = 'plans') THEN
+                    ALTER TABLE task_item RENAME TO plans;
+                END IF;
+                IF EXISTS (SELECT 1 FROM pg_indexes
+                           WHERE schemaname = current_schema() AND indexname = 'idx_task_item_user_id_timestamp_created') THEN
+                    ALTER INDEX idx_task_item_user_id_timestamp_created RENAME TO idx_plans_user_id_timestamp_created;
+                END IF;
+                IF EXISTS (SELECT 1 FROM pg_indexes
+                           WHERE schemaname = current_schema() AND indexname = 'idx_task_item_api_key_id') THEN
+                    ALTER INDEX idx_task_item_api_key_id RENAME TO idx_plans_api_key_id;
+                END IF;
+            END$$;
+            """
+            try:
+                with self.db.engine.begin() as conn:
+                    conn.execute(text(sql))
+            except Exception as exc:
+                logger.warning("Rename task_item -> plans failed: %s", exc, exc_info=True)
+
         def _ensure_planitem_artifact_columns() -> None:
             insp = inspect(self.db.engine)
-            columns = {col["name"] for col in insp.get_columns("task_item")}
+            columns = {col["name"] for col in insp.get_columns("plans")}
             with self.db.engine.begin() as conn:
                 if "generated_report_html" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS generated_report_html TEXT"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS generated_report_html TEXT"))
                 if "run_zip_snapshot" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_zip_snapshot BYTEA"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_zip_snapshot BYTEA"))
                 if "run_track_activity_jsonl" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_track_activity_jsonl TEXT"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_track_activity_jsonl TEXT"))
                 if "run_track_activity_bytes" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_track_activity_bytes INTEGER"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_track_activity_bytes INTEGER"))
                 if "run_activity_overview_json" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_activity_overview_json JSON"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_activity_overview_json JSON"))
                 if "run_artifact_layout_version" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_artifact_layout_version INTEGER"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_artifact_layout_version INTEGER"))
                 if "stop_requested" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS stop_requested BOOLEAN"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS stop_requested BOOLEAN"))
                 if "stop_requested_timestamp" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS stop_requested_timestamp TIMESTAMP"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS stop_requested_timestamp TIMESTAMP"))
 
         def _ensure_token_metrics_columns() -> None:
             insp = inspect(self.db.engine)
@@ -460,7 +493,7 @@ class MyFlaskApp:
             statements = (
                 "ALTER TABLE user_api_key ADD COLUMN IF NOT EXISTS label VARCHAR(128)",
                 "ALTER TABLE user_api_key ADD COLUMN IF NOT EXISTS key_plaintext VARCHAR(64)",
-                "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
+                "ALTER TABLE plans ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
                 "ALTER TABLE credit_history ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
                 "ALTER TABLE token_metrics ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
             )
@@ -473,38 +506,38 @@ class MyFlaskApp:
 
         def _ensure_step_count_columns() -> None:
             insp = inspect(self.db.engine)
-            columns = {col["name"] for col in insp.get_columns("task_item")}
+            columns = {col["name"] for col in insp.get_columns("plans")}
             with self.db.engine.begin() as conn:
                 if "steps_completed" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS steps_completed INTEGER"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS steps_completed INTEGER"))
                 if "steps_total" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS steps_total INTEGER"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS steps_total INTEGER"))
                 if "current_step" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS current_step VARCHAR(128)"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS current_step VARCHAR(128)"))
 
         def _ensure_failure_diagnostic_columns() -> None:
             insp = inspect(self.db.engine)
-            columns = {col["name"] for col in insp.get_columns("task_item")}
+            columns = {col["name"] for col in insp.get_columns("plans")}
             with self.db.engine.begin() as conn:
                 if "failure_reason" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(64)"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(64)"))
                 if "failed_step" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS failed_step VARCHAR(128)"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS failed_step VARCHAR(128)"))
                 if "recoverable" not in columns:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS recoverable BOOLEAN"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS recoverable BOOLEAN"))
             # Rename last_error -> error_message in a separate transaction so a
             # failed RENAME (race with another container) doesn't poison the above.
             if "error_message" not in columns:
                 if "last_error" in columns:
                     try:
                         with self.db.engine.begin() as conn:
-                            conn.execute(text("ALTER TABLE task_item RENAME COLUMN last_error TO error_message"))
+                            conn.execute(text("ALTER TABLE plans RENAME COLUMN last_error TO error_message"))
                     except Exception:
                         with self.db.engine.begin() as conn:
-                            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
+                            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
                 else:
                     with self.db.engine.begin() as conn:
-                        conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
+                        conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
 
         def _ensure_stopped_state() -> None:
             """Add 'stopped' value to the planstate/taskstate enum type (idempotent).
@@ -527,23 +560,23 @@ class MyFlaskApp:
 
         def _ensure_last_progress_at_column() -> None:
             insp = inspect(self.db.engine)
-            columns = {col["name"] for col in insp.get_columns("task_item")}
+            columns = {col["name"] for col in insp.get_columns("plans")}
             if "last_progress_at" not in columns:
                 with self.db.engine.begin() as conn:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS last_progress_at TIMESTAMP"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS last_progress_at TIMESTAMP"))
 
         def _ensure_planitem_indexes() -> None:
             insp = inspect(self.db.engine)
             table_names = set(insp.get_table_names())
             statements: list[str] = []
-            if "task_item" in table_names:
+            if "plans" in table_names:
                 statements.append(
-                    "CREATE INDEX IF NOT EXISTS idx_task_item_user_id_timestamp_created "
-                    "ON task_item (user_id, timestamp_created)"
+                    "CREATE INDEX IF NOT EXISTS idx_plans_user_id_timestamp_created "
+                    "ON plans (user_id, timestamp_created)"
                 )
                 statements.append(
-                    "CREATE INDEX IF NOT EXISTS idx_task_item_api_key_id "
-                    "ON task_item (api_key_id)"
+                    "CREATE INDEX IF NOT EXISTS idx_plans_api_key_id "
+                    "ON plans (api_key_id)"
                 )
             if "credit_history" in table_names:
                 statements.append(
@@ -593,6 +626,7 @@ class MyFlaskApp:
                         with self.db.engine.connect() as lock_conn:
                             lock_conn.execute(text(f"SELECT pg_advisory_lock({_ADVISORY_LOCK_KEY})"))
                             try:
+                                _ensure_plans_table_name()
                                 self.db.create_all()
                                 _ensure_planitem_artifact_columns()
                                 _ensure_token_metrics_columns()

--- a/frontend_multi_user/src/plan_routes.py
+++ b/frontend_multi_user/src/plan_routes.py
@@ -113,7 +113,7 @@ def _load_prompt_preview_safe(task_id: Any, max_chars: int = 240) -> str:
     except DataError:
         db.session.rollback()
         logger.warning(
-            "Detected invalid UTF-8 in task_item.prompt for task_id=%s; using placeholder preview.",
+            "Detected invalid UTF-8 in plans.prompt for task_id=%s; using placeholder preview.",
             task_id,
             exc_info=True,
         )
@@ -935,7 +935,7 @@ def plan():
             )
         except DataError:
             db.session.rollback()
-            logger.warning("Detected invalid UTF-8 in task_item.prompt for user_id=%s; falling back.", user_id, exc_info=True)
+            logger.warning("Detected invalid UTF-8 in plans.prompt for user_id=%s; falling back.", user_id, exc_info=True)
             tasks = (
                 db.session.query(PlanItem.id, PlanItem.timestamp_created, PlanItem.state, PlanItem.stop_requested)
                 .filter(uid_filter)

--- a/frontend_multi_user/templates/admin/database.html
+++ b/frontend_multi_user/templates/admin/database.html
@@ -245,20 +245,20 @@
     {% if vacuum_result.error %}
     <div class="error-banner">Vacuum failed: {{ vacuum_result.error }}</div>
     {% else %}
-    <div class="success-banner">VACUUM FULL task_item completed. Disk space reclaimed.</div>
+    <div class="success-banner">VACUUM FULL plans completed. Disk space reclaimed.</div>
     {% endif %}
   {% endif %}
 
   <div class="purge-section">
     <h3>Vacuum</h3>
     <p class="purge-stats">
-      Run <code>VACUUM FULL task_item</code> to rewrite the table and reclaim disk space.
+      Run <code>VACUUM FULL plans</code> to rewrite the table and reclaim disk space.
       This locks the table briefly.
     </p>
-    <form method="POST" onsubmit="return confirm('This will lock the task_item table while it rewrites it. Continue?');">
+    <form method="POST" onsubmit="return confirm('This will lock the plans table while it rewrites it. Continue?');">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="action" value="vacuum">
-      <button type="submit" class="btn-purge" style="background: #2980b9;">Vacuum task_item</button>
+      <button type="submit" class="btn-purge" style="background: #2980b9;">Vacuum plans</button>
     </form>
   </div>
 

--- a/mcp_cloud/db_setup.py
+++ b/mcp_cloud/db_setup.py
@@ -82,14 +82,49 @@ _startup_log("db_setup.py: calling db.init_app(app)")
 db.init_app(app)
 _startup_log("db_setup.py: db.init_app(app) done")
 
+def ensure_plans_table_name() -> None:
+    """Rename legacy 'task_item' table (and its indexes) to 'plans' (idempotent).
+
+    Wrapped in a transaction-level advisory lock so concurrent replicas do not
+    race — whoever gets the lock first does the rename; the others no-op.
+    Must run before db.create_all() so SQLAlchemy does not create a second
+    empty 'plans' table alongside the existing 'task_item'.
+    """
+    sql = """
+    DO $$
+    BEGIN
+        PERFORM pg_advisory_xact_lock(8462357421);
+        IF EXISTS (SELECT 1 FROM information_schema.tables
+                   WHERE table_schema = current_schema() AND table_name = 'task_item')
+           AND NOT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE table_schema = current_schema() AND table_name = 'plans') THEN
+            ALTER TABLE task_item RENAME TO plans;
+        END IF;
+        IF EXISTS (SELECT 1 FROM pg_indexes
+                   WHERE schemaname = current_schema() AND indexname = 'idx_task_item_user_id_timestamp_created') THEN
+            ALTER INDEX idx_task_item_user_id_timestamp_created RENAME TO idx_plans_user_id_timestamp_created;
+        END IF;
+        IF EXISTS (SELECT 1 FROM pg_indexes
+                   WHERE schemaname = current_schema() AND indexname = 'idx_task_item_api_key_id') THEN
+            ALTER INDEX idx_task_item_api_key_id RENAME TO idx_plans_api_key_id;
+        END IF;
+    END$$;
+    """
+    try:
+        with db.engine.begin() as conn:
+            conn.execute(text(sql))
+    except Exception as exc:
+        logger.warning("Rename task_item -> plans failed: %s", exc, exc_info=True)
+
+
 def ensure_planitem_stop_columns() -> None:
     statements = (
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_track_activity_jsonl TEXT",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_track_activity_bytes INTEGER",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_activity_overview_json JSON",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_artifact_layout_version INTEGER",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS stop_requested BOOLEAN",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS stop_requested_timestamp TIMESTAMP",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_track_activity_jsonl TEXT",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_track_activity_bytes INTEGER",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_activity_overview_json JSON",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_artifact_layout_version INTEGER",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS stop_requested BOOLEAN",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS stop_requested_timestamp TIMESTAMP",
     )
     for statement in statements:
         try:
@@ -103,7 +138,7 @@ def ensure_multi_api_key_columns() -> None:
     statements = (
         "ALTER TABLE user_api_key ADD COLUMN IF NOT EXISTS label VARCHAR(128)",
         "ALTER TABLE user_api_key ADD COLUMN IF NOT EXISTS key_plaintext VARCHAR(64)",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
         "ALTER TABLE credit_history ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
         "ALTER TABLE token_metrics ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
     )
@@ -115,11 +150,11 @@ def ensure_multi_api_key_columns() -> None:
             logger.warning("Schema update failed for %s: %s", stmt, exc, exc_info=True)
 
 def ensure_step_count_columns() -> None:
-    """Add steps_completed, steps_total, and current_step columns to task_item (idempotent)."""
+    """Add steps_completed, steps_total, and current_step columns to plans (idempotent)."""
     statements = (
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS steps_completed INTEGER",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS steps_total INTEGER",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS current_step VARCHAR(128)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS steps_completed INTEGER",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS steps_total INTEGER",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS current_step VARCHAR(128)",
     )
     for stmt in statements:
         try:
@@ -129,11 +164,11 @@ def ensure_step_count_columns() -> None:
             logger.warning("Schema update failed for %s: %s", stmt, exc, exc_info=True)
 
 def ensure_failure_diagnostics_columns() -> None:
-    """Add failure diagnostic columns to task_item (idempotent)."""
+    """Add failure diagnostic columns to plans (idempotent)."""
     statements = (
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(64)",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS failed_step VARCHAR(128)",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS recoverable BOOLEAN",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(64)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS failed_step VARCHAR(128)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS recoverable BOOLEAN",
     )
     for stmt in statements:
         try:
@@ -143,18 +178,18 @@ def ensure_failure_diagnostics_columns() -> None:
             logger.warning("Schema update failed for %s: %s", stmt, exc, exc_info=True)
     # Rename last_error → error_message (existing DBs); add column for fresh DBs.
     # Check column existence first to avoid noisy PostgreSQL ERROR logs on every restart.
-    columns = {col["name"] for col in inspect(db.engine).get_columns("task_item")}
+    columns = {col["name"] for col in inspect(db.engine).get_columns("plans")}
     if "error_message" not in columns:
         if "last_error" in columns:
             try:
                 with db.engine.begin() as conn:
-                    conn.execute(text("ALTER TABLE task_item RENAME COLUMN last_error TO error_message"))
+                    conn.execute(text("ALTER TABLE plans RENAME COLUMN last_error TO error_message"))
             except Exception:
                 with db.engine.begin() as conn:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
         else:
             with db.engine.begin() as conn:
-                conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
+                conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
 
 def ensure_stopped_state() -> None:
     """Add 'stopped' value to the planstate/taskstate enum type (idempotent).
@@ -171,9 +206,9 @@ def ensure_stopped_state() -> None:
             logger.debug("ALTER TYPE %s: %s", type_name, exc)
 
 def ensure_last_progress_at_column() -> None:
-    """Add last_progress_at column to task_item (idempotent)."""
+    """Add last_progress_at column to plans (idempotent)."""
     statements = (
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS last_progress_at TIMESTAMP",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS last_progress_at TIMESTAMP",
     )
     for stmt in statements:
         try:
@@ -184,6 +219,8 @@ def ensure_last_progress_at_column() -> None:
 
 _startup_log("db_setup.py: running schema migrations...")
 with app.app_context():
+    _startup_log("db_setup.py: ensure_plans_table_name")
+    ensure_plans_table_name()
     _startup_log("db_setup.py: db.create_all()")
     db.create_all()
     _startup_log("db_setup.py: db.create_all() done")

--- a/worker_plan_database/app.py
+++ b/worker_plan_database/app.py
@@ -201,26 +201,60 @@ app.config['SQLALCHEMY_DATABASE_URI'] = sqlalchemy_database_uri
 app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'pool_recycle' : 280, 'pool_pre_ping': True}
 db.init_app(app)
 
+def ensure_plans_table_name() -> None:
+    """Rename legacy 'task_item' table (and its indexes) to 'plans' (idempotent).
+
+    Serialized via a Postgres advisory lock so concurrent replicas do not race.
+    Must run before db.create_all() so SQLAlchemy does not create a second
+    empty 'plans' table alongside 'task_item'.
+    """
+    sql = """
+    DO $$
+    BEGIN
+        PERFORM pg_advisory_xact_lock(8462357421);
+        IF EXISTS (SELECT 1 FROM information_schema.tables
+                   WHERE table_schema = current_schema() AND table_name = 'task_item')
+           AND NOT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE table_schema = current_schema() AND table_name = 'plans') THEN
+            ALTER TABLE task_item RENAME TO plans;
+        END IF;
+        IF EXISTS (SELECT 1 FROM pg_indexes
+                   WHERE schemaname = current_schema() AND indexname = 'idx_task_item_user_id_timestamp_created') THEN
+            ALTER INDEX idx_task_item_user_id_timestamp_created RENAME TO idx_plans_user_id_timestamp_created;
+        END IF;
+        IF EXISTS (SELECT 1 FROM pg_indexes
+                   WHERE schemaname = current_schema() AND indexname = 'idx_task_item_api_key_id') THEN
+            ALTER INDEX idx_task_item_api_key_id RENAME TO idx_plans_api_key_id;
+        END IF;
+    END$$;
+    """
+    try:
+        with db.engine.begin() as conn:
+            conn.execute(text(sql))
+    except Exception as exc:
+        logger.warning("Rename task_item -> plans failed: %s", exc, exc_info=True)
+
+
 def ensure_planitem_artifact_columns() -> None:
     insp = inspect(db.engine)
-    columns = {col["name"] for col in insp.get_columns("task_item")}
+    columns = {col["name"] for col in insp.get_columns("plans")}
     with db.engine.begin() as conn:
         if "generated_report_html" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS generated_report_html TEXT"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS generated_report_html TEXT"))
         if "run_zip_snapshot" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_zip_snapshot BYTEA"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_zip_snapshot BYTEA"))
         if "run_track_activity_jsonl" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_track_activity_jsonl TEXT"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_track_activity_jsonl TEXT"))
         if "run_track_activity_bytes" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_track_activity_bytes INTEGER"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_track_activity_bytes INTEGER"))
         if "run_activity_overview_json" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_activity_overview_json JSON"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_activity_overview_json JSON"))
         if "run_artifact_layout_version" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS run_artifact_layout_version INTEGER"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS run_artifact_layout_version INTEGER"))
         if "stop_requested" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS stop_requested BOOLEAN"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS stop_requested BOOLEAN"))
         if "stop_requested_timestamp" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS stop_requested_timestamp TIMESTAMP"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS stop_requested_timestamp TIMESTAMP"))
 
 
 def ensure_token_metrics_columns() -> None:
@@ -284,16 +318,16 @@ def ensure_fractional_credit_columns() -> None:
 
 
 def ensure_step_count_columns() -> None:
-    """Add steps_completed, steps_total, and current_step columns to task_item (idempotent)."""
+    """Add steps_completed, steps_total, and current_step columns to plans (idempotent)."""
     insp = inspect(db.engine)
-    columns = {col["name"] for col in insp.get_columns("task_item")}
+    columns = {col["name"] for col in insp.get_columns("plans")}
     with db.engine.begin() as conn:
         if "steps_completed" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS steps_completed INTEGER"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS steps_completed INTEGER"))
         if "steps_total" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS steps_total INTEGER"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS steps_total INTEGER"))
         if "current_step" not in columns:
-            conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS current_step VARCHAR(128)"))
+            conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS current_step VARCHAR(128)"))
 
 
 def ensure_multi_api_key_columns() -> None:
@@ -301,7 +335,7 @@ def ensure_multi_api_key_columns() -> None:
     statements = (
         "ALTER TABLE user_api_key ADD COLUMN IF NOT EXISTS label VARCHAR(128)",
         "ALTER TABLE user_api_key ADD COLUMN IF NOT EXISTS key_plaintext VARCHAR(64)",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
         "ALTER TABLE credit_history ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
         "ALTER TABLE token_metrics ADD COLUMN IF NOT EXISTS api_key_id VARCHAR(36)",
     )
@@ -313,11 +347,11 @@ def ensure_multi_api_key_columns() -> None:
                 logger.warning("Schema update failed for %s: %s", stmt, exc, exc_info=True)
 
 def ensure_failure_diagnostic_columns() -> None:
-    """Add failure diagnostic columns to task_item (idempotent)."""
+    """Add failure diagnostic columns to plans (idempotent)."""
     statements = (
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(64)",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS failed_step VARCHAR(128)",
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS recoverable BOOLEAN",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(64)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS failed_step VARCHAR(128)",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS recoverable BOOLEAN",
     )
     with db.engine.begin() as conn:
         for stmt in statements:
@@ -327,23 +361,23 @@ def ensure_failure_diagnostic_columns() -> None:
                 logger.warning("Schema update failed for %s: %s", stmt, exc, exc_info=True)
     # Rename last_error → error_message (existing DBs); add column for fresh DBs.
     # Check column existence first to avoid noisy PostgreSQL ERROR logs on every restart.
-    columns = {col["name"] for col in inspect(db.engine).get_columns("task_item")}
+    columns = {col["name"] for col in inspect(db.engine).get_columns("plans")}
     if "error_message" not in columns:
         if "last_error" in columns:
             try:
                 with db.engine.begin() as conn:
-                    conn.execute(text("ALTER TABLE task_item RENAME COLUMN last_error TO error_message"))
+                    conn.execute(text("ALTER TABLE plans RENAME COLUMN last_error TO error_message"))
             except Exception:
                 with db.engine.begin() as conn:
-                    conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
+                    conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
         else:
             with db.engine.begin() as conn:
-                conn.execute(text("ALTER TABLE task_item ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
+                conn.execute(text("ALTER TABLE plans ADD COLUMN IF NOT EXISTS error_message VARCHAR(256)"))
 
 def ensure_last_progress_at_column() -> None:
-    """Add last_progress_at column to task_item (idempotent)."""
+    """Add last_progress_at column to plans (idempotent)."""
     statements = (
-        "ALTER TABLE task_item ADD COLUMN IF NOT EXISTS last_progress_at TIMESTAMP",
+        "ALTER TABLE plans ADD COLUMN IF NOT EXISTS last_progress_at TIMESTAMP",
     )
     with db.engine.begin() as conn:
         for stmt in statements:
@@ -1545,6 +1579,7 @@ def process_pending_tasks() -> bool:
 def startup_worker():
     with app.app_context():
         try:
+            ensure_plans_table_name()
             db.create_all()
             ensure_planitem_artifact_columns()
             ensure_step_count_columns()


### PR DESCRIPTION
## Summary
Closes the "Rename table name" TODO from \`docs/plan.md\`. Matches the Python \`PlanItem\` naming introduced in proposal #74 (which kept the DB table at its legacy \`task_item\` name to avoid a migration).

**Migration strategy**
- New helper \`ensure_plans_table_name()\` renames the table (and its two indexes) if and only if legacy \`task_item\` exists AND \`plans\` does not. Wrapped in a Postgres transaction-level advisory lock so the three services (\`frontend_multi_user\`, \`worker_plan_database\`, \`mcp_cloud\`) cannot race on startup — whichever replica grabs the lock first does the rename; the others no-op.
- Runs before \`db.create_all()\` so SQLAlchemy does not create a second empty \`plans\` table alongside \`task_item\`.
- \`PlanItem.__tablename__\` flipped from \`"task_item"\` to \`"plans"\`.
- All \`ALTER TABLE\` / \`CREATE INDEX\` / \`SELECT\` / \`UPDATE\` / \`VACUUM\` strings in the three services and admin routes now reference \`plans\`.
- Indexes renamed \`idx_task_item_*\` → \`idx_plans_*\`.
- Admin template wording and the \`_vacuum_task_item()\` helper renamed to \`_vacuum_plans()\`.
- Log messages updated.

**No zero-downtime guarantees**: during a rolling deploy, a still-running old replica will fail queries against the new name until it gets redeployed. User confirmed this is fine (no users on Railway).

## Test plan
- [ ] CI passes
- [ ] Fresh DB: \`docker compose up\` creates a \`plans\` table, no \`task_item\`
- [ ] Existing DB (Railway): first replica boot renames \`task_item\` → \`plans\` atomically, subsequent replicas no-op
- [ ] Admin panel: size info, purge, and vacuum still work against the renamed table
- [ ] End-to-end plan_create → plan_status → report download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)