### PR TITLE
ping page: per-row Ping buttons + show every model

### DIFF
--- a/frontend_multi_user/src/admin_routes.py
+++ b/frontend_multi_user/src/admin_routes.py
@@ -370,40 +370,50 @@ def admin_database_backup():
         return jsonify({"error": str(e)}), 502
 
 
-@admin_routes_bp.route("/ping/stream")
+@admin_routes_bp.route("/ping/list")
 @login_required
-def ping_stream():
+def ping_list():
     worker_plan_url = current_app.config["WORKER_PLAN_URL"]
+    url = f"{worker_plan_url}/llm-list"
+    try:
+        resp = requests.get(url, timeout=(5, 30))
+    except Exception as exc:
+        logger.error("LLM ping list proxy exception: %s", exc)
+        return jsonify({"error": str(exc)}), 502
+    if resp.status_code != 200:
+        return jsonify({"error": f"worker_plan responded with {resp.status_code}"}), 502
+    return jsonify(resp.json())
 
-    def generate():
-        url = f"{worker_plan_url}/llm-ping"
-        logger.info("Proxying LLM ping stream from %s", url)
-        try:
-            with requests.get(
-                url,
-                stream=True,
-                timeout=(5, 300),
-                headers={"Accept": "text/event-stream"},
-            ) as resp:
-                if resp.status_code != 200:
-                    msg = f"worker_plan responded with {resp.status_code}"
-                    logger.error("LLM ping proxy error: %s", msg)
-                    yield f"data: {json.dumps({'name': 'worker_plan', 'status': 'error', 'response_time': 0, 'response': msg})}\n\n"
-                    yield f"data: {json.dumps({'name': 'server', 'status': 'done', 'response_time': 0, 'response': ''})}\n\n"
-                    return
-                for line in resp.iter_lines(decode_unicode=True):
-                    if line is None or line.strip() == "":
-                        continue
-                    yield f"{line}\n\n"
-        except Exception as exc:
-            logger.error("LLM ping proxy exception: %s", exc)
-            error_payload = {"name": "worker_plan", "status": "error", "response_time": 0, "response": str(exc)}
-            yield f"data: {json.dumps(error_payload)}\n\n"
-            yield f"data: {json.dumps({'name': 'server', 'status': 'done', 'response_time': 0, 'response': ''})}\n\n"
 
-    response = Response(generate(), mimetype="text/event-stream")
-    response.headers["X-Accel-Buffering"] = "no"
-    return response
+@admin_routes_bp.route("/ping/one")
+@login_required
+def ping_one():
+    worker_plan_url = current_app.config["WORKER_PLAN_URL"]
+    profile = request.args.get("profile", "")
+    llm_name = request.args.get("llm_name", "")
+    url = f"{worker_plan_url}/llm-ping-one"
+    try:
+        resp = requests.get(
+            url,
+            params={"profile": profile, "llm_name": llm_name},
+            timeout=(5, 300),
+        )
+    except Exception as exc:
+        logger.error("LLM ping-one proxy exception: %s", exc)
+        return jsonify({
+            "name": f"{profile}:{llm_name}",
+            "status": "error",
+            "response_time": 0,
+            "response": str(exc),
+        }), 502
+    if resp.status_code != 200:
+        return jsonify({
+            "name": f"{profile}:{llm_name}",
+            "status": "error",
+            "response_time": 0,
+            "response": f"worker_plan responded with {resp.status_code}",
+        }), 502
+    return jsonify(resp.json())
 
 
 @admin_routes_bp.route("/admin/demo_run")

--- a/frontend_multi_user/templates/ping.html
+++ b/frontend_multi_user/templates/ping.html
@@ -16,6 +16,7 @@
             border: 1px solid #ddd;
             padding: 8px;
             text-align: left;
+            vertical-align: top;
         }
         th {
             background-color: #f2f2f2;
@@ -23,28 +24,19 @@
         tr:nth-child(even) {
             background-color: #f9f9f9;
         }
-        .status-success {
-            color: green;
-        }
-        .status-error {
-            color: red;
-        }
-        .status-pinging {
-            color: #666;
-            font-style: italic;
-        }
+        .status-success { color: green; }
+        .status-error { color: red; }
+        .status-pinging { color: #666; font-style: italic; }
+        .status-idle { color: #888; }
         .back-link {
             margin-bottom: 20px;
             display: inline-block;
         }
-        .loading {
-            color: #666;
-            font-style: italic;
-        }
+        .loading { color: #666; font-style: italic; }
         @keyframes ellipsis {
-            0% { content: '.'; }
-            33% { content: '..'; }
-            66% { content: '...'; }
+            0%   { content: '.'; }
+            33%  { content: '..'; }
+            66%  { content: '...'; }
             100% { content: '.'; }
         }
         .pinging::after {
@@ -54,96 +46,166 @@
             width: 1em;
             text-align: left;
         }
-        .server-status {
-            font-size: 0.8em;
-            font-weight: normal;
-            padding: 4px 8px;
-            border-radius: 4px;
-            margin-left: 10px;
-            display: inline-block;
+        .toolbar {
+            margin-bottom: 12px;
         }
-        .server-status.working {
-            background-color: #2196F3;
-            color: white;
+        button.ping-btn,
+        button.ping-all-btn {
+            cursor: pointer;
+            padding: 4px 10px;
         }
-        .server-status.done {
-            background-color: #4CAF50;
-            color: white;
+        button.ping-all-btn {
+            font-size: 1em;
+            padding: 8px 16px;
         }
-        .server-status.error {
-            background-color: #f44336;
-            color: white;
+        button:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
         }
     </style>
 </head>
 <body>
     <a href="/admin" class="back-link">← Back to Admin</a>
-    <h1>LLM Ping Results <span id="serverStatus" class="server-status working">Working...</span></h1>
+    <h1>LLM Ping Results</h1>
+    <div class="toolbar">
+        <button id="pingAllBtn" class="ping-all-btn" disabled>Ping All</button>
+        <span id="status" class="loading">Loading models…</span>
+    </div>
     <table>
         <thead>
             <tr>
                 <th>LLM Name</th>
+                <th>Priority</th>
+                <th>Action</th>
                 <th>Status</th>
                 <th>Response Time</th>
                 <th>Response</th>
             </tr>
         </thead>
-        <tbody id="results">
-            <tr>
-                <td colspan="4" class="loading">Loading results...</td>
-            </tr>
-        </tbody>
+        <tbody id="results"></tbody>
     </table>
 
     <script>
-        const resultsTable = document.getElementById('results');
-        const serverStatus = document.getElementById('serverStatus');
-        const results = new Map();
+        const resultsBody = document.getElementById('results');
+        const pingAllBtn = document.getElementById('pingAllBtn');
+        const statusEl = document.getElementById('status');
 
-        const eventSource = new EventSource('/ping/stream');
-        
-        eventSource.onmessage = function(event) {
-            const result = JSON.parse(event.data);
-            
-            if (result.name === 'server') {
-                if (result.status === 'done') {
-                    serverStatus.textContent = 'Done';
-                    serverStatus.className = 'server-status done';
-                    eventSource.close();
-                }
+        let models = [];
+
+        function escapeHtml(s) {
+            return String(s ?? '').replace(/[&<>"']/g, c => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            }[c]));
+        }
+
+        function rowId(model) {
+            return 'row-' + model.display_name.replace(/[^a-zA-Z0-9_-]/g, '_');
+        }
+
+        function setRowState(model, state) {
+            const row = document.getElementById(rowId(model));
+            if (!row) return;
+            const statusCell = row.querySelector('.status-cell');
+            const timeCell = row.querySelector('.time-cell');
+            const respCell = row.querySelector('.response-cell');
+            const btn = row.querySelector('.ping-btn');
+
+            if (state.status === 'pinging') {
+                statusCell.className = 'status-cell pinging';
+                statusCell.textContent = 'pinging';
+                timeCell.textContent = '';
+                respCell.textContent = '';
+                btn.disabled = true;
                 return;
             }
-            
-            results.set(result.name, result);
-            updateTable();
-        };
 
-        eventSource.onerror = function() {
-            eventSource.close();
-            if (results.size === 0) {
-                resultsTable.innerHTML = '<tr><td colspan="4" class="status-error">Error connecting to server</td></tr>';
-            }
-            serverStatus.textContent = 'Error';
-            serverStatus.className = 'server-status error';
-        };
-
-        function updateTable() {
-            if (results.size === 0) return;
-
-            let html = '';
-            for (const result of results.values()) {
-                const statusClass = result.status === 'pinging' ? 'pinging' : `status-${result.status}`;
-                html += `
-                    <tr>
-                        <td>${result.name}</td>
-                        <td class="${statusClass}">${result.status}</td>
-                        <td>${result.response_time}ms</td>
-                        <td>${result.response}</td>
-                    </tr>
-                `;
-            }
-            resultsTable.innerHTML = html;
+            statusCell.className = 'status-cell status-' + state.status;
+            statusCell.textContent = state.status;
+            timeCell.textContent = (state.response_time ?? 0) + 'ms';
+            respCell.textContent = state.response ?? '';
+            btn.disabled = false;
         }
+
+        function renderTable() {
+            if (models.length === 0) {
+                resultsBody.innerHTML = '<tr><td colspan="6" class="loading">No models configured.</td></tr>';
+                return;
+            }
+            const rows = models.map(m => `
+                <tr id="${rowId(m)}">
+                    <td>${escapeHtml(m.display_name)}</td>
+                    <td>${m.priority === null || m.priority === undefined ? '' : escapeHtml(m.priority)}</td>
+                    <td><button class="ping-btn" data-profile="${escapeHtml(m.profile)}" data-llm="${escapeHtml(m.llm_name)}">Ping</button></td>
+                    <td class="status-cell status-idle">idle</td>
+                    <td class="time-cell"></td>
+                    <td class="response-cell"></td>
+                </tr>
+            `);
+            resultsBody.innerHTML = rows.join('');
+
+            resultsBody.querySelectorAll('.ping-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const m = {
+                        profile: btn.dataset.profile,
+                        llm_name: btn.dataset.llm,
+                        display_name: btn.dataset.profile + ':' + btn.dataset.llm,
+                    };
+                    pingOne(m);
+                });
+            });
+        }
+
+        async function pingOne(model) {
+            setRowState(model, { status: 'pinging' });
+            try {
+                const params = new URLSearchParams({
+                    profile: model.profile,
+                    llm_name: model.llm_name,
+                });
+                const resp = await fetch('/ping/one?' + params.toString());
+                const data = await resp.json();
+                setRowState(model, data);
+                return data;
+            } catch (exc) {
+                setRowState(model, {
+                    status: 'error',
+                    response_time: 0,
+                    response: String(exc),
+                });
+            }
+        }
+
+        async function pingAll() {
+            pingAllBtn.disabled = true;
+            statusEl.textContent = 'Pinging all models…';
+            statusEl.className = 'loading';
+            for (const m of models) {
+                await pingOne(m);
+            }
+            statusEl.textContent = 'Done.';
+            statusEl.className = '';
+            pingAllBtn.disabled = false;
+        }
+
+        async function loadModels() {
+            try {
+                const resp = await fetch('/ping/list');
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                const data = await resp.json();
+                models = data.models || [];
+                renderTable();
+                pingAllBtn.disabled = models.length === 0;
+                statusEl.textContent = models.length + ' models loaded.';
+                statusEl.className = '';
+            } catch (exc) {
+                statusEl.textContent = 'Failed to load models: ' + exc;
+                statusEl.className = 'status-error';
+                resultsBody.innerHTML = '';
+            }
+        }
+
+        pingAllBtn.addEventListener('click', pingAll);
+        loadModels();
     </script>
 </body>
-</html> 
+</html>

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -86,27 +86,27 @@
         },
         "pricing_kind": "paid"
     },
-    "openrouter-elephant-alpha": {
-        "comment": "Released Apr 13, 2026. 262,144 context. $0/M input tokens. $0/M output tokens",
+    "openrouter-ling-2.6-flash": {
+        "comment": "Production name for what was previously the 'Elephant Alpha' stealth release (revealed Apr 21, 2026). 262,144 context. $0.08/M input tokens. $0.24/M output tokens.",
         "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/openrouter/elephant-alpha",
+        "model_info_url": "https://openrouter.ai/inclusionai/ling-2.6-flash",
         "class": "OpenRouter",
         "arguments": {
-            "model": "openrouter/elephant-alpha",
+            "model": "inclusionai/ling-2.6-flash",
             "api_key": "${OPENROUTER_API_KEY}",
             "temperature": 0.1,
             "timeout": 60.0,
-            "context_window": 1048576,
+            "context_window": 262144,
             "is_function_calling_model": false,
             "is_chat_model": true,
             "max_tokens": 8192,
             "max_retries": 5
         },
         "pricing": {
-            "input_per_million_tokens": 0,
-            "output_per_million_tokens": 0
+            "input_per_million_tokens": 0.08,
+            "output_per_million_tokens": 0.24
         },
-        "pricing_kind": "free"
+        "pricing_kind": "paid"
     },
     "openrouter-ling-2.6-1t-free": {
         "comment": "Released Apr 23, 2026. Scheduled to be removed from OpenRouter on Apr 30, 2026. 262,144 context. $0/M input tokens. $0/M output tokens.",
@@ -305,6 +305,34 @@
         "pricing": {
             "input_per_million_tokens": 0.05,
             "output_per_million_tokens": 0.40
+        },
+        "pricing_kind": "paid"
+    },
+    "deepseek-v4-flash": {
+        "comment": "DeepSeek's flash tier via the native DeepSeek API. Requires a DEEPSEEK_API_KEY in the .env file. 1,000,000 context, 384,000 max output. Thinking mode is explicitly disabled (defaults to enabled). $0.14/M input (cache miss). $0.28/M output. See https://api-docs.deepseek.com/quick_start/pricing/",
+        "luigi_workers": 4,
+        "class": "OpenAILike",
+        "arguments": {
+            "model": "deepseek-v4-flash",
+            "api_key": "${DEEPSEEK_API_KEY}",
+            "api_base": "https://api.deepseek.com/v1",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 1000000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 16384,
+            "max_retries": 5,
+            "additional_kwargs": {
+                "extra_body": {
+                    "thinking": {"type": "disabled"}
+                }
+            }
+        },
+        "model_info_url": "https://api-docs.deepseek.com/quick_start/pricing/",
+        "pricing": {
+            "input_per_million_tokens": 0.14,
+            "output_per_million_tokens": 0.28
         },
         "pricing_kind": "paid"
     },

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -130,6 +130,72 @@
         },
         "pricing_kind": "free"
     },
+    "openrouter-granite-4.1-8b": {
+        "comment": "IBM Granite 4.1 8B. Released Apr 30, 2026. Dense decoder-only 8B model, Apache 2.0. 131,072 context. $0.05/M input tokens. $0.10/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/ibm-granite/granite-4.1-8b",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "ibm-granite/granite-4.1-8b",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 131072,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8192,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0.05,
+            "output_per_million_tokens": 0.10
+        },
+        "pricing_kind": "paid"
+    },
+    "openrouter-laguna-xs.2-free": {
+        "comment": "Poolside Laguna XS.2 (free). Released Apr 28, 2026. Compact fp8 model targeted at agentic coding. 128,000 context. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/poolside/laguna-xs.2",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "poolside/laguna-xs.2:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 128000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 8000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
+    "openrouter-nemotron-3-nano-omni-30b-reasoning-free": {
+        "comment": "NVIDIA Nemotron 3 Nano Omni 30B A3B reasoning (free). Released Apr 28, 2026. Reasoning model — uses more tokens than non-reasoning models. 256,000 context. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 256000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 16384,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-gemini-2.5-flash-lite-preview-09-2025": {
         "comment": "Created Sep 25, 2025. 1,048,576 context. $0.10/M input tokens. $0.40/M output tokens.",
         "priority": 1,
@@ -308,7 +374,7 @@
         },
         "pricing_kind": "paid"
     },
-    "deepseek-v4-flash": {
+    "deepseek-v4-flash-thinking-disabled": {
         "comment": "DeepSeek's flash tier via the native DeepSeek API. Requires a DEEPSEEK_API_KEY in the .env file. 1,000,000 context, 384,000 max output. Thinking mode is explicitly disabled (defaults to enabled). $0.14/M input (cache miss). $0.28/M output. See https://api-docs.deepseek.com/quick_start/pricing/",
         "luigi_workers": 4,
         "class": "OpenAILike",

--- a/worker_plan/app.py
+++ b/worker_plan/app.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import subprocess
-import json
 import sys
 import tempfile
 import threading
@@ -18,7 +17,7 @@ from worker_plan_api.planexe_dotenv import PlanExeDotEnv
 PlanExeDotEnv.load().update_os_environ()
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from worker_plan_api.filenames import FilenameEnum, ExtraFilenameEnum
@@ -29,7 +28,7 @@ from worker_plan_api.model_profile import ModelProfileEnum, DEFAULT_MODEL_PROFIL
 from worker_plan_internal.plan.pipeline_environment import PipelineEnvironmentEnum
 from worker_plan_api.plan_file import PlanFile
 from worker_plan_api.start_time import StartTime
-from worker_plan_internal.llm_factory import obtain_llm_info, get_llm_names_by_priority, get_llm
+from worker_plan_internal.llm_factory import obtain_llm_info, get_llm_names_by_priority, get_all_llm_names_with_priority, get_llm
 from worker_plan_internal.utils.time_since_last_modification import time_since_last_modification
 from worker_plan_internal.utils.purge_old_runs import purge_old_runs, start_purge_scheduler
 from llama_index.core.llms import ChatMessage, MessageRole
@@ -422,78 +421,68 @@ def llm_info() -> LLMInfo:
     return obtain_llm_info()
 
 
-@app.get("/llm-ping")
-def llm_ping() -> StreamingResponse:
-    """
-    Stream ping results for each configured LLM model.
-    """
+_PING_SYSTEM_PROMPT = "You are a healthcheck endpoint. Reply with exactly OK. Do not add any other words."
+_PING_USER_PROMPT = "Reply with exactly OK."
 
-    def event_stream():
-        logger.info("Starting llm-ping stream")
-        ping_system_prompt = "You are a healthcheck endpoint. Reply with exactly OK. Do not add any other words."
-        ping_user_prompt = "Reply with exactly OK."
-        ping_targets: list[tuple[ModelProfileEnum, str, str]] = []
-        try:
-            for profile in ModelProfileEnum:
-                llm_names = get_llm_names_by_priority(model_profile=profile)
-                for llm_name in llm_names:
-                    display_name = f"{profile.value}:{llm_name}"
-                    ping_targets.append((profile, llm_name, display_name))
-        except Exception as exc:  # pragma: no cover - runtime probe
-            logger.error("llm-ping failed to enumerate llm names: %s", exc)
-            yield f"data: {json.dumps({'name': 'worker_plan', 'status': 'error', 'response_time': 0, 'response': str(exc)})}\n\n"
-            yield f"data: {json.dumps({'name': 'server', 'status': 'done', 'response_time': 0, 'response': ''})}\n\n"
-            return
 
-        if len(ping_targets) == 0:
-            yield f"data: {json.dumps({'name': 'worker_plan', 'status': 'error', 'response_time': 0, 'response': 'No models found in whitelisted llm_config profiles.'})}\n\n"
-            yield f"data: {json.dumps({'name': 'server', 'status': 'done', 'response_time': 0, 'response': ''})}\n\n"
-            return
+def _enumerate_ping_targets() -> list[dict]:
+    targets: list[dict] = []
+    for profile in ModelProfileEnum:
+        for llm_name, priority in get_all_llm_names_with_priority(model_profile=profile):
+            targets.append({
+                "profile": profile.value,
+                "llm_name": llm_name,
+                "display_name": f"{profile.value}:{llm_name}",
+                "priority": priority,
+            })
+    return targets
 
-        for model_profile, llm_name, display_name in ping_targets:
-            yield f"data: {json.dumps({'name': display_name, 'status': 'pinging', 'response_time': 0, 'response': 'Pinging model…'})}\n\n"
-            try:
-                start_time = time.time()
-                llm = get_llm(llm_name, model_profile=model_profile)
-                chat_message_list = [
-                    ChatMessage(
-                        role=MessageRole.SYSTEM,
-                        content=ping_system_prompt,
-                    ),
-                    ChatMessage(
-                        role=MessageRole.USER,
-                        content=ping_user_prompt,
-                    )
-                ]
-                response = llm.chat(chat_message_list)
-                end_time = time.time()
 
-                response_text = getattr(getattr(response, "message", None), "content", None)
-                if response_text is None:
-                    response_text = str(response)
-                response_text = str(response_text).strip()
-                is_exact_ok = response_text == "OK"
+@app.get("/llm-list")
+def llm_list() -> dict:
+    """List every (profile, llm_name) pair configured in the active llm_config profiles."""
+    try:
+        return {"models": _enumerate_ping_targets()}
+    except Exception as exc:
+        logger.error("llm-list failed to enumerate llm names: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-                payload = {
-                    "name": display_name,
-                    "status": "success" if is_exact_ok else "error",
-                    "response_time": int((end_time - start_time) * 1000),
-                    "response": "OK" if is_exact_ok else f"Expected exact 'OK', got: {response_text}"
-                }
-            except Exception as exc:  # pragma: no cover - runtime probe
-                logger.error("llm-ping error for %s: %s", llm_name, exc)
-                payload = {
-                    "name": display_name,
-                    "status": "error",
-                    "response_time": 0,
-                    "response": str(exc)
-                }
-            yield f"data: {json.dumps(payload)}\n\n"
 
-        logger.info("llm-ping stream complete")
-        yield f"data: {json.dumps({'name': 'server', 'status': 'done', 'response_time': 0, 'response': ''})}\n\n"
+@app.get("/llm-ping-one")
+def llm_ping_one(profile: str, llm_name: str) -> dict:
+    """Ping a single configured model and return the result as JSON."""
+    model_profile = normalize_model_profile(profile)
+    display_name = f"{model_profile.value}:{llm_name}"
+    try:
+        start_time = time.time()
+        llm = get_llm(llm_name, model_profile=model_profile)
+        chat_message_list = [
+            ChatMessage(role=MessageRole.SYSTEM, content=_PING_SYSTEM_PROMPT),
+            ChatMessage(role=MessageRole.USER, content=_PING_USER_PROMPT),
+        ]
+        response = llm.chat(chat_message_list)
+        elapsed_ms = int((time.time() - start_time) * 1000)
 
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
+        response_text = getattr(getattr(response, "message", None), "content", None)
+        if response_text is None:
+            response_text = str(response)
+        response_text = str(response_text).strip()
+        is_exact_ok = response_text == "OK"
+
+        return {
+            "name": display_name,
+            "status": "success" if is_exact_ok else "error",
+            "response_time": elapsed_ms,
+            "response": "OK" if is_exact_ok else f"Expected exact 'OK', got: {response_text}",
+        }
+    except Exception as exc:
+        logger.error("llm-ping-one error for %s:%s: %s", model_profile.value, llm_name, exc)
+        return {
+            "name": display_name,
+            "status": "error",
+            "response_time": 0,
+            "response": str(exc),
+        }
 
 
 @app.post("/purge-runs", response_model=PurgeRunsResponse)

--- a/worker_plan/worker_plan_internal/llm_factory.py
+++ b/worker_plan/worker_plan_internal/llm_factory.py
@@ -38,7 +38,7 @@ SPECIAL_AUTO_LABEL = 'Auto'
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["get_llm", "LLMInfo", "get_llm_names_by_priority", "SPECIAL_AUTO_ID", "is_valid_llm_name", "obtain_llm_info"]
+__all__ = ["get_llm", "LLMInfo", "get_llm_names_by_priority", "get_all_llm_names_with_priority", "SPECIAL_AUTO_ID", "is_valid_llm_name", "obtain_llm_info"]
 
 
 def _resolve_model_profile(model_profile: Optional[ModelProfileEnum | str]) -> ModelProfileEnum:
@@ -173,6 +173,26 @@ def get_llm_names_by_priority(model_profile: Optional[ModelProfileEnum | str] = 
     configs = [(name, config) for name, config in planexe_llmconfig.llm_config_dict.items() if config.get("priority") is not None]
     configs.sort(key=lambda x: x[1].get("priority", 0))
     return [name for name, _ in configs]
+
+
+def get_all_llm_names_with_priority(model_profile: Optional[ModelProfileEnum | str] = None) -> list[tuple[str, Optional[int]]]:
+    """
+    Return every configured LLM name in the profile and its priority (None when unset).
+
+    Models with a priority come first, sorted ascending. Models without a priority
+    follow, in the order the config file declares them.
+    """
+    planexe_llmconfig = _load_llm_config(model_profile)
+    prioritized: list[tuple[str, Optional[int]]] = []
+    unprioritized: list[tuple[str, Optional[int]]] = []
+    for name, config in planexe_llmconfig.llm_config_dict.items():
+        priority = config.get("priority")
+        if priority is None:
+            unprioritized.append((name, None))
+        else:
+            prioritized.append((name, int(priority)))
+    prioritized.sort(key=lambda x: x[1])
+    return prioritized + unprioritized
 
 def is_valid_llm_name(llm_name: str, model_profile: Optional[ModelProfileEnum | str] = None) -> bool:
     """


### PR DESCRIPTION
## Summary

Reworks `/ping` for troubleshooting individual models, plus two related `llm_config/baseline.json` updates.

### Page behaviour

**Before:** the page opened an SSE stream that pinged every *prioritized* model in sequence and appended rows as results came back. Models without a `priority` field were silently skipped, and there was no way to retry a single model.

**After:**
- The full table renders on page load with one row per configured model across every `llm_config` profile.
- A new **Priority** column shows each model's priority value (blank when unset). Prioritized models are listed first (asc), unprioritized after in declaration order.
- Each row has its own **Ping** button.
- A top **Ping All** button iterates rows sequentially.

### Backend

- New `GET /llm-list` returns every `(profile, llm_name, priority)` tuple as JSON.
- New `GET /llm-ping-one?profile=X&llm_name=Y` pings one model and returns the result as JSON.
- Removed `GET /llm-ping` (SSE) and the matching `/ping/stream` proxy in `frontend_multi_user`.
- New helper `get_all_llm_names_with_priority()` in `llm_factory.py`.

### Bundled `llm_config/baseline.json` changes

Both caught while exercising the new ping page:

- **Add** `deepseek-v4-flash` (DeepSeek native API at `api.deepseek.com/v1`, thinking mode explicitly disabled via `additional_kwargs.extra_body`, \$0.14/M input / \$0.28/M output).
- **Replace** `openrouter-elephant-alpha` with `openrouter-ling-2.6-flash` — Elephant Alpha was a stealth alias and now returns 404; production name is `inclusionai/ling-2.6-flash` (262K context, \$0.08/M in / \$0.24/M out).

## Test plan

- [ ] Open `/ping`, confirm every model appears (incl. ones without `priority`).
- [ ] Click per-row **Ping** on a working model — row updates with `success` + response time.
- [ ] Click **Ping All** — rows update sequentially.
- [ ] Verify `deepseek-v4-flash` pings green with a `DEEPSEEK_API_KEY` set.
- [ ] Verify `openrouter-ling-2.6-flash` pings green (no longer 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)