### PR TITLE
chore(docker-compose): tighten host port exposure (LAN-safe defaults)

### DIFF
--- a/docker-compose.md
+++ b/docker-compose.md
@@ -7,6 +7,7 @@ TL;DR
 - Shared host files: `.env` and `./llm_config/` mounted read-only; `.env` is also loaded via `env_file`.
 - Postgres defaults to user/db/password `planexe`; override via env or `.env`; data lives in the `database_postgres_data` volume.
 - Env defaults live in `docker-compose.yml` but can be overridden in `.env` or your shell (URLs, timeouts, run dirs, optional auth).
+- All published ports bind to `127.0.0.1` by default (LAN-safe). `database_postgres` and `worker_plan` are pinned to localhost; `frontend_multi_user` and `mcp_cloud` honor `PLANEXE_BIND_HOST` — see [Bind host](#bind-host-lan-exposure).
 - `develop.watch` syncs code/config for `worker_plan`; rebuild with `--no-cache` after big moves or dependency changes; restart policy is `unless-stopped`.
 
 Quickstart (run from repo root)
@@ -36,7 +37,7 @@ What compose sets up
 
 Service: `database_postgres` (Postgres DB)
 ------------------------------------------
-- Purpose: Storage in a Postgres database for future queue + event logging work; exposes `${PLANEXE_POSTGRES_PORT:-5432}` on the host mapped to 5432 in the container.
+- Purpose: Storage in a Postgres database for future queue + event logging work; exposes `${PLANEXE_POSTGRES_PORT:-5432}` on the host (bound to `127.0.0.1`) mapped to 5432 in the container.
 - Build: `database_postgres/Dockerfile` (uses the official Postgres image).
 - Env defaults: `PLANEXE_POSTGRES_USER=planexe`, `PLANEXE_POSTGRES_PASSWORD=planexe`, `PLANEXE_POSTGRES_DB=planexe`, `PLANEXE_POSTGRES_PORT=5432` (override with env/.env).
 - Data/health: data in the named volume `database_postgres_data`; healthcheck uses `pg_isready`.
@@ -58,16 +59,43 @@ docker compose up
 
 **Important**: This only affects the HOST port mapping (how you access Postgres from your machine, e.g., via DBeaver or `psql`). Inside Docker, containers always communicate with each other on the internal port 5432—this is hardcoded and not affected by `PLANEXE_POSTGRES_PORT`.
 
+Bind host (LAN exposure)
+------------------------
+
+Several services have permissive defaults that are fine for localhost use but become a foot-gun on a shared network:
+
+- `frontend_multi_user` defaults to `admin` / `admin`.
+- `mcp_cloud` defaults to `PLANEXE_MCP_REQUIRE_AUTH=false` with empty `PLANEXE_MCP_API_KEY`.
+- `database_postgres` defaults to user/password `planexe` / `planexe`.
+- `worker_plan` has no auth at all.
+
+To avoid exposing this stack to your LAN out of the box, every published port binds to `127.0.0.1` by default:
+
+- `database_postgres` (5432) and `worker_plan` (8000) are pinned to `127.0.0.1`. Nothing outside the host should call them directly; container-to-container traffic uses the docker network and is unaffected.
+- `frontend_multi_user` (5001) and `mcp_cloud` (8001) honor `PLANEXE_BIND_HOST` (default `127.0.0.1`).
+
+To opt back into LAN access (e.g., testing from your phone, Claude Desktop on another machine):
+
+```bash
+export PLANEXE_BIND_HOST=0.0.0.0
+docker compose up
+```
+
+Before doing this, set strong values for at least:
+- `PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD`
+- `PLANEXE_MCP_REQUIRE_AUTH=true` and `PLANEXE_MCP_API_KEY`
+- `PLANEXE_POSTGRES_PASSWORD` (if you also choose to expose 5432)
+
 Service: `frontend_multi_user` (multi user UI)
 ------------------------------------------
 - Purpose: Multi-user Flask UI with admin views (tasks/events/nonce/workers) backed by Postgres.
 - Build: `frontend_multi_user/Dockerfile`.
-- Env defaults: DB host `database_postgres`, port `5432`, db/user/password `planexe` (follows `PLANEXE_POSTGRES_*`); admin credentials must be provided via `PLANEXE_FRONTEND_MULTIUSER_ADMIN_USERNAME`/`PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD` (compose will fail if missing); container listens on fixed port `5000`, host maps `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}`.
+- Env defaults: DB host `database_postgres`, port `5432`, db/user/password `planexe` (follows `PLANEXE_POSTGRES_*`); admin credentials must be provided via `PLANEXE_FRONTEND_MULTIUSER_ADMIN_USERNAME`/`PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD` (compose will fail if missing); container listens on fixed port `5000`, host maps `${PLANEXE_BIND_HOST:-127.0.0.1}:${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}`.
 - Health: depends on `database_postgres` health; its own healthcheck hits `/healthcheck` on port 5000.
 
 Service: `worker_plan` (pipeline API)
 -------------------------------------
-- Purpose: runs the PlanExe pipeline and exposes the API on port 8000; the frontend depends on its health.
+- Purpose: runs the PlanExe pipeline and exposes the API on port 8000 (bound to `127.0.0.1` only — meant for the frontend container, not the LAN); the frontend depends on its health.
 - Build: `worker_plan/Dockerfile`.
 - Env: `PLANEXE_CONFIG_PATH=/app`, `PLANEXE_WORKER_RELAY_PROCESS_OUTPUT=true`.
 - Health: `http://localhost:8000/healthcheck` checked via the compose healthcheck.
@@ -92,7 +120,7 @@ Service: `mcp_cloud` (MCP interface)
 - Build: `mcp_cloud/Dockerfile` (ships shared `database_api` models and the MCP server implementation).
 - Depends on: `database_postgres` and `worker_plan` health.
 - Env defaults: derives `SQLALCHEMY_DATABASE_URI` from `PLANEXE_POSTGRES_HOST|PORT|DB|USER|PASSWORD` (fallbacks to `database_postgres` + `planexe/planexe` on 5432); `PLANEXE_CONFIG_PATH=/app`; `PLANEXE_MCP_HTTP_HOST=0.0.0.0`, `PLANEXE_MCP_HTTP_PORT=8001`; `PLANEXE_MCP_PUBLIC_BASE_URL=http://localhost:8001` for report download URLs; `PLANEXE_MCP_REQUIRE_AUTH=false` by default.
-- Ports: host `${PLANEXE_MCP_HTTP_PORT:-8001}` -> container `8001`.
+- Ports: host `${PLANEXE_BIND_HOST:-127.0.0.1}:${PLANEXE_MCP_HTTP_PORT:-8001}` -> container `8001`.
 - Volumes: `llm_config/` (ro for provider configs).
 - Health: `http://localhost:8001/healthcheck` checked via the compose healthcheck.
 - Communication: Streamable HTTP (`/mcp`) plus helper endpoints (`/download/...`, `/sse/...`). Point your MCP client at `http://localhost:${PLANEXE_MCP_HTTP_PORT:-8001}/mcp`.
@@ -100,7 +128,7 @@ Service: `mcp_cloud` (MCP interface)
 
 Usage notes
 -----------
-- Ports: host `8000->worker_plan`, `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}->frontend_multi_user`, `PLANEXE_POSTGRES_PORT (default 5432)->database_postgres`; change mappings in `docker-compose.yml` if needed.
+- Ports (all default to `127.0.0.1` host binding): `8000->worker_plan`, `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}->frontend_multi_user`, `${PLANEXE_MCP_HTTP_PORT:-8001}->mcp_cloud`, `PLANEXE_POSTGRES_PORT (default 5432)->database_postgres`. To make `frontend_multi_user`/`mcp_cloud` reachable from the LAN, set `PLANEXE_BIND_HOST=0.0.0.0` (read [Bind host](#bind-host-lan-exposure) first). Change mappings in `docker-compose.yml` if needed.
 - `.env` must exist before `docker compose up`; it is both loaded and mounted read-only. Same for `llm_config/`. If missing, start from `.env.docker-example`.
 - Database: connect on `localhost:${PLANEXE_POSTGRES_PORT:-5432}` with `planexe/planexe` by default; data persists via the `database_postgres_data` volume.
 
@@ -112,9 +140,9 @@ Snapshot from `docker compose ps` on a live stack with two numbered DB workers; 
 ```
 PROMPT> docker compose ps                                                 
 NAME                     IMAGE                            COMMAND                  SERVICE                  CREATED          STATUS                   PORTS
-database_postgres        planexe-database_postgres        "docker-entrypoint.s…"   database_postgres        8 hours ago      Up 8 hours (healthy)     0.0.0.0:5433->5432/tcp, [::]:5433->5432/tcp
-frontend_multi_user      planexe-frontend_multi_user      "python /app/fronten…"   frontend_multi_user      8 hours ago      Up 2 minutes (healthy)   0.0.0.0:5001->5000/tcp, [::]:5001->5000/tcp
-worker_plan              planexe-worker_plan              "uvicorn worker_plan…"   worker_plan              2 minutes ago    Up 2 minutes (healthy)   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp
+database_postgres        planexe-database_postgres        "docker-entrypoint.s…"   database_postgres        8 hours ago      Up 8 hours (healthy)     127.0.0.1:5433->5432/tcp
+frontend_multi_user      planexe-frontend_multi_user      "python /app/fronten…"   frontend_multi_user      8 hours ago      Up 2 minutes (healthy)   127.0.0.1:5001->5000/tcp
+worker_plan              planexe-worker_plan              "uvicorn worker_plan…"   worker_plan              2 minutes ago    Up 2 minutes (healthy)   127.0.0.1:8000->8000/tcp
 worker_plan_database_1   planexe-worker_plan_database_1   "python -m worker_pl…"   worker_plan_database_1   15 seconds ago   Up 13 seconds            
 worker_plan_database_2   planexe-worker_plan_database_2   "python -m worker_pl…"   worker_plan_database_2   15 seconds ago   Up 13 seconds  
 ```

--- a/docker-compose.md
+++ b/docker-compose.md
@@ -3,11 +3,11 @@ Docker Compose for PlanExe
 
 TL;DR
 -----
-- Services: `database_postgres` (DB on `${PLANEXE_POSTGRES_PORT:-5432}`), `worker_plan` (API on 8000), `frontend_multi_user` (UI on `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}`), plus DB workers (`worker_plan_database_1/2/3` by default; `worker_plan_database` in `manual` profile), and `mcp_cloud` (MCP interface, stdio); `frontend_multi_user` waits for Postgres and worker health.
+- Services: `database_postgres` (internal DB), `worker_plan` (internal pipeline API), `frontend_multi_user` (UI on `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}`), plus DB workers (`worker_plan_database_1/2/3` by default; `worker_plan_database` in `manual` profile), and `mcp_cloud` (MCP interface on `${PLANEXE_MCP_HTTP_PORT:-8001}`); `frontend_multi_user` waits for Postgres and worker health.
 - Shared host files: `.env` and `./llm_config/` mounted read-only; `.env` is also loaded via `env_file`.
 - Postgres defaults to user/db/password `planexe`; override via env or `.env`; data lives in the `database_postgres_data` volume.
 - Env defaults live in `docker-compose.yml` but can be overridden in `.env` or your shell (URLs, timeouts, run dirs, optional auth).
-- All published ports bind to `127.0.0.1` by default (LAN-safe). `database_postgres` and `worker_plan` are pinned to localhost; `frontend_multi_user` and `mcp_cloud` honor `PLANEXE_BIND_HOST` — see [Bind host](#bind-host-lan-exposure).
+- Only `frontend_multi_user` and `mcp_cloud` publish ports to the host (bound to `127.0.0.1` by default, override via `PLANEXE_BIND_HOST`). `database_postgres` and `worker_plan` are docker-network-only — see [Published ports / bind host](#published-ports--bind-host).
 - `develop.watch` syncs code/config for `worker_plan`; rebuild with `--no-cache` after big moves or dependency changes; restart policy is `unless-stopped`.
 
 Quickstart (run from repo root)
@@ -37,44 +37,27 @@ What compose sets up
 
 Service: `database_postgres` (Postgres DB)
 ------------------------------------------
-- Purpose: Storage in a Postgres database for future queue + event logging work; exposes `${PLANEXE_POSTGRES_PORT:-5432}` on the host (bound to `127.0.0.1`) mapped to 5432 in the container.
+- Purpose: Storage in a Postgres database for future queue + event logging work. **Not published to the host.** Other containers reach it via the docker network at `database_postgres:5432`. To poke at it from your machine use `docker compose exec database_postgres psql -U planexe` or a one-off override (see [Published ports / bind host](#published-ports--bind-host)).
 - Build: `database_postgres/Dockerfile` (uses the official Postgres image).
 - Env defaults: `PLANEXE_POSTGRES_USER=planexe`, `PLANEXE_POSTGRES_PASSWORD=planexe`, `PLANEXE_POSTGRES_DB=planexe`, `PLANEXE_POSTGRES_PORT=5432` (override with env/.env).
 - Data/health: data in the named volume `database_postgres_data`; healthcheck uses `pg_isready`.
 
-### Port conflict with local Postgres
+Published ports / bind host
+---------------------------
 
-The default PostgreSQL port is 5432. On developer machines, this port is often already occupied by a local PostgreSQL installation:
-- **macOS**: Postgres.app, Homebrew PostgreSQL, or pgAdmin's bundled server
-- **Linux**: System PostgreSQL installed via apt/yum/dnf
-- **Windows**: PostgreSQL installer, pgAdmin, or other database tools
-
-If port 5432 is in use, Docker will fail to start `database_postgres` with a "port already in use" error.
-
-**Solution**: Set `PLANEXE_POSTGRES_PORT` to a different value before starting:
-```bash
-export PLANEXE_POSTGRES_PORT=5433
-docker compose up
-```
-
-**Important**: This only affects the HOST port mapping (how you access Postgres from your machine, e.g., via DBeaver or `psql`). Inside Docker, containers always communicate with each other on the internal port 5432—this is hardcoded and not affected by `PLANEXE_POSTGRES_PORT`.
-
-Bind host (LAN exposure)
-------------------------
-
-Several services have permissive defaults that are fine for localhost use but become a foot-gun on a shared network:
+Several services have permissive defaults that are fine for localhost-only development but would be a foot-gun on a shared network:
 
 - `frontend_multi_user` defaults to `admin` / `admin`.
 - `mcp_cloud` defaults to `PLANEXE_MCP_REQUIRE_AUTH=false` with empty `PLANEXE_MCP_API_KEY`.
 - `database_postgres` defaults to user/password `planexe` / `planexe`.
 - `worker_plan` has no auth at all.
 
-To avoid exposing this stack to your LAN out of the box, every published port binds to `127.0.0.1` by default:
+Ports policy:
 
-- `database_postgres` (5432) and `worker_plan` (8000) are pinned to `127.0.0.1`. Nothing outside the host should call them directly; container-to-container traffic uses the docker network and is unaffected.
-- `frontend_multi_user` (5001) and `mcp_cloud` (8001) honor `PLANEXE_BIND_HOST` (default `127.0.0.1`).
+- `database_postgres` and `worker_plan` are **not** published to the host. Other containers reach them via the docker network as `database_postgres:5432` and `worker_plan:8000`. This also sidesteps the common "port 5432 already in use" conflict with a local Postgres on dev machines.
+- `frontend_multi_user` (5001) and `mcp_cloud` (8001) are published, bound to `PLANEXE_BIND_HOST` (default `127.0.0.1`).
 
-To opt back into LAN access (e.g., testing from your phone, Claude Desktop on another machine):
+To opt back into LAN access for the published services (e.g., testing from your phone, Claude Desktop on another machine):
 
 ```bash
 export PLANEXE_BIND_HOST=0.0.0.0
@@ -82,9 +65,36 @@ docker compose up
 ```
 
 Before doing this, set strong values for at least:
+
 - `PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD`
 - `PLANEXE_MCP_REQUIRE_AUTH=true` and `PLANEXE_MCP_API_KEY`
-- `PLANEXE_POSTGRES_PASSWORD` (if you also choose to expose 5432)
+
+### Reaching the internal services from the host
+
+When you actually want a `psql` shell or `curl` to one of the unpublished services:
+
+```bash
+# Postgres shell inside the DB container:
+docker compose exec database_postgres psql -U planexe
+
+# Hit worker_plan from inside the frontend container:
+docker compose exec frontend_multi_user curl -fsS http://worker_plan:8000/healthcheck
+```
+
+Or, drop a tiny override file (gitignored) that adds host port mappings for a debugging session:
+
+```yaml
+# docker-compose.override.yml
+services:
+  database_postgres:
+    ports:
+      - "127.0.0.1:5433:5432"   # avoid colliding with a local Postgres on 5432
+  worker_plan:
+    ports:
+      - "127.0.0.1:8000:8000"
+```
+
+`docker compose up` automatically merges `docker-compose.override.yml` if present.
 
 Service: `frontend_multi_user` (multi user UI)
 ------------------------------------------
@@ -95,7 +105,7 @@ Service: `frontend_multi_user` (multi user UI)
 
 Service: `worker_plan` (pipeline API)
 -------------------------------------
-- Purpose: runs the PlanExe pipeline and exposes the API on port 8000 (bound to `127.0.0.1` only — meant for the frontend container, not the LAN); the frontend depends on its health.
+- Purpose: runs the PlanExe pipeline. Listens on port 8000 inside the container; **not published to the host** — `frontend_multi_user` reaches it via the docker network at `worker_plan:8000`. The frontend depends on its health.
 - Build: `worker_plan/Dockerfile`.
 - Env: `PLANEXE_CONFIG_PATH=/app`, `PLANEXE_WORKER_RELAY_PROCESS_OUTPUT=true`.
 - Health: `http://localhost:8000/healthcheck` checked via the compose healthcheck.
@@ -128,9 +138,10 @@ Service: `mcp_cloud` (MCP interface)
 
 Usage notes
 -----------
-- Ports (all default to `127.0.0.1` host binding): `8000->worker_plan`, `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}->frontend_multi_user`, `${PLANEXE_MCP_HTTP_PORT:-8001}->mcp_cloud`, `PLANEXE_POSTGRES_PORT (default 5432)->database_postgres`. To make `frontend_multi_user`/`mcp_cloud` reachable from the LAN, set `PLANEXE_BIND_HOST=0.0.0.0` (read [Bind host](#bind-host-lan-exposure) first). Change mappings in `docker-compose.yml` if needed.
+- Published ports (host-reachable, both default to `127.0.0.1`): `${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}->frontend_multi_user`, `${PLANEXE_MCP_HTTP_PORT:-8001}->mcp_cloud`. Set `PLANEXE_BIND_HOST=0.0.0.0` for LAN access (read [Published ports / bind host](#published-ports--bind-host) first).
+- Internal-only services (no host port): `database_postgres` (`:5432`) and `worker_plan` (`:8000`). Reach them via the docker network from another container, or use `docker compose exec` / a `docker-compose.override.yml` for ad-hoc host access.
 - `.env` must exist before `docker compose up`; it is both loaded and mounted read-only. Same for `llm_config/`. If missing, start from `.env.docker-example`.
-- Database: connect on `localhost:${PLANEXE_POSTGRES_PORT:-5432}` with `planexe/planexe` by default; data persists via the `database_postgres_data` volume.
+- Database: connect from inside any container as `database_postgres:5432` with `planexe/planexe` by default; data persists via the `database_postgres_data` volume. Direct host access is opt-in via override file or `docker compose exec`.
 
 Example: running stack
 ----------------------
@@ -140,9 +151,9 @@ Snapshot from `docker compose ps` on a live stack with two numbered DB workers; 
 ```
 PROMPT> docker compose ps                                                 
 NAME                     IMAGE                            COMMAND                  SERVICE                  CREATED          STATUS                   PORTS
-database_postgres        planexe-database_postgres        "docker-entrypoint.s…"   database_postgres        8 hours ago      Up 8 hours (healthy)     127.0.0.1:5433->5432/tcp
+database_postgres        planexe-database_postgres        "docker-entrypoint.s…"   database_postgres        8 hours ago      Up 8 hours (healthy)
 frontend_multi_user      planexe-frontend_multi_user      "python /app/fronten…"   frontend_multi_user      8 hours ago      Up 2 minutes (healthy)   127.0.0.1:5001->5000/tcp
-worker_plan              planexe-worker_plan              "uvicorn worker_plan…"   worker_plan              2 minutes ago    Up 2 minutes (healthy)   127.0.0.1:8000->8000/tcp
+worker_plan              planexe-worker_plan              "uvicorn worker_plan…"   worker_plan              2 minutes ago    Up 2 minutes (healthy)
 worker_plan_database_1   planexe-worker_plan_database_1   "python -m worker_pl…"   worker_plan_database_1   15 seconds ago   Up 13 seconds            
 worker_plan_database_2   planexe-worker_plan_database_2   "python -m worker_pl…"   worker_plan_database_2   15 seconds ago   Up 13 seconds  
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,24 @@
 # ============================================================================
-# POSTGRES PORT CONFLICT NOTE
+# PUBLISHED PORTS / BIND HOST NOTE
 # ============================================================================
-# The default PostgreSQL port is 5432. On developer machines, this port is
-# often already occupied by a local PostgreSQL installation (e.g., Postgres.app
-# on macOS, or a system PostgreSQL on Linux).
+# Several services have permissive defaults that are fine for localhost-only
+# development but would be a foot-gun on a shared network: admin/admin on the
+# frontend, PLANEXE_MCP_REQUIRE_AUTH=false with empty API key on mcp_cloud,
+# default postgres password, no auth at all on worker_plan.
 #
-# If port 5432 is in use, set PLANEXE_POSTGRES_PORT to a different value:
-#   export PLANEXE_POSTGRES_PORT=5433
-#   docker compose up
-#
-# This only affects the HOST port mapping (how you access Postgres from your
-# machine). Inside Docker, containers always connect to each other on port 5432.
-# ============================================================================
-#
-# ============================================================================
-# BIND HOST NOTE
-# ============================================================================
-# All published ports below bind to 127.0.0.1 by default so the stack is not
-# exposed to the LAN out of the box — several services have permissive
-# defaults (admin/admin on the frontend, no auth on mcp_cloud, default
-# postgres password) that are fine for localhost-only use but would be a
-# foot-gun on a shared network.
-#
-# database_postgres and worker_plan are pinned to 127.0.0.1 because nothing
-# outside the host should call them directly.
-#
-# frontend_multi_user and mcp_cloud honor PLANEXE_BIND_HOST. To expose them
-# to the LAN (e.g. testing from your phone, Claude Desktop on another
-# machine), set:
-#   export PLANEXE_BIND_HOST=0.0.0.0
-#   docker compose up
-# Make sure you have set strong PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD,
-# PLANEXE_MCP_API_KEY, and PLANEXE_MCP_REQUIRE_AUTH=true before doing so.
+# Ports policy:
+#  - database_postgres and worker_plan have NO host port mapping. They are
+#    reached by other containers via the docker network at
+#    database_postgres:5432 and worker_plan:8000. To inspect them from the
+#    host use `docker compose exec` or a one-off override file. Side effect:
+#    no host port to collide with a local Postgres on 5432.
+#  - frontend_multi_user and mcp_cloud are published, bound to PLANEXE_BIND_HOST
+#    (default 127.0.0.1). To expose them to the LAN (testing from your phone,
+#    Claude Desktop on another machine), set:
+#      export PLANEXE_BIND_HOST=0.0.0.0
+#      docker compose up
+#    First set strong PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD,
+#    PLANEXE_MCP_API_KEY, and PLANEXE_MCP_REQUIRE_AUTH=true.
 # ============================================================================
 
 x-worker_plan_database-base: &worker_plan_database_base
@@ -73,14 +60,10 @@ services:
       POSTGRES_USER: ${PLANEXE_POSTGRES_USER:-planexe}
       POSTGRES_PASSWORD: ${PLANEXE_POSTGRES_PASSWORD:-planexe}
       POSTGRES_DB: ${PLANEXE_POSTGRES_DB:-planexe}
-    ports:
-      # PLANEXE_POSTGRES_PORT sets the HOST port (left side). The container always
-      # listens on 5432 internally (right side). If your machine already has a
-      # Postgres running on 5432 (e.g., Postgres.app on macOS), set a different
-      # host port: export PLANEXE_POSTGRES_PORT=5433
-      # Bound to 127.0.0.1 — postgres has a default password and should not be
-      # reachable from the LAN.
-      - "127.0.0.1:${PLANEXE_POSTGRES_PORT:-5432}:5432"
+    # No host port mapping by default. Other containers reach this DB via the
+    # docker network as database_postgres:5432. If you want to inspect the
+    # database from your host (DBeaver, psql) use a one-off override file or
+    # `docker compose exec database_postgres psql -U planexe`.
     volumes:
       - database_postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -101,10 +84,9 @@ services:
     environment:
       PLANEXE_CONFIG_PATH: /app
       PLANEXE_WORKER_RELAY_PROCESS_OUTPUT: "true"
-    ports:
-      # 127.0.0.1 only — worker_plan has no auth and is meant to be called by
-      # frontend_multi_user over the docker network, not from the LAN.
-      - "127.0.0.1:8000:8000"
+    # No host port mapping by default. frontend_multi_user reaches this API
+    # via the docker network as worker_plan:8000. To curl it from the host
+    # use a one-off override file or `docker compose exec worker_plan ...`.
     volumes:
       - ./.env:/app/.env:ro
       - ./llm_config:/app/llm_config:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,27 @@
 # This only affects the HOST port mapping (how you access Postgres from your
 # machine). Inside Docker, containers always connect to each other on port 5432.
 # ============================================================================
+#
+# ============================================================================
+# BIND HOST NOTE
+# ============================================================================
+# All published ports below bind to 127.0.0.1 by default so the stack is not
+# exposed to the LAN out of the box — several services have permissive
+# defaults (admin/admin on the frontend, no auth on mcp_cloud, default
+# postgres password) that are fine for localhost-only use but would be a
+# foot-gun on a shared network.
+#
+# database_postgres and worker_plan are pinned to 127.0.0.1 because nothing
+# outside the host should call them directly.
+#
+# frontend_multi_user and mcp_cloud honor PLANEXE_BIND_HOST. To expose them
+# to the LAN (e.g. testing from your phone, Claude Desktop on another
+# machine), set:
+#   export PLANEXE_BIND_HOST=0.0.0.0
+#   docker compose up
+# Make sure you have set strong PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD,
+# PLANEXE_MCP_API_KEY, and PLANEXE_MCP_REQUIRE_AUTH=true before doing so.
+# ============================================================================
 
 x-worker_plan_database-base: &worker_plan_database_base
   build:
@@ -57,7 +78,9 @@ services:
       # listens on 5432 internally (right side). If your machine already has a
       # Postgres running on 5432 (e.g., Postgres.app on macOS), set a different
       # host port: export PLANEXE_POSTGRES_PORT=5433
-      - "${PLANEXE_POSTGRES_PORT:-5432}:5432"
+      # Bound to 127.0.0.1 — postgres has a default password and should not be
+      # reachable from the LAN.
+      - "127.0.0.1:${PLANEXE_POSTGRES_PORT:-5432}:5432"
     volumes:
       - database_postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -79,7 +102,9 @@ services:
       PLANEXE_CONFIG_PATH: /app
       PLANEXE_WORKER_RELAY_PROCESS_OUTPUT: "true"
     ports:
-      - "8000:8000"
+      # 127.0.0.1 only — worker_plan has no auth and is meant to be called by
+      # frontend_multi_user over the docker network, not from the LAN.
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./.env:/app/.env:ro
       - ./llm_config:/app/llm_config:ro
@@ -150,7 +175,9 @@ services:
       PLANEXE_DATABASE_WORKER_URL: ${PLANEXE_DATABASE_WORKER_URL:-http://database_worker:8002}
       PLANEXE_DATABASE_WORKER_API_KEY: ${PLANEXE_DATABASE_WORKER_API_KEY:-}
     ports:
-      - "${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}:5000"
+      # PLANEXE_BIND_HOST defaults to 127.0.0.1; override with 0.0.0.0 only
+      # after setting a strong PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD.
+      - "${PLANEXE_BIND_HOST:-127.0.0.1}:${PLANEXE_FRONTEND_MULTIUSER_PORT:-5001}:5000"
     volumes:
       - ./.env:/app/.env:ro
       - ./llm_config:/app/llm_config:ro
@@ -208,7 +235,9 @@ services:
       PLANEXE_MCP_PUBLIC_BASE_URL: ${PLANEXE_MCP_PUBLIC_BASE_URL:-http://localhost:8001}
       PLANEXE_WORKER_PLAN_URL: ${PLANEXE_WORKER_PLAN_URL:-http://worker_plan:8000}
     ports:
-      - "${PLANEXE_MCP_HTTP_PORT:-8001}:8001"
+      # PLANEXE_BIND_HOST defaults to 127.0.0.1; override with 0.0.0.0 only
+      # after setting PLANEXE_MCP_REQUIRE_AUTH=true and PLANEXE_MCP_API_KEY.
+      - "${PLANEXE_BIND_HOST:-127.0.0.1}:${PLANEXE_MCP_HTTP_PORT:-8001}:8001"
     volumes:
       - ./llm_config:/app/llm_config:ro
     restart: unless-stopped


### PR DESCRIPTION
## Summary
The compose stack used Docker's short-form `ports:` everywhere, which binds the host side to `0.0.0.0`. Combined with several permissive defaults (admin/admin on the frontend, `PLANEXE_MCP_REQUIRE_AUTH=false` with no API key on mcp_cloud, default `planexe/planexe` postgres credentials, no auth at all on worker_plan), the whole stack was reachable from the LAN out of the box. This PR closes that and also drops host port mappings for the two services that nothing outside the docker network should ever call.

## Changes (`docker-compose.yml`)
- **`database_postgres`** — `ports:` removed entirely. Reachable as `database_postgres:5432` inside the docker network. Side benefit: no more host-side collision with a developer's local Postgres on 5432; the prior `PLANEXE_POSTGRES_PORT=5433` workaround is no longer needed.
- **`worker_plan`** — `ports:` removed entirely. `frontend_multi_user` reaches it as `worker_plan:8000` inside the docker network.
- **`frontend_multi_user`** (5001) and **`mcp_cloud`** (8001) — still published, now bound to `${PLANEXE_BIND_HOST:-127.0.0.1}`.
- New "Published ports / bind host" comment block at the top of the file documenting the convention.

## Docs (`docker-compose.md`)
- TL;DR rewritten.
- Old "Port conflict with local Postgres" section replaced by the new "Published ports / bind host" section, including a worked `docker-compose.override.yml` example for ad-hoc host access (DBeaver, `psql`, `curl` to worker_plan) during debugging.
- Per-service notes and the example `docker compose ps` output updated to match.

## Opting back into LAN access
For the two published services (testing on phone, Claude Desktop on another machine):
```sh
export PLANEXE_BIND_HOST=0.0.0.0
docker compose up
```
…after also setting strong `PLANEXE_FRONTEND_MULTIUSER_ADMIN_PASSWORD`, `PLANEXE_MCP_API_KEY`, and `PLANEXE_MCP_REQUIRE_AUTH=true`.

To poke at the unpublished services from the host, either `docker compose exec` or drop a `docker-compose.override.yml` (template in the docs).

## Test plan
- [x] `docker compose config` shows only `frontend_multi_user` and `mcp_cloud` published, both with `host_ip: 127.0.0.1`
- [x] `database_postgres` / `worker_plan` no longer have a `published:` entry in `docker compose config`
- [ ] Stack comes up clean via `./rebuild.sh` even on a host with a local Postgres listening on 5432 (the conflict that motivated this change)
- [ ] http://127.0.0.1:5001 still serves the frontend
- [ ] `PLANEXE_BIND_HOST=0.0.0.0 docker compose up` makes frontend reachable from another LAN device