### PR TITLE
docs(readme): make in-browser "Try it" CTA the primary action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@
 </p>
 
 <p align="center">
+  <a href="https://app.mach-ai.com/planexe_early_access">
+    <img src="https://img.shields.io/badge/%F0%9F%9A%80%20Try%20PlanExe%20in%20your%20browser-Generate%20a%20free%20plan-2ea44f?style=for-the-badge" alt="Try PlanExe in your browser — generate a free plan" height="48">
+  </a>
+</p>
+
+<p align="center">
+  No install. Describe your idea in the form, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes.
+</p>
+
+<p align="center">
   <a href="https://home.planexe.org/"><strong>Create an account</strong></a> &nbsp;|&nbsp;
-  <a href="https://app.mach-ai.com/planexe_early_access"><strong>Generate a free plan</strong></a> &nbsp;|&nbsp;
+  <a href="https://planexe.org/examples/"><strong>See example plans</strong></a> &nbsp;|&nbsp;
   <a href="https://docs.planexe.org/getting_started/"><strong>Getting started guide</strong></a>
 </p>
 


### PR DESCRIPTION
## Summary
Inspired by [space-agent](https://github.com/agent0ai/space-agent)'s "TRY LIVE NOW!" banner. The free hosted trial was previously the middle of three small text links right under the tagline and easy to miss — visitors had to read carefully to notice they could try PlanExe without installing anything.

## Changes (`README.md`)
- New prominent shields.io button immediately under the tagline: **🚀 Try PlanExe in your browser — Generate a free plan**, linking to `https://app.mach-ai.com/planexe_early_access`.
- One-line honesty disclaimer below it: *"No install. Describe your idea in the form, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes."* This sets expectations realistically (PlanExe is not a 30-second round trip like space-agent — it asks for a description and takes time) so visitors who click don't bounce.
- The smaller text-link row drops the now-redundant "Generate a free plan" entry and replaces it with **See example plans** (`https://planexe.org/examples/`) — what most visitors who don't want to commit 15 minutes will reach for next.

## Visual preview
The button uses shields.io's `for-the-badge` style with a green color, sitting prominently between the hero image and the smaller text-link row. Renders on both light and dark GitHub themes.

## Test plan
- [ ] Open the PR on GitHub and confirm the button renders in both light and dark mode
- [ ] Click the button and confirm it lands on the early-access form
- [ ] Click "See example plans" and confirm it lands on the examples page