### PR TITLE
docs(readme): trim Try-it section copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@
 </p>
 
 <p align="center">
-  <strong>PlanExe is the premier planning tool for AI agents.</strong>
-</p>
-
-<p align="center">
   <a href="https://app.mach-ai.com/planexe_early_access">
     <img src="https://img.shields.io/badge/%F0%9F%9A%80%20Try%20PlanExe%20in%20your%20browser-Generate%20a%20free%20plan-2ea44f?style=for-the-badge" alt="Try PlanExe in your browser — generate a free plan" height="48">
   </a>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  No install. Describe your idea in the form, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes.
+  Describe your idea in the form, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
Two small copy trims to the README header:

- Drop the leading "No install." from the disclaimer line under the Try-it CTA. Leaves: *"Describe your idea in the form, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes."*
- Drop the line *"PlanExe is the premier planning tool for AI agents."* — the tagline directly above ("Turn your idea into a comprehensive plan in minutes, not months.") already does the framing work.

## Test plan
- [ ] Render the README on GitHub and confirm the header still reads cleanly