### PR TITLE
docs(readme): drop "in the form" from Try-it line

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  Describe your idea in the form, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes.
+  Describe your idea, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
"Form" is web-developer jargon and not helpful for non-technical visitors. The line still reads naturally without it: *"Describe your idea, hit submit, and PlanExe returns a ~40-page plan in about 15 minutes."*

## Test plan
- [ ] Render the README on GitHub and confirm the line still reads cleanly