### PR TITLE
chore: add openrouter-tencent-hy3-preview-free to baseline.json

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -86,6 +86,28 @@
         },
         "pricing_kind": "free"
     },
+    "openrouter-tencent-hy3-preview-free": {
+        "comment": "Released Apr 22, 2026. Tencent MoE designed for agentic workflows, configurable reasoning levels. 262,144 context. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/tencent/hy3-preview",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "tencent/hy3-preview:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8192,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-gemini-2.0-flash-001": {
         "comment": "This is very fast. Created Feb 25, 2025. 1,048,576 context. $0.075/M input tokens. $0.30/M output tokens.",
         "priority": 1,


### PR DESCRIPTION
## Summary
Adds Tencent's Hy3 preview (free tier) via OpenRouter to the baseline profile.

- Model: \`tencent/hy3-preview:free\`
- Architecture: MoE with configurable reasoning levels, designed for agentic workflows
- Context window: 262,144
- Pricing: free (\$0/M input, \$0/M output)
- Released: 2026-04-22
- Placed next to the other free OpenRouter entries

Values sourced from [openrouter.ai/tencent/hy3-preview:free](https://openrouter.ai/tencent/hy3-preview:free).

## Test plan
- [ ] CI passes (JSON validates)
- [ ] Profile loads without error via \`model_profiles\` MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)