### PR TITLE
docs: add proposal 135 — Critical Premises

### DIFF
--- a/docs/proposals/135-critical-premises.md
+++ b/docs/proposals/135-critical-premises.md
@@ -1,0 +1,861 @@
+Critical Premises
+
+Purpose
+
+The Critical Premises step identifies assumptions beneath the rest of the plan. These are not ordinary execution risks. They are basic conditions that must be true for the plan to be worth doing at all.
+
+If a critical premise fails, the plan may still be technically executable, but its value, legitimacy, usefulness, or public defensibility would be seriously undermined.
+
+This section exists to catch the kind of mistake that looks obvious in hindsight:
+
+* A roundabout that does not connect to active roads.
+* A school built where there are no students.
+* A marketplace with sellers but no buyers.
+* A software migration where the old system cannot actually be shut down.
+* A product launch where the target users are legally unable to use the product.
+
+These assumptions are often omitted because they sound too basic to mention. That is precisely why they need to be checked.
+
+⸻
+
+Definition
+
+A critical premise is a foundational assumption that satisfies all of the following:
+
+1. It is easy to leave unstated because it seems self-evident.
+2. It is not merely about execution difficulty.
+3. If false, the project may still be completed, but the completed outcome would be useless, indefensible, absurd, unsafe, illegal, or strategically pointless.
+4. It can be validated before major commitment.
+5. It should affect the go/no-go decision.
+
+Critical premises are different from normal risks.
+
+A normal risk asks:
+
+What might make the plan harder, slower, or more expensive?
+
+A critical premise asks:
+
+What must already be true for this plan to deserve execution?
+
+⸻
+
+Why This Step Exists
+
+Many bad projects do not fail because they were impossible to execute. They fail because the wrong thing was executed.
+
+The project team may successfully deliver the asset, product, program, or system, but later discover that the underlying justification was missing.
+
+Examples:
+
+* The asset exists, but no one can use it.
+* The service launches, but the target users do not need it.
+* The infrastructure is built, but the dependent infrastructure never arrives.
+* The event is organized, but the audience cannot attend.
+* The software is deployed, but the business process cannot change.
+* The facility is opened, but no one has authority or budget to operate it.
+
+The Critical Premises section is designed to catch these failures before the plan becomes a polished justification for a bad idea.
+
+⸻
+
+Relationship to Other Sections
+
+Assumptions
+
+The existing Assumptions section captures general planning assumptions: location, currency, stakeholders, constraints, risks, operating context, and similar background conditions.
+
+Premortem
+
+The Premortem section imagines that the project failed and asks what caused that failure. It focuses on failure modes, early warning signs, and mitigation.
+
+Critical Premises
+
+The Critical Premises section comes before or near the Premortem. It asks whether the project has a valid reason to exist in the first place.
+
+It is narrower and sharper than the Assumptions section.
+
+It is more foundational than the Premortem.
+
+It should contain only a small number of high-impact premises.
+
+⸻
+
+Core Question
+
+For each plan, ask:
+
+What basic fact would make this project look foolish, wasteful, illegitimate, or useless if it turned out not to be true?
+
+Secondary questions:
+
+* What must be true on day one for the project to deliver value?
+* What is everyone assuming because it would be embarrassing to ask?
+* What would a skeptical journalist, citizen, customer, auditor, or user immediately question?
+* What would make the completed project look absurd in a photo, headline, demo, or audit report?
+* What future dependency is being treated as if it already exists?
+* What user, demand, legality, access, or system-integration fact is being taken for granted?
+* Would the project still be worthwhile if expected future growth never arrives?
+
+⸻
+
+Output Format
+
+Each critical premise should include:
+
+### Critical Premise 1: [Short name]
+**Premise:**  
+[The basic assumption that must be true.]
+**Why it matters:**  
+[Explain why the plan loses value, legitimacy, usefulness, or purpose if this is false.]
+**Why it may be omitted:**  
+[Explain why planners may leave it unstated: it feels obvious, politically awkward, outside scope, embarrassing, or assumed by everyone.]
+**How to validate:**  
+[Concrete checks, data, documents, inspections, interviews, or tests that can confirm or falsify the premise.]
+**Falsifier:**  
+[The evidence that would prove this premise is false.]
+**Decision impact:**  
+[Continue, revise, pause, or reject the project.]
+
+Optional fields:
+
+**Severity if false:** 1–10  
+**Confidence today:** Low / Medium / High  
+**Validation owner:** [Role]  
+**Validation deadline:** [When this must be checked]
+
+⸻
+
+Recommended Number of Premises
+
+Use 3 to 7 critical premises.
+
+Fewer than 3 usually misses important categories.
+
+More than 7 usually turns the section into a general assumptions list.
+
+For most plans, 4 or 5 is ideal.
+
+⸻
+
+Detection Categories
+
+The model should search for critical premises in these categories.
+
+1. Day-One Usefulness
+
+Does the finished project provide value immediately when delivered?
+
+Bad assumption:
+
+The project will become useful later once other things happen.
+
+Example premise:
+
+The asset provides measurable value at commissioning, independent of future development.
+
+2. System Integration
+
+Does the project connect to the system it is supposed to improve?
+
+Bad assumption:
+
+The component is useful by itself, even though it depends on a larger system.
+
+Example premise:
+
+The new road element connects to active roads and supports actual traffic movement when opened.
+
+3. Real Demand
+
+Is there current or committed demand, not only hoped-for future demand?
+
+Bad assumption:
+
+If we build it, demand will appear.
+
+Example premise:
+
+The target users have a current, measurable need for the product, service, asset, or intervention.
+
+4. Independent Justification
+
+Would the project still make sense if future growth, future funding, or future adjacent projects are delayed?
+
+Bad assumption:
+
+The future context is certain enough to justify present spending.
+
+Example premise:
+
+The project has a positive value case even if dependent future projects are delayed by several years.
+
+5. Legal and Practical Access
+
+Can the intended users legally and practically access the result?
+
+Bad assumption:
+
+Users can use the thing once it exists.
+
+Example premise:
+
+The intended beneficiaries are legally allowed, physically able, and practically likely to use the delivered outcome.
+
+6. Ownership and Operation
+
+Who operates, maintains, supports, or owns the result after delivery?
+
+Bad assumption:
+
+Someone will take care of it later.
+
+Example premise:
+
+A funded owner is accountable for operation, maintenance, support, and lifecycle costs after delivery.
+
+7. Counterfactual Value
+
+Is this better than doing nothing, repairing the existing system, or using a cheaper alternative?
+
+Bad assumption:
+
+The project is good because it is a project.
+
+Example premise:
+
+The proposed intervention outperforms cheaper or simpler alternatives on the relevant outcome metric.
+
+8. Political and Public Legitimacy
+
+Could the project be defended to citizens, customers, auditors, employees, or regulators?
+
+Bad assumption:
+
+The formal justification will be enough.
+
+Example premise:
+
+The project can be publicly defended using concrete benefits, not only strategic language.
+
+9. User Behavior
+
+Will the intended users actually behave in the way the plan requires?
+
+Bad assumption:
+
+Users will adopt the solution because it exists.
+
+Example premise:
+
+Users have sufficient motivation, incentives, ability, and trust to adopt the delivered solution.
+
+10. Timing and Sequencing
+
+Is the project being built in the right order relative to dependent projects?
+
+Bad assumption:
+
+Building this part now is harmless even if the rest is delayed.
+
+Example premise:
+
+Dependent upstream or downstream projects are funded, authorized, and scheduled before this project relies on them.
+
+⸻
+
+Common Signals That a Critical Premise Is Missing
+
+The plan contains phrases like:
+
+* “future growth”
+* “strategic corridor”
+* “anticipated demand”
+* “future-ready”
+* “scalable”
+* “long-term vision”
+* “unlocking potential”
+* “catalyst for development”
+* “expected adoption”
+* “stakeholder alignment”
+* “transformational impact”
+* “capacity for future expansion”
+
+These phrases are not automatically bad. But they often hide missing proof.
+
+When these phrases appear, the Critical Premises step should ask:
+
+* What current evidence supports this?
+* What happens if the future demand does not arrive?
+* Does the project still produce value without the future scenario?
+* Is this a present need or a speculative future justification?
+
+⸻
+
+Examples of Silly Mistakes This Section Should Catch
+
+Infrastructure
+
+Roundabout in a Field
+
+Mistake: A roundabout is built before the roads or logistics facility it is meant to serve.
+
+Missing critical premise:
+
+The roundabout connects to active roads and provides measurable traffic-flow or safety value at commissioning.
+
+Falsifier:
+
+The roundabout only becomes useful after a future rail, logistics, industrial, or highway project is completed.
+
+Decision impact:
+
+Pause or reject construction until the connecting infrastructure is funded, authorized, and scheduled.
+
+⸻
+
+Bridge With No Approach Roads
+
+Mistake: A technically sound bridge is built, but the approach roads are delayed or unfunded.
+
+Missing critical premise:
+
+The bridge will be connected to usable approach roads on both sides when opened.
+
+Falsifier:
+
+One or both approach-road packages are not funded or legally approved.
+
+Decision impact:
+
+Do not begin bridge construction before approach-road delivery is secured.
+
+⸻
+
+Airport Expansion Without Airline Demand
+
+Mistake: A regional airport expands terminal capacity, but no airlines commit to new routes.
+
+Missing critical premise:
+
+Airlines have committed or strongly validated demand for additional routes and passenger volume.
+
+Falsifier:
+
+No carrier has signed route commitments, and passenger forecasts rely only on regional optimism.
+
+Decision impact:
+
+Scale down, delay, or require airline commitments before expansion.
+
+⸻
+
+Bike Lane No One Can Reach
+
+Mistake: A high-quality bike lane is built, but it does not connect to existing cycling routes or destinations.
+
+Missing critical premise:
+
+The bike lane forms part of a usable route between real origins and destinations.
+
+Falsifier:
+
+The lane begins and ends in disconnected segments with no practical route continuity.
+
+Decision impact:
+
+Redesign the route or prioritize connection segments first.
+
+⸻
+
+Software and IT
+
+Migration Where the Old System Cannot Be Retired
+
+Mistake: A new system is built, but the old system remains legally or operationally required.
+
+Missing critical premise:
+
+The old system can be retired or materially reduced after the new system goes live.
+
+Falsifier:
+
+Legal, reporting, integration, or customer obligations require the old system to remain fully operational.
+
+Decision impact:
+
+Reframe the project as coexistence, not migration, and revise cost/benefit assumptions.
+
+⸻
+
+Internal Tool Nobody Has Time to Use
+
+Mistake: A useful internal dashboard is built, but staff workflows leave no time or incentive to use it.
+
+Missing critical premise:
+
+The target users have both the workflow opportunity and incentive to use the tool regularly.
+
+Falsifier:
+
+Users are measured on speed through existing systems and receive no benefit from using the new dashboard.
+
+Decision impact:
+
+Change workflow incentives or do not build the tool.
+
+⸻
+
+AI Assistant Without Data Access
+
+Mistake: An AI assistant is planned, but it cannot access the documents, systems, or permissions needed to answer real questions.
+
+Missing critical premise:
+
+The assistant can access the data needed for its core use cases within legal and security constraints.
+
+Falsifier:
+
+The required systems cannot be connected, or access would violate policy.
+
+Decision impact:
+
+Narrow the use case or solve access governance before implementation.
+
+⸻
+
+Automation of a Process That Should Be Removed
+
+Mistake: A bad manual process is automated instead of eliminated.
+
+Missing critical premise:
+
+The process being automated is still necessary and valuable.
+
+Falsifier:
+
+The process exists only because of outdated policy, duplicated approvals, or legacy reporting habits.
+
+Decision impact:
+
+Remove or redesign the process before considering automation.
+
+⸻
+
+Business and Product
+
+Marketplace With Only One Side Validated
+
+Mistake: A marketplace validates seller interest but not buyer demand.
+
+Missing critical premise:
+
+Both sides of the marketplace have sufficient motivation to participate at the same time.
+
+Falsifier:
+
+Sellers are interested only if buyers exist, while buyers are interested only if inventory already exists.
+
+Decision impact:
+
+Redesign the launch wedge or reject the marketplace model.
+
+⸻
+
+Premium Product for Users Who Cannot Pay
+
+Mistake: A product solves a real problem for users without budget authority.
+
+Missing critical premise:
+
+The people who feel the pain either control budget or can influence the buyer.
+
+Falsifier:
+
+Users love the product, but purchasing decisions are controlled by a different group with different priorities.
+
+Decision impact:
+
+Change buyer targeting, pricing, or product positioning.
+
+⸻
+
+App That Requires Behavior Change Users Do Not Want
+
+Mistake: The app is technically good, but users must change habits they are not motivated to change.
+
+Missing critical premise:
+
+The target users are willing to change their current behavior enough to receive the product’s benefit.
+
+Falsifier:
+
+Users agree the product is useful but continue using existing workarounds.
+
+Decision impact:
+
+Reduce required behavior change or reject the product concept.
+
+⸻
+
+Expansion Into a Market Where the Channel Does Not Exist
+
+Mistake: A company enters a new market assuming it can sell through channels that are weak or absent there.
+
+Missing critical premise:
+
+A viable distribution channel exists for reaching the target buyers at acceptable cost.
+
+Falsifier:
+
+Customer acquisition depends on partnerships, platforms, or resellers that are unavailable or unwilling.
+
+Decision impact:
+
+Build channel first or choose a different market.
+
+⸻
+
+Education and Training
+
+Training Program for a Skill Employers Do Not Reward
+
+Mistake: A training program teaches a skill that sounds valuable but does not improve hiring, promotion, or productivity outcomes.
+
+Missing critical premise:
+
+The taught skill produces a measurable benefit that learners or sponsors actually value.
+
+Falsifier:
+
+Employers, managers, or learners cannot identify a concrete use for the skill after training.
+
+Decision impact:
+
+Change curriculum or reject the program.
+
+⸻
+
+Course for Students Who Lack Prerequisites
+
+Mistake: A course is designed well, but the target learners do not have the required background.
+
+Missing critical premise:
+
+The target learners have the prerequisite knowledge needed to benefit from the course.
+
+Falsifier:
+
+Diagnostic tests show most learners cannot follow the first module.
+
+Decision impact:
+
+Add prerequisite training or redefine the audience.
+
+⸻
+
+Events and Community Projects
+
+Event Where the Audience Cannot Attend
+
+Mistake: An event is planned for a time, place, or format that prevents the intended audience from attending.
+
+Missing critical premise:
+
+The target audience can realistically attend the event.
+
+Falsifier:
+
+The date conflicts with work, school, holidays, transport availability, visa constraints, or major competing events.
+
+Decision impact:
+
+Change timing, location, or format.
+
+⸻
+
+Community Center Without Operating Budget
+
+Mistake: A facility is built, but there is no budget for staff, maintenance, programming, or utilities.
+
+Missing critical premise:
+
+A funded operator exists for the facility after construction.
+
+Falsifier:
+
+Capital funding is available, but operating funding is not committed.
+
+Decision impact:
+
+Secure operating model before construction.
+
+⸻
+
+Health and Public Services
+
+Clinic Without Staff
+
+Mistake: A clinic is built in an underserved area, but qualified staff cannot be recruited or retained.
+
+Missing critical premise:
+
+The clinic can recruit and retain enough qualified staff to provide the intended services.
+
+Falsifier:
+
+Workforce analysis shows no realistic staffing pipeline at the proposed location and salary level.
+
+Decision impact:
+
+Solve staffing model before construction or change service design.
+
+⸻
+
+Public Service That Eligible Users Cannot Access
+
+Mistake: A service exists, but eligibility rules, transport, language, documentation, or digital access prevent the intended users from using it.
+
+Missing critical premise:
+
+The intended beneficiaries can practically access the service.
+
+Falsifier:
+
+Users lack required documents, transport, devices, language support, or awareness.
+
+Decision impact:
+
+Redesign access pathway before launch.
+
+⸻
+
+How the Step Should Work in Plan Generation
+
+Step 1: Read the Plan’s Stated Purpose
+
+Identify the promised outcome.
+
+Examples:
+
+* Improve traffic safety.
+* Reduce processing time.
+* Increase user adoption.
+* Enable regional development.
+* Deliver a new public service.
+* Replace a legacy system.
+
+Step 2: Identify the Delivered Object
+
+What will physically or operationally exist at the end?
+
+Examples:
+
+* A roundabout.
+* A software platform.
+* A school.
+* A training program.
+* A dashboard.
+* A clinic.
+* A logistics hub.
+
+Step 3: Ask What Must Be True for the Delivered Object to Matter
+
+For each delivered object, ask:
+
+* Who uses it?
+* Why do they use it?
+* Can they access it?
+* Does it connect to the necessary system?
+* Is demand current, committed, or speculative?
+* Who operates it afterward?
+* Is there a cheaper way to achieve the same outcome?
+
+Step 4: Look for Future-Justification Language
+
+Flag plans that rely heavily on future conditions:
+
+* future growth
+* future demand
+* future funding
+* future infrastructure
+* future adoption
+* future policy changes
+* future partner behavior
+
+Then test whether the plan still works without those future conditions.
+
+Step 5: Generate Candidate Critical Premises
+
+Generate 8 to 12 candidate premises internally.
+
+Then select the strongest 3 to 7.
+
+Prefer premises that are:
+
+* basic but unstated
+* falsifiable
+* high impact
+* relevant to go/no-go
+* embarrassing if false
+* testable before commitment
+
+Step 6: Write Them Professionally
+
+Avoid wording that makes the reader feel stupid.
+
+Poor wording:
+
+Do not build a roundabout unless it connects to roads.
+
+Better wording:
+
+The roundabout must provide measurable opening-day traffic or safety value within the active road network.
+
+Poor wording:
+
+Make sure users actually want this.
+
+Better wording:
+
+Target users must have a current, validated need and a practical adoption path.
+
+Poor wording:
+
+Do not automate pointless work.
+
+Better wording:
+
+The process targeted for automation must remain necessary after policy and workflow simplification options are considered.
+
+⸻
+
+Suggested Prompt Text
+
+Create a section called "Critical Premises".
+This section identifies assumptions beneath the rest of the plan. These are basic conditions that are easy to leave unstated because they seem self-evident. If one is false, the project may still be technically executable, but its value, legitimacy, or usefulness would be seriously undermined.
+Do not repeat ordinary risks from the Premortem. Focus on whether the project deserves to exist in its proposed form.
+For each critical premise, include:
+- Premise
+- Why it matters
+- Why it may be omitted
+- How to validate
+- Falsifier
+- Decision impact
+Search especially for:
+- day-one usefulness
+- connection to existing systems
+- current or committed demand
+- dependence on future projects
+- legal/practical access by intended users
+- post-delivery ownership and operating capacity
+- whether a cheaper alternative would achieve the same outcome
+- whether the project could be publicly defended if future growth does not arrive
+Use professional planning language. Make the premise explicit without sounding patronizing.
+Generate 3 to 7 critical premises.
+
+⸻
+
+Suggested JSON Schema
+
+{
+  "critical_premises": [
+    {
+      "name": "Standalone opening-day value",
+      "premise": "The delivered asset provides measurable value at commissioning without relying on future adjacent development.",
+      "why_it_matters": "If the asset only becomes useful after future projects are completed, the investment may create a stranded asset.",
+      "why_it_may_be_omitted": "The team may assume the surrounding development will happen because it is part of the strategic narrative.",
+      "how_to_validate": "Confirm current demand data, active network integration, funded dependent projects, and opening-day use cases.",
+      "falsifier": "The asset has no meaningful use until a future project is completed.",
+      "decision_impact": "Pause or redesign before major capital commitment.",
+      "severity_if_false": 9,
+      "confidence_today": "Medium"
+    }
+  ]
+}
+
+⸻
+
+Quality Bar
+
+A good Critical Premises section should make the plan harder to fool.
+
+It should not be long.
+
+It should not duplicate the Premortem.
+
+It should not list generic assumptions.
+
+It should expose the assumptions that would make the whole project look ridiculous if they were false.
+
+The section succeeds when it produces at least one reaction like:
+
+Yes, that sounds obvious — but we really do need to prove it.
+
+⸻
+
+Example: Hungary Roundabout
+
+Critical Premise 1: Standalone Opening-Day Value
+
+Premise:
+The roundabout provides measurable traffic-flow or safety value at commissioning within the active road network.
+
+Why it matters:
+If the roundabout depends entirely on future logistics, rail, industrial, or highway projects to become useful, the project risks becoming a stranded asset.
+
+Why it may be omitted:
+The plan’s strategic narrative may assume future development will arrive, making current standalone utility feel too obvious or too politically awkward to question.
+
+How to validate:
+Confirm current traffic counts, accident history, active road connections, opening-day routing, and whether any dependent infrastructure is funded and scheduled.
+
+Falsifier:
+The roundabout has no meaningful traffic or safety function until future adjacent development is completed.
+
+Decision impact:
+Pause or reject construction until the project has standalone opening-day value or the dependent infrastructure is legally and financially committed.
+
+⸻
+
+Critical Premise 2: Network Integration
+
+Premise:
+All required road approaches are usable, authorized, and aligned with the roundabout’s commissioning date.
+
+Why it matters:
+A road asset that is physically complete but not integrated into the live road network cannot deliver its intended benefit.
+
+Why it may be omitted:
+Network connection may be treated as outside the roundabout package, even though the roundabout’s usefulness depends on it.
+
+How to validate:
+Review road approach designs, permits, construction schedules, land access, and commissioning dependencies.
+
+Falsifier:
+One or more required connecting road segments are unfunded, unauthorized, inaccessible, or scheduled after the roundabout opens.
+
+Decision impact:
+Resequence the project or combine it with the connecting road package.
+
+⸻
+
+Critical Premise 3: Public Defensibility
+
+Premise:
+The project can be justified using present-day safety, traffic, or access benefits, not only future economic-development claims.
+
+Why it matters:
+Public infrastructure spending becomes difficult to defend if benefits depend on speculative development.
+
+Why it may be omitted:
+Strategic development language can hide the absence of current measurable need.
+
+How to validate:
+Prepare a benefit case using present-day data and test whether it remains persuasive if future development is delayed by five years.
+
+Falsifier:
+The benefit case collapses when future development assumptions are removed.
+
+Decision impact:
+Reduce scope, delay construction, or redirect funds to a project with stronger present-day value.


### PR DESCRIPTION
## Summary
Adds `docs/proposals/135-critical-premises.md`. Proposes a "Critical Premises" step focused on foundational assumptions whose failure would make the completed plan useless, indefensible, or strategically pointless — independent of how well execution goes (e.g. a roundabout that does not connect to active roads, a school where there are no students). Distinguishes critical premises from ordinary execution risks and gives criteria for what qualifies.

## Test plan
- [ ] Review wording for tone consistency with surrounding proposals