### PR TITLE
chore: add openrouter-deepseek-v4-flash to baseline.json

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -156,7 +156,7 @@
         "pricing_kind": "paid"
     },
     "openrouter-deepseek-v4-flash": {
-        "comment": "Released Apr 24, 2026. MoE (284B total / 13B activated), efficiency-optimized. 1,048,576 context. $0.14/M input tokens. $0.28/M output tokens.",
+        "comment": "Released Apr 24, 2026. MoE (284B total / 13B activated). 1,048,576 context. $0.14/M input tokens. $0.28/M output tokens.",
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -155,6 +155,28 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-deepseek-v4-flash": {
+        "comment": "Released Apr 24, 2026. MoE (284B total / 13B activated), efficiency-optimized. 1,048,576 context. $0.14/M input tokens. $0.28/M output tokens.",
+        "luigi_workers": 4,
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "deepseek/deepseek-v4-flash",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 1048576,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8192,
+            "max_retries": 5
+        },
+        "model_info_url": "https://openrouter.ai/deepseek/deepseek-v4-flash",
+        "pricing": {
+            "input_per_million_tokens": 0.14,
+            "output_per_million_tokens": 0.28
+        },
+        "pricing_kind": "paid"
+    },
     "alibabacloud-qwen-flash-2025-07-28": {
         "comment": "This is slow. Requires a DASHSCOPE_API_KEY created on the Alibaba Cloud website. Snapshot from 2025-07-28. 1,000,000 context. $0.05/M input tokens. $0.40/M output tokens.",
         "luigi_workers": 4,


### PR DESCRIPTION
## Summary
Adds the DeepSeek V4 Flash model (released 2026-04-24) via OpenRouter to the baseline profile.

- Model: \`deepseek/deepseek-v4-flash\`
- Architecture: efficiency-optimized MoE (284B total / 13B activated)
- Context window: 1,048,576
- Pricing: \$0.14/M input, \$0.28/M output
- Placed alongside the other OpenRouter entries, ahead of the Alibaba Cloud block

Values sourced from [openrouter.ai/deepseek/deepseek-v4-flash](https://openrouter.ai/deepseek/deepseek-v4-flash).

## Test plan
- [ ] CI passes (JSON validates)
- [ ] Profile loads without error via \`model_profiles\` MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)