### PR TITLE
fix(frontend_multi_user): unblock /viewplan and gunicorn control server

### DIFF
--- a/frontend_multi_user/Dockerfile
+++ b/frontend_multi_user/Dockerfile
@@ -39,9 +39,42 @@ EXPOSE 5000
 
 ENV PLANEXE_FRONTEND_MULTIUSER_WORKERS=4
 
+# --keep-alive 0 — workaround for sync-worker timeouts after large responses.
+#
+# Symptom: gunicorn master kills a worker with "WORKER TIMEOUT (pid:N)" exactly
+# 120s after a successful big response (e.g. /plan/download/zip returning ~4MB,
+# /viewplan returning ~600KB). Traceback always points at recv() / "no URI
+# read" — misleading, that's just where SIGABRT interrupts the worker. The
+# actual cause is the worker sitting idle in recv() on a kept-alive TCP
+# connection that the upstream peer (Cloudflare edge in our deploy) holds open
+# without sending another request. The sync worker counts that idle wait
+# against --timeout, so the master eventually kills it.
+#
+# Worked in the past: this only became a regular issue recently. Likely cause
+# is gunicorn 25.x sync-worker keep-alive handling combined with our move
+# behind Cloudflare; previous gunicorn versions / direct connections did not
+# trigger it.
+#
+# Fix: --keep-alive 0 forces gunicorn to close the connection right after each
+# response. The worker returns to accept() instead of waiting in recv(), so it
+# can never sit idle past --timeout. Tiny perf cost (one TCP handshake per
+# request) — irrelevant for our traffic volume.
+#
+# Alternatives considered, not taken:
+#  1. --worker-class gthread --threads N — threaded workers tolerate idle
+#     connections without blocking. Bigger change; revisit if we ever want
+#     real keep-alive for performance.
+#  2. Pin gunicorn <25 — would also work if this is a 25.x regression, but
+#     locks us out of upstream fixes and the 25.x control-server feature.
+#  3. Lower --timeout — masks symptom at the cost of killing legitimately
+#     slow handlers. Rejected.
+#
+# Revisit if we switch worker class, drop Cloudflare in front of this service,
+# or upgrade gunicorn past a release that fixes sync keep-alive idle handling.
 CMD gunicorn wsgi:app \
     --bind 0.0.0.0:${PLANEXE_FRONTEND_MULTIUSER_PORT:-5000} \
     --workers ${PLANEXE_FRONTEND_MULTIUSER_WORKERS} \
     --timeout 120 \
+    --keep-alive 0 \
     --access-logfile - \
     --chdir /app/frontend_multi_user/src

--- a/frontend_multi_user/Dockerfile
+++ b/frontend_multi_user/Dockerfile
@@ -26,6 +26,11 @@ RUN set -eux; \
 # Default location for generated plans
 RUN mkdir -p /app/run && chown -R appuser:appuser /app/run
 
+# Gunicorn 25.x writes control-server state into <cwd>/.gunicorn at startup,
+# resolved before --chdir is applied, so it lands in /app. Pre-create with
+# correct ownership to avoid PermissionError from the master process.
+RUN mkdir -p /app/.gunicorn && chown appuser:appuser /app/.gunicorn
+
 USER appuser
 
 WORKDIR /app/frontend_multi_user

--- a/frontend_multi_user/Dockerfile
+++ b/frontend_multi_user/Dockerfile
@@ -43,4 +43,5 @@ CMD gunicorn wsgi:app \
     --bind 0.0.0.0:${PLANEXE_FRONTEND_MULTIUSER_PORT:-5000} \
     --workers ${PLANEXE_FRONTEND_MULTIUSER_WORKERS} \
     --timeout 120 \
+    --access-logfile - \
     --chdir /app/frontend_multi_user/src

--- a/frontend_multi_user/src/app.py
+++ b/frontend_multi_user/src/app.py
@@ -925,15 +925,25 @@ class MyFlaskApp:
         from src.billing import _record_event, _finalize_stripe_checkout_session
         from src.plan_routes import _get_current_user_account, _admin_user_ids
 
+        # /healthcheck fires every 10s from the docker healthcheck and
+        # produces a gunicorn access-log line on its own; skip it here so the
+        # console isn't flooded. If healthchecks ever hang, the absence of the
+        # gunicorn access-log line + a WORKER TIMEOUT is still diagnostic.
+        _trace_skip_paths = frozenset({"/healthcheck"})
+
         @self.app.before_request
         def _trace_request_arrival():
             """Log every request entry so a hung worker's URL is visible even
             if the handler never returns. Pairs with _trace_request_completion."""
+            if request.path in _trace_skip_paths:
+                return
             g._planexe_req_started = time.monotonic()
             logger.info("→ %s %s", request.method, request.full_path.rstrip("?"))
 
         @self.app.after_request
         def _trace_request_completion(response):
+            if request.path in _trace_skip_paths:
+                return response
             started = g.pop("_planexe_req_started", None)
             duration_ms = (time.monotonic() - started) * 1000 if started is not None else -1
             logger.info(

--- a/frontend_multi_user/src/app.py
+++ b/frontend_multi_user/src/app.py
@@ -17,7 +17,7 @@ from urllib.parse import quote_plus, urlparse
 from typing import Dict, Optional, Tuple, Any, cast
 from types import SimpleNamespace
 from pathlib import Path
-from flask import Flask, render_template, request, jsonify, send_file, redirect, url_for, session, abort
+from flask import Flask, render_template, request, jsonify, send_file, redirect, url_for, session, abort, g
 from flask_admin import Admin, AdminIndexView, expose
 from flask_login import LoginManager, UserMixin, login_user, login_required, current_user
 from authlib.integrations.flask_client import OAuth
@@ -924,6 +924,23 @@ class MyFlaskApp:
         from src.auth import get_or_create_api_key, _auth_provider_label
         from src.billing import _record_event, _finalize_stripe_checkout_session
         from src.plan_routes import _get_current_user_account, _admin_user_ids
+
+        @self.app.before_request
+        def _trace_request_arrival():
+            """Log every request entry so a hung worker's URL is visible even
+            if the handler never returns. Pairs with _trace_request_completion."""
+            g._planexe_req_started = time.monotonic()
+            logger.info("→ %s %s", request.method, request.full_path.rstrip("?"))
+
+        @self.app.after_request
+        def _trace_request_completion(response):
+            started = g.pop("_planexe_req_started", None)
+            duration_ms = (time.monotonic() - started) * 1000 if started is not None else -1
+            logger.info(
+                "← %s %s %s %.0fms",
+                response.status_code, request.method, request.full_path.rstrip("?"), duration_ms,
+            )
+            return response
 
         @self.app.before_request
         def _auto_login_open_access():

--- a/frontend_multi_user/src/plan_routes.py
+++ b/frontend_multi_user/src/plan_routes.py
@@ -3,13 +3,14 @@ import io
 import json
 import logging
 import os
+import time
 import uuid
 import zipfile
 from datetime import datetime, UTC
 from decimal import Decimal
 from typing import Any, Optional
 
-from flask import Blueprint, current_app, jsonify, make_response, redirect, render_template, request, url_for
+from flask import Blueprint, Response, current_app, jsonify, make_response, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from sqlalchemy import func
 from sqlalchemy.exc import DataError
@@ -901,13 +902,31 @@ def viewplan():
         logger.warning("Unauthorized report access attempt. plan_id=%s user_id=%s", plan_id, current_user.id)
         return jsonify({"error": "Forbidden"}), 403
 
-    if not plan.generated_report_html:
+    if not plan.has_generated_report_html:
         logger.error("Report HTML not found for plan_id=%s", plan_id)
         return jsonify({"error": "Report not available"}), 404
 
-    response = make_response(plan.generated_report_html)
-    response.headers["Content-Type"] = "text/html"
-    return response
+    # generated_report_html is a deferred TEXT column (~800KB typical). Loading
+    # it can stall when the row is large or the DB is busy with a checkpoint;
+    # log timing so we can attribute future worker timeouts to the right step.
+    load_start = time.monotonic()
+    report_html = plan.generated_report_html
+    load_secs = time.monotonic() - load_start
+    if not report_html:
+        logger.error("Report HTML empty for plan_id=%s", plan_id)
+        return jsonify({"error": "Report not available"}), 404
+    report_bytes = report_html.encode("utf-8")
+    logger.info(
+        "ViewPlan: loaded report for plan_id=%s in %.2fs (%d bytes)",
+        plan_id, load_secs, len(report_bytes),
+    )
+
+    chunk_size = 65536
+    def _stream():
+        for i in range(0, len(report_bytes), chunk_size):
+            yield report_bytes[i:i + chunk_size]
+
+    return Response(_stream(), mimetype="text/html")
 
 
 @plan_routes_bp.route("/plan")


### PR DESCRIPTION
## Summary
- `/viewplan` was hanging gunicorn workers past the 120s timeout. The handler loads the `deferred` `generated_report_html` column (~800KB typical) and hands it to `make_response` as one big string. In one captured incident this lazy load overlapped a 134s postgres checkpoint, so the worker silently sat on the DB read until the master killed it. The "no URI read" traceback was misleading — that's just where SIGABRT interrupted the worker after the slow request returned.
- Gunicorn 25.x writes its control-server state to `<cwd>/.gunicorn` at master startup, before `--chdir` is applied, so it landed in `/app` — root-owned in the image, hence `Permission denied: '/app/.gunicorn'` on every restart.

## Changes
- `frontend_multi_user/src/plan_routes.py`:
  - First check now uses the cheap `has_generated_report_html` column_property so the deferred TEXT column isn't loaded just to test for null.
  - Deferred load is timed and logged: `ViewPlan: loaded report for plan_id=… in N.NNs (B bytes)`.
  - Response is streamed in 64KB chunks via a generator instead of `make_response(big_string)`.
- `frontend_multi_user/Dockerfile`: pre-create `/app/.gunicorn` owned by `appuser`.

## Notes
Streaming/chunking won't make a slow DB read fast. The new timing log is so the *next* timeout cleanly attributes time to DB load vs. response send. If it confirms the DB read is the bottleneck, the right follow-up is to move report HTML out of `plans.generated_report_html` and onto disk/object storage.

## Test plan
- [ ] Rebuild `frontend_multi_user` image and confirm no more `Permission denied: '/app/.gunicorn'` in master logs
- [ ] Open a completed plan via `/viewplan` and confirm the new `ViewPlan: loaded report …` log line appears
- [ ] Confirm the report renders end-to-end with chunked streaming