### PR TITLE
chore: add openrouter-inception-mercury-2 to premium.json

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -177,6 +177,28 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-inception-mercury-2": {
+        "comment": "Released Mar 4, 2026. Inception Mercury 2: fast reasoning LLM (>1000 tokens/sec). 128,000 context. $0.25/M input tokens. $0.75/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inception/mercury-2",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "inception/mercury-2",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 128000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8192,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0.25,
+            "output_per_million_tokens": 0.75
+        },
+        "pricing_kind": "paid"
+    },
     "alibabacloud-qwen-flash-2025-07-28": {
         "comment": "This is slow. Requires a DASHSCOPE_API_KEY created on the Alibaba Cloud website. Snapshot from 2025-07-28. 1,000,000 context. $0.05/M input tokens. $0.40/M output tokens.",
         "luigi_workers": 4,

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -177,28 +177,6 @@
         },
         "pricing_kind": "paid"
     },
-    "openrouter-inception-mercury-2": {
-        "comment": "Released Mar 4, 2026. Inception Mercury 2: fast reasoning LLM (>1000 tokens/sec). 128,000 context. $0.25/M input tokens. $0.75/M output tokens.",
-        "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/inception/mercury-2",
-        "class": "OpenRouter",
-        "arguments": {
-            "model": "inception/mercury-2",
-            "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 0.1,
-            "timeout": 60.0,
-            "context_window": 128000,
-            "is_function_calling_model": false,
-            "is_chat_model": true,
-            "max_tokens": 8192,
-            "max_retries": 5
-        },
-        "pricing": {
-            "input_per_million_tokens": 0.25,
-            "output_per_million_tokens": 0.75
-        },
-        "pricing_kind": "paid"
-    },
     "alibabacloud-qwen-flash-2025-07-28": {
         "comment": "This is slow. Requires a DASHSCOPE_API_KEY created on the Alibaba Cloud website. Snapshot from 2025-07-28. 1,000,000 context. $0.05/M input tokens. $0.40/M output tokens.",
         "luigi_workers": 4,

--- a/llm_config/premium.json
+++ b/llm_config/premium.json
@@ -1,29 +1,30 @@
 {
-    "openrouter-stepfun-step-3-5-flash": {
-        "comment": "This is very fast. Created Jan 29, 2026. 256,000 context. $0.10/M input tokens. $0.30/M output tokens.",
-        "priority": 21,
+    "openrouter-inception-mercury-2": {
+        "comment": "Released Mar 4, 2026. Inception Mercury 2: 128,000 context. $0.25/M input tokens. $0.75/M output tokens.",
+        "priority": 1,
         "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inception/mercury-2",
         "class": "OpenRouter",
         "arguments": {
-            "model": "stepfun/step-3.5-flash",
+            "model": "inception/mercury-2",
             "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 1,
+            "temperature": 0.1,
             "timeout": 60.0,
+            "context_window": 128000,
             "is_function_calling_model": false,
             "is_chat_model": true,
-            "max_tokens": 32000,
+            "max_tokens": 8192,
             "max_retries": 5
         },
-        "model_info_url": "https://openrouter.ai/stepfun/step-3.5-flash",
         "pricing": {
-            "input_per_million_tokens": 0.10,
-            "output_per_million_tokens": 0.30
+            "input_per_million_tokens": 0.25,
+            "output_per_million_tokens": 0.75
         },
         "pricing_kind": "paid"
     },
     "openrouter-google/gemini-2.5-flash-lite-preview-09-2025": {
         "comment": "This is fast. Created Feb 11, 2026. 204,800 context. $0.30/M input tokens. $2.55/M output tokens.",
-        "priority": 1,
+        "priority": 2,
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {
@@ -45,7 +46,7 @@
     },
     "openrouter-qwen-qwen3-5-397b-a17b": {
         "comment": "This is fast. Created Feb 16, 2026. 262,144 context. Pricing varies by context length: starting at $0.15/M input, $1.00/M output; highest tier $0.60/M input, $3.60/M output (when input > 128k tokens).",
-        "priority": 2,
+        "priority": 3,
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {
@@ -67,7 +68,7 @@
     },
     "openai-gpt-5-mini": {
         "comment": "This is slow. Requires that you have a OPENAI_API_KEY in the .env file. This is a reasoning model, so it takes MUCH longer to create a plan. $0.25/M input tokens. $2.00/M output tokens.",
-        "priority": 5,
+        "priority": 4,
         "luigi_workers": 4,
         "class": "OpenAI",
         "arguments": {
@@ -84,6 +85,28 @@
         "pricing": {
             "input_per_million_tokens": 0.25,
             "output_per_million_tokens": 2.00
+        },
+        "pricing_kind": "paid"
+    },
+    "openrouter-stepfun-step-3-5-flash": {
+        "comment": "This is very fast. Created Jan 29, 2026. 256,000 context. $0.10/M input tokens. $0.30/M output tokens.",
+        "priority": 100,
+        "luigi_workers": 4,
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "stepfun/step-3.5-flash",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 1,
+            "timeout": 60.0,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "model_info_url": "https://openrouter.ai/stepfun/step-3.5-flash",
+        "pricing": {
+            "input_per_million_tokens": 0.10,
+            "output_per_million_tokens": 0.30
         },
         "pricing_kind": "paid"
     }


### PR DESCRIPTION
## Summary
Adds Inception's Mercury 2 via OpenRouter to the **premium** profile (moved from the initial baseline attempt — costs ~2x the cheaper baseline models).

- Model: \`inception/mercury-2\`
- Context window: 128,000
- Pricing: \$0.25/M input, \$0.75/M output (paid)
- Released: 2026-03-04
- Placed as \`priority: 1\` in premium.json; existing entries shifted down.

Values sourced from [openrouter.ai/inception/mercury-2](https://openrouter.ai/inception/mercury-2).

## Test plan
- [ ] CI passes (JSON validates)
- [ ] Profile loads without error via \`model_profiles\` MCP tool with \`premium\` selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)