### PR TITLE
chore: add openrouter-ling-2.6-1t-free to baseline.json

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -64,6 +64,28 @@
         },
         "pricing_kind": "free"
     },
+    "openrouter-ling-2.6-1t-free": {
+        "comment": "Released Apr 23, 2026. Scheduled to be removed from OpenRouter on Apr 30, 2026. 262,144 context. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inclusionai/ling-2.6-1t",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "inclusionai/ling-2.6-1t:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8192,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-gemini-2.0-flash-001": {
         "comment": "This is very fast. Created Feb 25, 2025. 1,048,576 context. $0.075/M input tokens. $0.30/M output tokens.",
         "priority": 1,


### PR DESCRIPTION
## Summary
Adds InclusionAI's Ling 2.6 1T (free tier) via OpenRouter to the baseline profile.

- Model: \`inclusionai/ling-2.6-1t:free\`
- Context window: 262,144
- Pricing: free (\$0/M input, \$0/M output)
- Released: 2026-04-23
- Placed next to the other free OpenRouter entry (\`openrouter-elephant-alpha\`)

**Heads-up:** OpenRouter has scheduled this model to be removed on **2026-04-30**, so the entry is time-boxed.

Values sourced from [openrouter.ai/inclusionai/ling-2.6-1t:free](https://openrouter.ai/inclusionai/ling-2.6-1t:free).

## Test plan
- [ ] CI passes (JSON validates)
- [ ] Profile loads without error via \`model_profiles\` MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)