### PR TITLE
llm_factory: cache parsed llm_config per profile

### DIFF
--- a/worker_plan/worker_plan_internal/llm_factory.py
+++ b/worker_plan/worker_plan_internal/llm_factory.py
@@ -51,8 +51,15 @@ def _resolve_model_profile(model_profile: Optional[ModelProfileEnum | str]) -> M
     return resolve_model_profile_from_env()
 
 
+_llm_config_cache: dict[ModelProfileEnum, PlanExeLLMConfig] = {}
+
+
 def _load_llm_config(model_profile: Optional[ModelProfileEnum | str]) -> PlanExeLLMConfig:
     resolved_profile = _resolve_model_profile(model_profile)
+    cached = _llm_config_cache.get(resolved_profile)
+    if cached is not None:
+        return cached
+
     planexe_llmconfig = PlanExeLLMConfig.load(model_profile=resolved_profile)
     try:
         from worker_plan_internal.llm_util.model_pricing import load_pricing_from_llm_config
@@ -64,6 +71,8 @@ def _load_llm_config(model_profile: Optional[ModelProfileEnum | str]) -> PlanExe
         install_anthropic_usage_hook()
     except Exception:
         logger.debug("Failed to install Anthropic usage hook", exc_info=True)
+
+    _llm_config_cache[resolved_profile] = planexe_llmconfig
     return planexe_llmconfig
 
 
@@ -230,7 +239,9 @@ def get_llm(llm_name: Optional[str] = None, model_profile: Optional[ModelProfile
 
     config = planexe_llmconfig.llm_config_dict[llm_name]
     class_name = config.get("class")
-    arguments = config.get("arguments", {})
+    # Copy before mutating — _load_llm_config caches the parsed config
+    # across calls, so we must not write per-call kwargs back into it.
+    arguments = dict(config.get("arguments", {}))
 
     # Override with any kwargs passed to get_llm()
     arguments.update(kwargs)


### PR DESCRIPTION
## Summary

Production logs were full of repeated INFO/WARNING noise at every Luigi task start:

```
INFO  planexe_config        - Optional file '.env' not found …
WARN  planexe_llmconfig     - Environment variable 'OPENAI_API_KEY' not found.
WARN  planexe_llmconfig     - Environment variable 'DASHSCOPE_API_KEY' not found.
WARN  planexe_llmconfig     - Environment variable 'DEEPSEEK_API_KEY' not found.
INFO  planexe_llmconfig     - Applied PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=…
```

…because every LLM lookup was re-reading the JSON, re-substituting env vars, and re-applying the class whitelist.

Now `_load_llm_config` caches the parsed `PlanExeLLMConfig` in a module-level dict keyed by resolved `ModelProfileEnum`. Subsequent calls hit the cache. Pricing and Anthropic usage-hook side effects move into the cache-miss branch — same end state, just no longer redone per call.

### Latent mutation bug fixed in passing

`get_llm` was mutating `config["arguments"]` in place when merging caller kwargs. Pre-cache that was harmless (the dict was rebuilt every call). With caching it would leak state across calls. Shallow-copy the dict before `update()`.

### Not in this PR

The `OPENAI_API_KEY` / `DASHSCOPE_API_KEY` / `DEEPSEEK_API_KEY` warnings still fire on the first load even though those entries are dropped by the OpenRouter class whitelist. Fixing that needs `filter_by_whitelisted_classes` to run *before* `substitute_env_vars` in `PlanExeLLMConfig.load`. Saved for a separate PR.

## Test plan

- [ ] Boot worker_plan, run a plan, confirm the `Optional file '.env' not found` / `Environment variable …_API_KEY not found` lines now appear at most once per profile per worker (instead of per task).
- [ ] `get_llm("foo", max_tokens=8192)` followed by `get_llm("foo")` — the second call must NOT see `max_tokens=8192` leaked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)