### PR TITLE
docs: add proposal 136 — Good Plans Should Not Die

### DIFF
--- a/docs/proposals/136-good-plans-should-not-die.md
+++ b/docs/proposals/136-good-plans-should-not-die.md
@@ -1,0 +1,677 @@
+# Good Plans Should Not Die Because the Wrong Person Generated Them
+
+## Core thesis
+
+Many people can see problems before they have the skills, money, confidence, network, or credibility to solve them.
+
+A planning system should not assume that the person who generated a plan is automatically the best person to execute it. Sometimes they are. Sometimes they are not. Sometimes they are the originator, the domain expert, the first user, the critic, the future contributor, or the spark that helps a better-fit team form around the opportunity.
+
+The purpose of PlanExe, or a system like it, could therefore be larger than generating plans. It could become a system that:
+
+> Turns underprepared people into capable executors, or routes good plans to better-fit teams.
+
+This reframes planning as a form of opportunity discovery and human-capability matching.
+
+The guiding principle is simple:
+
+> Good plans should not die because the wrong person generated them.
+
+---
+
+## The problem
+
+Most people underestimate what it takes to execute an ambitious plan.
+
+They underestimate money, time, sales, operations, legal exposure, hiring difficulty, customer acquisition, maintenance, stakeholder coordination, and the emotional load of persistence. They also often overestimate how much of the plan they personally need to carry.
+
+This creates two common failure modes.
+
+First, a person generates or imagines a valuable idea but lacks the skills or resources to execute it. The plan dies early, not because the problem is unimportant, but because the person is not currently capable of carrying the execution burden.
+
+Second, a person tries to execute anyway, burns time and money, discovers too late that the project needed a different team composition, and abandons the effort after avoidable damage.
+
+A planning system can intervene before both failures happen.
+
+It can ask:
+
+- Is the plan itself promising?
+- Is the current person or team capable of executing it?
+- What capability gaps exist?
+- Can those gaps be closed through education?
+- Should the original person lead, contribute, advise, or step aside?
+- Should the plan remain private, become open, or be routed to selected people?
+
+---
+
+## From founder-centric to plan-centric execution
+
+The traditional startup model is founder-centric:
+
+> Founder → idea → team → execution
+
+This works when the founder has the right combination of insight, skill, charisma, persistence, and access. But it also discards many good opportunities because the originator is not the right operator.
+
+A plan-centric model works differently:
+
+> Problem → plan → feasibility score → capability map → education or team assembly → execution
+
+In this model, the plan becomes a structured opportunity. The person who generated the plan is important, but not automatically central.
+
+They may become:
+
+- the founder/operator
+- a domain advisor
+- a contributor
+- a community steward
+- a technical builder
+- a first customer proxy
+- an originator with attribution
+- an originator with equity or bounty rights
+- or simply the person who released the idea into the world
+
+This is not anti-founder.
+
+It is anti-mismatch.
+
+The goal is not to remove people. The goal is to put the right people around the right plans.
+
+---
+
+## Capability gap analysis
+
+Every serious plan implies a set of required capabilities.
+
+For example, a business plan may require:
+
+- customer discovery
+- sales
+- product management
+- technical implementation
+- legal/compliance understanding
+- budgeting and finance
+- operations
+- hiring
+- stakeholder management
+- fundraising
+- marketing
+- support and maintenance
+
+A social project may require:
+
+- community trust
+- partnerships
+- grant writing
+- public-sector navigation
+- volunteer coordination
+- event operations
+- safeguarding policies
+- local presence
+
+A technical open-source project may require:
+
+- architecture
+- documentation
+- issue triage
+- governance
+- contributor onboarding
+- release management
+- security review
+- funding maintenance
+- community moderation
+
+PlanExe could compare the plan’s required capabilities against the user’s current capabilities.
+
+The result would not be a judgment of the user’s worth. It would be a practical execution diagnosis.
+
+Example:
+
+| Capability | Required level | Current level | Gap |
+|---|---:|---:|---:|
+| Domain insight | High | High | Low |
+| Technical build | Medium | High | None |
+| Sales | High | Low | Severe |
+| Budgeting | Medium | Low | High |
+| Operations | Medium | Medium | Moderate |
+| Hiring | Medium | Low | High |
+| Customer discovery | High | Low | Severe |
+
+The system could then recommend one of several paths:
+
+- Train the user to lead the next phase.
+- Keep the user as domain advisor, but recruit an operator.
+- Assemble a team around the plan.
+- Shrink the plan into a validation experiment.
+- Release the plan openly for others to build upon.
+- Keep the plan private because it is sensitive.
+
+---
+
+## Education as execution preparation
+
+Most education teaches general subjects first and hopes the learner later finds a use for them.
+
+A plan-driven school would work in the opposite direction.
+
+> The plan defines the curriculum.
+
+If the user wants to execute a marketplace plan but lacks sales skill, the system does not send them to a generic entrepreneurship course.
+
+It gives them a focused path:
+
+- interview 20 potential users
+- write a customer discovery script
+- identify buyer versus user
+- test willingness to pay
+- create a simple landing page
+- manually match the first 5 transactions
+- calculate unit economics
+- produce evidence for or against the plan
+
+The education is not abstract. It is tied to execution readiness.
+
+A PlanExe school could contain several tracks.
+
+---
+
+### Founder readiness track
+
+For users who want to lead their own plans.
+
+Focus areas:
+
+- problem validation
+- customer interviews
+- MVP scoping
+- budgeting
+- pricing
+- sales
+- fundraising
+- hiring
+- execution discipline
+- risk management
+
+Outcome:
+
+> The user becomes qualified to run at least the validation phase of the plan.
+
+---
+
+### Operator track
+
+For people who may not originate the plan but can execute it.
+
+Focus areas:
+
+- project ownership
+- team coordination
+- KPI management
+- vendor management
+- stakeholder reporting
+- budget control
+- conflict handling
+- delivery under uncertainty
+
+Outcome:
+
+> The user becomes eligible to lead or co-lead plans generated by others.
+
+---
+
+### Specialist tracks
+
+For people who fill specific execution gaps.
+
+Possible tracks:
+
+- sales and business development
+- technical implementation
+- product management
+- finance and runway planning
+- legal and compliance operations
+- community building
+- partnership development
+- grant writing
+- documentation
+- support and maintenance
+
+Outcome:
+
+> The platform can match people to plans based on demonstrated ability, not just self-description.
+
+---
+
+## Proof of capability
+
+The school should not rely only on certificates.
+
+It should produce proof-of-capability artifacts.
+
+Examples:
+
+- 10 completed customer interviews
+- a validated budget
+- a working prototype
+- a landing page with signups
+- letters of intent
+- a grant application draft
+- a support process
+- a risk-adjusted milestone plan
+- a technical architecture review
+- a sales call recording or transcript
+- a community onboarding guide
+
+These artifacts become evidence that the person has moved closer to execution readiness.
+
+PlanExe could maintain a readiness score:
+
+| Area | Before | After |
+|---|---:|---:|
+| Founder readiness | C- | B |
+| Investor readiness | D | B- |
+| Customer validation | F | C+ |
+| Budget realism | D | B |
+| Sales capability | F | C |
+
+This creates a bridge between education, funding, and execution.
+
+---
+
+## Team composition instead of founder worship
+
+A plan should generate a required team composition.
+
+Example:
+
+| Role | Importance | Reason |
+|---|---:|---|
+| Operator / CEO | High | Owns execution and coordination |
+| Domain expert | High | Validates real-world problem and edge cases |
+| Technical builder | Medium | Builds MVP and maintains system |
+| Sales lead | High | Finds customers and revenue |
+| Finance/controller | Medium | Controls budget and runway |
+| Legal/compliance advisor | Depends | Required for regulated areas |
+| Community lead | Depends | Important for open or network-based plans |
+
+The original user can then be evaluated against this map.
+
+The answer may be:
+
+> You should lead this.
+
+Or:
+
+> You should not lead this yet, but you could after completing the founder readiness track.
+
+Or:
+
+> You are best suited as domain advisor. This plan needs a separate operator.
+
+Or:
+
+> This plan is promising but should be opened to a broader team.
+
+This is more honest than pretending every idea-generator should become a CEO.
+
+---
+
+## Open by default, closed when necessary
+
+As an open-source-oriented system, PlanExe should lean toward openness where possible.
+
+Many plans are not truly proprietary. They describe public problems, common needs, community improvements, social projects, open-source tools, educational resources, or local services. In those cases, openness can increase the chance that something useful happens.
+
+An open plan can attract:
+
+- contributors
+- operators
+- domain experts
+- funders
+- reviewers
+- local implementers
+- translators
+- maintainers
+- educators
+- community stewards
+
+Open plans also create public learning. Even failed plans can teach others what was tried, what assumptions were wrong, and what bottlenecks appeared.
+
+However, not all plans should be open.
+
+Some plans are sensitive because they involve:
+
+- personal data
+- vulnerable populations
+- security issues
+- medical or psychological information
+- legal strategy
+- competitive business details
+- unpublished inventions
+- political risk
+- safety-critical infrastructure
+- abuse prevention
+- private financial information
+- community conflict
+- whistleblowing
+- location-sensitive operations
+
+For these, openness can create harm.
+
+The platform should therefore support several visibility modes.
+
+---
+
+### Private mode
+
+The plan is visible only to the user.
+
+Best for:
+
+- sensitive personal situations
+- early private business ideas
+- legal or financial planning
+- security-sensitive projects
+- plans involving identifiable people
+
+---
+
+### Selective sharing mode
+
+The plan is shared only with chosen reviewers, mentors, investors, collaborators, or advisors.
+
+Best for:
+
+- investor review
+- expert validation
+- legal review
+- team recruitment
+- private venture assembly
+
+---
+
+### Open review mode
+
+The plan is public for comments, critique, forks, and improvements.
+
+Best for:
+
+- open-source projects
+- public-good projects
+- educational ideas
+- community infrastructure
+- research concepts
+- non-sensitive social projects
+
+---
+
+### Open execution mode
+
+The plan is not only public but actively invites people to claim tasks, form teams, create forks, or launch implementations.
+
+Best for:
+
+- open-source software
+- civic projects
+- public datasets
+- educational curricula
+- community tools
+- standards and protocols
+
+---
+
+### Sensitive mode
+
+The system detects or the user marks the plan as sensitive. Sharing is restricted by default.
+
+Best for:
+
+- security
+- vulnerable people
+- legal exposure
+- health-related matters
+- political risk
+- private organizational strategy
+
+---
+
+## Open plans as commons
+
+An open plan can become a commons object.
+
+That means it is not merely a document. It is something people can reuse, adapt, fork, criticize, and execute in different contexts.
+
+For example:
+
+- one person generates a plan for a community repair cafe
+- another adapts it for a different city
+- a third adds a grant template
+- a fourth contributes a volunteer onboarding checklist
+- a fifth adds a budget spreadsheet
+- several groups execute local variants
+
+This resembles open-source software, but for action plans.
+
+The plan becomes a living artifact.
+
+Possible open-plan features:
+
+- forks
+- issues
+- pull requests
+- comments
+- execution reports
+- budget variants
+- local adaptations
+- risk updates
+- contributor credits
+- licensing options
+- implementation case studies
+
+---
+
+## Ownership and attribution
+
+If plans can be routed to better-fit teams, ownership must be handled carefully.
+
+Users should not feel that their ideas are being taken from them.
+
+The platform should make visibility and rights explicit.
+
+Possible originator options:
+
+| Option | Meaning |
+|---|---|
+| Private ownership | The user keeps the plan private. |
+| Open contribution | The user releases the plan openly for others to use. |
+| Attribution required | Others may use the plan, but must credit the originator. |
+| Originator bounty | The originator may receive a fixed reward if the plan is adopted. |
+| Originator equity | The originator may receive a small stake if a venture forms. |
+| Advisor role | The originator remains involved as domain advisor. |
+| Founder candidate | The originator wants to be evaluated for an execution role. |
+| Assignment | The originator transfers the opportunity to another team where legally meaningful. |
+
+Not every idea is protectable. Many ideas are common. But attribution, consent, and role clarity still matter.
+
+The ethical rule should be:
+
+> No plan should be routed to investors, operators, or public execution without clear user consent.
+
+---
+
+## Investor and funder matching
+
+Some plans fail because they lack capital.
+
+But capital should not be the first fix. A weak plan does not become strong because it receives money. Funding should come after feasibility work.
+
+PlanExe could classify capital fit:
+
+| Plan type | Likely funding route |
+|---|---|
+| Venture-scale startup | Angels, accelerators, pre-seed investors |
+| Local service business | Local financing, revenue, partners |
+| Public-good project | Grants, foundations, municipalities |
+| Open-source tool | Sponsorships, donations, grants, commercial support |
+| Research project | Academic grants, philanthropy, public programs |
+| Creator/media project | Crowdfunding, memberships, sponsorships |
+| Community project | Local partners, volunteers, public funds |
+
+The investor or funder should not receive a raw generated plan. They should receive a short, standardized opportunity package:
+
+- one-page summary
+- feasibility score
+- capital need
+- use of funds
+- current evidence
+- missing validation
+- team composition needed
+- risk disclosure
+- execution milestones
+- full plan available on request
+
+This protects investors from low-quality noise and protects users from premature exposure.
+
+---
+
+## Plan readiness stages
+
+Not every plan should be executed immediately.
+
+A useful system should classify readiness.
+
+| Stage | Meaning | Next action |
+|---|---|---|
+| Idea | Interesting but unstructured | Generate plan and assumptions |
+| Structured plan | Coherent but unvalidated | Identify risks and gaps |
+| Feasibility pass | Budget/team/scope roughly plausible | Run validation tasks |
+| Validated opportunity | Evidence supports the plan | Seek team/funding |
+| Execution-ready | Team, capital, milestones, and risks are aligned | Launch execution |
+| Active execution | Work is underway | Track progress and adapt |
+| Forkable/open template | Useful pattern for others | Publish and maintain |
+
+This avoids treating all generated plans as equally mature.
+
+---
+
+## The role of AI
+
+The AI is not just a writer.
+
+It can become a venture architect, curriculum generator, team designer, and feasibility critic.
+
+Its roles include:
+
+- generate the initial plan
+- expose hidden costs
+- identify capability gaps
+- shrink the plan to a feasible version
+- recommend education paths
+- define required team composition
+- classify funding type
+- prepare investor or grant materials
+- detect sensitive content
+- recommend open versus closed visibility
+- track execution progress
+- update the plan when reality disagrees
+
+The strongest version of this system does not flatter the user. It tells the truth early.
+
+Sometimes the truth is:
+
+> This plan is too expensive.
+
+Sometimes it is:
+
+> This plan is good, but you are not yet ready to lead it.
+
+Sometimes it is:
+
+> This plan should be open, because more people can benefit from it.
+
+Sometimes it is:
+
+> This plan should stay closed, because openness could create harm.
+
+Sometimes it is:
+
+> The best next step is not funding. It is one cheap validation experiment.
+
+---
+
+## Ethical principles
+
+A system like this should follow strong ethical principles.
+
+### Consent before routing
+
+Plans should not be sent to investors, operators, public directories, or potential teams without explicit consent.
+
+### Openness where useful, privacy where necessary
+
+Open plans can create public value. Sensitive plans require protection.
+
+### Do not exploit underprepared users
+
+If someone lacks money or skill, the system should not push them into expensive services before helping them reduce scope and validate the idea.
+
+### Separate plan quality from person worth
+
+A low founder-readiness score is not a personal insult. It is a task-fit diagnosis.
+
+### Reward originators fairly
+
+If a plan leads to a venture, project, or funded initiative, the originator’s expected role and compensation should be clear.
+
+### Make uncertainty visible
+
+Generated plans should show assumptions, confidence levels, missing evidence, and validation tasks.
+
+### Prefer reality over polish
+
+A beautiful plan with false assumptions is worse than a rough plan with honest evidence.
+
+---
+
+## Product vision
+
+The long-term vision is a platform where plans, people, education, funding, and execution are connected.
+
+A person brings a problem or ambition.
+
+PlanExe turns it into a structured plan.
+
+The system then asks:
+
+- Is this plan feasible?
+- What would it cost?
+- What is the smallest useful version?
+- What skills are required?
+- Is the originator ready?
+- Can education close the gap?
+- Should collaborators be recruited?
+- Should the plan be open or closed?
+- What kind of funding fits?
+- What evidence is needed before execution?
+
+The result is not just a document.
+
+The result is a path from intention to capability.
+
+---
+
+## Closing statement
+
+The world does not lack people with ideas. It lacks systems that can transform ideas into feasible action, match plans with capable humans, and preserve good opportunities when the original person is not the right executor.
+
+PlanExe can become such a system.
+
+Its deeper promise is not merely:
+
+> Generate a plan.
+
+Its deeper promise is:
+
+> Help the right plan find the right people, the right level of openness, the right education, the right funding, and the right execution path.
+
+Good plans should not die because the wrong person generated them.
+
+And underprepared people should not be discarded. They should be shown the path from where they are to the role they can realistically play.


### PR DESCRIPTION
## Summary
Adds `docs/proposals/136-good-plans-should-not-die.md`. Argues that PlanExe could grow beyond plan generation into opportunity discovery and human-capability matching: when a generated plan looks promising but the originator isn't currently the right person to execute it, the system should either help close their capability gaps or route the plan to a better-fit team — so promising plans don't die just because the wrong person generated them.

## Test plan
- [ ] Review for tone consistency with surrounding proposals