### PR TITLE
Bump flask-admin to 2.1.0 (replaces dependabot #662)

### DIFF
--- a/frontend_multi_user/pyproject.toml
+++ b/frontend_multi_user/pyproject.toml
@@ -5,7 +5,7 @@ description = "Running PlanExe on Railway"
 requires-python = ">=3.13"
 dependencies = [
     "flask==3.1.3",
-    "flask-admin==2.0.2",
+    "flask-admin==2.1.0",
     "flask-login==0.6.3",
     "flask-sqlalchemy==3.1.1",
     "flask-wtf==1.3.0",

--- a/frontend_multi_user/src/planexe_modelviews.py
+++ b/frontend_multi_user/src/planexe_modelviews.py
@@ -4,6 +4,7 @@ Custom ModelViews for the PlanExe-server tables.
 import base64
 import json
 import math
+import typing
 import uuid
 from datetime import datetime
 from decimal import Decimal
@@ -18,8 +19,21 @@ from flask_login import current_user
 from sqlalchemy.orm import defer
 from wtforms import FileField, BooleanField
 
+if typing.TYPE_CHECKING:
+    # flask-admin 2.1.0 typed `ModelView.session` via an overload pair
+    # that pyright resolves to `None`, and `ModelView.model` as
+    # `type[DeclarativeBase]`, which loses access to project-specific
+    # columns. Narrow both attributes for static analysis only —
+    # runtime behaviour is unchanged.
+    from sqlalchemy.orm import Session
+    from database_api.model_planitem import PlanItem
+
+
 class AdminOnlyModelView(ModelView):
     """Restrict admin views to authenticated admin users only."""
+    if typing.TYPE_CHECKING:
+        session: Session
+
     def is_accessible(self):
         return current_user.is_authenticated and getattr(current_user, "is_admin", False)
 
@@ -105,6 +119,9 @@ class WorkerItemView(AdminOnlyModelView):
 
 class PlanItemView(AdminOnlyModelView):
     """Custom ModelView for PlanItem"""
+    if typing.TYPE_CHECKING:
+        model: type[PlanItem]
+
     column_list = [
         'id',
         'timestamp_created',


### PR DESCRIPTION
## Summary

Replaces dependabot PR #662, which failed CI typecheck with 10 errors in `frontend_multi_user/src/planexe_modelviews.py`. This branch bumps the dep AND fixes the typecheck breakage.

## Root cause

flask-admin 2.1.0 retyped `ModelView` attributes:

- `session` is now assigned via `_warn_session_deprecation(...)`, whose overload pair pyright resolves to `None`. So every `self.session.query/.add/.commit/.get` access fails type-checking.
- `model` is now typed `type[T_SQLALCHEMY_MODEL]`, which pyright resolves to `type[Any] | type[DeclarativeBase]`. `DeclarativeBase` has no project-specific columns, so `self.model.id` / `.generated_report_html` etc fail.

## Fix

Static-analysis-only — runtime behaviour is unchanged. Add `TYPE_CHECKING`-guarded imports of `sqlalchemy.orm.Session` and `PlanItem`, then narrow the inherited attribute annotations:

```python
class AdminOnlyModelView(ModelView):
    if typing.TYPE_CHECKING:
        session: Session  # narrow inherited attr for static analysis

class PlanItemView(AdminOnlyModelView):
    if typing.TYPE_CHECKING:
        model: type[PlanItem]  # narrow inherited attr for static analysis
```

Session narrowing propagates to all `AdminOnlyModelView` subclasses. Model narrowing only applies where project-specific columns are accessed.

## Test plan

- [x] Local pyright: 0 errors on `src/planexe_modelviews.py` (was 10)
- [ ] CI green
- [ ] User-tested in admin panel (if needed)

## Closes
- #662 (the failing dependabot PR — close that one once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)