### PR TITLE
Drop unused ReportGenerator.append_markdowns

### DIFF
--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -119,26 +119,6 @@ class ReportGenerator:
         html = markdown.markdown(md_data)
         self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
 
-    def append_markdowns(self, document_title: str, file_paths: list[Path], css_classes: list[str] = []):
-        """Append several markdown files concatenated under a single section title.
-
-        Markdown tables in any of the input files are rendered as HTML
-        tables via the `tables` extension; fenced code blocks are
-        rendered via `fenced_code`. Plain markdown (no tables, no code
-        blocks) renders identically with these extensions enabled.
-        """
-        parts: list[str] = []
-        for fp in file_paths:
-            md_data = self.read_markdown_file(fp)
-            if md_data is None:
-                logging.warning(f"Document: '{document_title}'. Could not read markdown file: {fp}")
-                continue
-            parts.append(md_data)
-        if not parts:
-            return
-        html = markdown.markdown("\n\n".join(parts), extensions=['tables', 'fenced_code'])
-        self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
-    
     def append_markdown_with_tables(self, document_title: str, file_path: Path, css_classes: list[str] = []):
         """Append a markdown document to the report. Render markdown tables as HTML tables."""
         md_data = self.read_markdown_file(file_path)


### PR DESCRIPTION
## Summary
- `append_markdowns` (plural) had one caller in `ReportTask` for the Assumptions section.
- That call site was replaced with `append_markdown_with_tables` after the classify_domain content moved into `ConsolidateAssumptionsMarkdownTask`.
- Method is dead code; deleting it.

## Test plan
- [ ] CI green (lint, tests, typecheck)
- [ ] No remaining references to `append_markdowns` in the codebase