### PR TITLE
cache PlanExeConfig / PlanExeDotEnv / PlanExeLLMConfig loaders

### DIFF
--- a/worker_plan/worker_plan_api/planexe_config.py
+++ b/worker_plan/worker_plan_api/planexe_config.py
@@ -17,6 +17,7 @@ IDEA: validate the contents of ".env"
 IDEA: validate the contents of profile config files (llm_config/*.json)
 """
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Optional
 import logging
@@ -91,49 +92,12 @@ class PlanExeConfig:
         :param llm_config_json_name_override: Optional explicit config filename override.
         :return: A new PlanExeConfig instance with resolved paths and profile metadata.
         """
-        logger.debug("PlanExeConfig.load() creating a new instance...")
-        planexe_config_path = cls.resolve_planexe_config_path()
-
-        if isinstance(model_profile_override, ModelProfileEnum):
-            model_profile = model_profile_override
-        elif isinstance(model_profile_override, str):
-            model_profile = normalize_model_profile(model_profile_override)
-        else:
-            model_profile = resolve_model_profile_from_env()
-
-        llm_config_json_name = resolve_llm_config_filename(
-            model_profile=model_profile,
-            explicit_filename=llm_config_json_name_override,
+        profile_key = (
+            model_profile_override.value
+            if isinstance(model_profile_override, ModelProfileEnum)
+            else model_profile_override
         )
-
-        dotenv_path = cls.find_file_in_search_order(
-            ConfigNameEnum.DOTENV.value,
-            planexe_config_path,
-            is_optional=True,
-        )
-        llm_config_json_path = cls.find_file_in_search_order(llm_config_json_name, planexe_config_path)
-
-        # Safe fallback: if profile config is missing, use baseline config.
-        if llm_config_json_path is None and llm_config_json_name != ConfigNameEnum.LLM_CONFIG_JSON_DEFAULT.value:
-            baseline_name = ConfigNameEnum.LLM_CONFIG_JSON_DEFAULT.value
-            baseline_path = cls.find_file_in_search_order(baseline_name, planexe_config_path)
-            if baseline_path is not None:
-                logger.warning(
-                    "Selected profile config %r not found. Falling back to baseline config %r.",
-                    llm_config_json_name,
-                    baseline_name,
-                )
-                llm_config_json_name = baseline_name
-                llm_config_json_path = baseline_path
-                model_profile = DEFAULT_MODEL_PROFILE
-
-        return cls(
-            planexe_config_path=planexe_config_path,
-            dotenv_path=dotenv_path,
-            model_profile=model_profile,
-            llm_config_json_name=llm_config_json_name,
-            llm_config_json_path=llm_config_json_path,
-        )
+        return _load_cached(profile_key, llm_config_json_name_override)
 
     @classmethod
     def resolve_planexe_config_path(cls) -> Optional[Path]:
@@ -204,6 +168,54 @@ class PlanExeConfig:
         else:
             logger.warning(f"{filename!r} not found in any of the search locations (ENV_VAR, CWD, Project Root).")
         return None
+
+
+@cache
+def _load_cached(
+    profile_key: Optional[str],
+    llm_config_json_name_override: Optional[str],
+) -> PlanExeConfig:
+    logger.debug("PlanExeConfig.load() creating a new instance...")
+    planexe_config_path = PlanExeConfig.resolve_planexe_config_path()
+
+    if profile_key is None:
+        model_profile = resolve_model_profile_from_env()
+    else:
+        model_profile = normalize_model_profile(profile_key)
+
+    llm_config_json_name = resolve_llm_config_filename(
+        model_profile=model_profile,
+        explicit_filename=llm_config_json_name_override,
+    )
+
+    dotenv_path = PlanExeConfig.find_file_in_search_order(
+        ConfigNameEnum.DOTENV.value,
+        planexe_config_path,
+        is_optional=True,
+    )
+    llm_config_json_path = PlanExeConfig.find_file_in_search_order(llm_config_json_name, planexe_config_path)
+
+    # Safe fallback: if profile config is missing, use baseline config.
+    if llm_config_json_path is None and llm_config_json_name != ConfigNameEnum.LLM_CONFIG_JSON_DEFAULT.value:
+        baseline_name = ConfigNameEnum.LLM_CONFIG_JSON_DEFAULT.value
+        baseline_path = PlanExeConfig.find_file_in_search_order(baseline_name, planexe_config_path)
+        if baseline_path is not None:
+            logger.warning(
+                "Selected profile config %r not found. Falling back to baseline config %r.",
+                llm_config_json_name,
+                baseline_name,
+            )
+            llm_config_json_name = baseline_name
+            llm_config_json_path = baseline_path
+            model_profile = DEFAULT_MODEL_PROFILE
+
+    return PlanExeConfig(
+        planexe_config_path=planexe_config_path,
+        dotenv_path=dotenv_path,
+        model_profile=model_profile,
+        llm_config_json_name=llm_config_json_name,
+        llm_config_json_path=llm_config_json_path,
+    )
 
 
 if __name__ == "__main__":

--- a/worker_plan/worker_plan_api/planexe_dotenv.py
+++ b/worker_plan/worker_plan_api/planexe_dotenv.py
@@ -28,6 +28,73 @@ class PlanExeDotEnv:
     def load(cls):
         return _load_cached()
 
+    def update_os_environ(self):
+        """Update os.environ with the resolved environment values."""
+        count_before = len(os.environ)
+        os.environ.update(self.dotenv_dict)
+        count_after = len(os.environ)
+        logger.debug(f"PlanExeDotEnv.update_os_environ() Updated os.environ with the .env file content. number of items before: {count_before}, number of items after: {count_after}")
+
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        return self.dotenv_dict.get(key, default)
+
+    def get_absolute_path_to_file(self, key: str) -> Optional[Path]:
+        """
+        Resolves and validates the "key" variable.
+        It's expected to be an absolute path to a file.
+        If the key is not found, returns None.
+
+        :return: A Path object if valid, otherwise None.
+        """
+        path_str = self.dotenv_dict.get(key)
+        if path_str is None:
+            logger.debug(f"{key} is not set")
+            return None
+
+        try:
+            path_obj = Path(path_str)
+        except Exception as e: # If path_str is bizarre
+            logger.error(f"Invalid {key} string '{path_str!r}': {e!r}")
+            return None
+        if not path_obj.is_absolute():
+            logger.error(f"{key} must be an absolute path: {path_obj!r}")
+            return None
+        if not path_obj.is_file():
+            logger.error(f"{key} must be a file: {path_obj!r}")
+            return None
+        logger.debug(f"Using {key}: {path_obj!r}")
+        return path_obj
+
+    def get_absolute_path_to_dir(self, key: str) -> Optional[Path]:
+        """
+        Resolves and validates the "key" variable.
+        It's expected to be an absolute path to a directory.
+        If the key is not found, returns None.
+
+        :return: A Path object if valid, otherwise None.
+        """
+        path_str = self.dotenv_dict.get(key)
+        if path_str is None:
+            logger.debug(f"{key} is not set")
+            return None
+
+        try:
+            path_obj = Path(path_str)
+        except Exception as e: # If path_str is bizarre
+            logger.error(f"Invalid {key} string '{path_str!r}': {e!r}")
+            return None
+        if not path_obj.is_absolute():
+            logger.error(f"{key} must be an absolute path: {path_obj!r}")
+            return None
+        if not path_obj.is_dir():
+            logger.error(f"{key} must be a directory: {path_obj!r}")
+            return None
+        logger.debug(f"Using {key}: {path_obj!r}")
+        return path_obj
+
+    def __repr__(self):
+        return f"PlanExeDotEnv(dotenv_path={self.dotenv_path!r}, dotenv_dict.keys()={self.dotenv_dict.keys()!r})"
+
 
 @cache
 def _load_cached() -> PlanExeDotEnv:
@@ -53,73 +120,6 @@ def _load_cached() -> PlanExeDotEnv:
         dotenv_path=dotenv_path,
         dotenv_dict=dotenv_dict,
     )
-
-    def update_os_environ(self):
-        """Update os.environ with the resolved environment values."""
-        count_before = len(os.environ)
-        os.environ.update(self.dotenv_dict)
-        count_after = len(os.environ)
-        logger.debug(f"PlanExeDotEnv.update_os_environ() Updated os.environ with the .env file content. number of items before: {count_before}, number of items after: {count_after}")
-
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-        return self.dotenv_dict.get(key, default)
-
-    def get_absolute_path_to_file(self, key: str) -> Optional[Path]:
-        """
-        Resolves and validates the "key" variable.
-        It's expected to be an absolute path to a file.
-        If the key is not found, returns None.
-        
-        :return: A Path object if valid, otherwise None.
-        """
-        path_str = self.dotenv_dict.get(key)
-        if path_str is None:
-            logger.debug(f"{key} is not set")
-            return None
-            
-        try:
-            path_obj = Path(path_str)
-        except Exception as e: # If path_str is bizarre
-            logger.error(f"Invalid {key} string '{path_str!r}': {e!r}")
-            return None
-        if not path_obj.is_absolute():
-            logger.error(f"{key} must be an absolute path: {path_obj!r}")
-            return None
-        if not path_obj.is_file():
-            logger.error(f"{key} must be a file: {path_obj!r}")
-            return None
-        logger.debug(f"Using {key}: {path_obj!r}")
-        return path_obj
-
-    def get_absolute_path_to_dir(self, key: str) -> Optional[Path]:
-        """
-        Resolves and validates the "key" variable.
-        It's expected to be an absolute path to a directory.
-        If the key is not found, returns None.
-        
-        :return: A Path object if valid, otherwise None.
-        """
-        path_str = self.dotenv_dict.get(key)
-        if path_str is None:
-            logger.debug(f"{key} is not set")
-            return None
-            
-        try:
-            path_obj = Path(path_str)
-        except Exception as e: # If path_str is bizarre
-            logger.error(f"Invalid {key} string '{path_str!r}': {e!r}")
-            return None
-        if not path_obj.is_absolute():
-            logger.error(f"{key} must be an absolute path: {path_obj!r}")
-            return None
-        if not path_obj.is_dir():
-            logger.error(f"{key} must be a directory: {path_obj!r}")
-            return None
-        logger.debug(f"Using {key}: {path_obj!r}")
-        return path_obj
-
-    def __repr__(self):
-        return f"PlanExeDotEnv(dotenv_path={self.dotenv_path!r}, dotenv_dict.keys()={self.dotenv_dict.keys()!r})"
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/worker_plan/worker_plan_api/planexe_dotenv.py
+++ b/worker_plan/worker_plan_api/planexe_dotenv.py
@@ -4,6 +4,7 @@ Load PlanExe's environment, combining the OS environment and optional .env file 
 PROMPT> python -m worker_plan_api.planexe_dotenv
 """
 from dataclasses import dataclass
+from functools import cache
 import os
 from pathlib import Path
 from typing import Optional
@@ -13,6 +14,7 @@ from worker_plan_api.planexe_config import PlanExeConfig
 from enum import Enum
 
 logger = logging.getLogger(__name__)
+
 
 class DotEnvKeyEnum(str, Enum):
     PATH_TO_PYTHON = "PATH_TO_PYTHON"
@@ -24,28 +26,33 @@ class PlanExeDotEnv:
 
     @classmethod
     def load(cls):
-        config = PlanExeConfig.load()
-        dotenv_path = config.dotenv_path
-        env_before = os.environ.copy()
+        return _load_cached()
 
-        # Load from .env if present, otherwise fall back to an empty dict.
-        dotenv_file_values = {}
-        if dotenv_path is not None:
-            dotenv_file_values = {k: v for k, v in dotenv_values(dotenv_path=dotenv_path).items() if v is not None}
 
-        # Merge .env file values with the real environment (environment variables take precedence).
-        dotenv_dict = {**dotenv_file_values, **os.environ}
+@cache
+def _load_cached() -> PlanExeDotEnv:
+    config = PlanExeConfig.load()
+    dotenv_path = config.dotenv_path
+    env_before = os.environ.copy()
 
-        if env_before != os.environ:
-            logger.error("PlanExeDotEnv.load() The dotenv_values() modified the environment variables. My assumption is that it doesn't do that. If you see this, please report it as a bug.")
-            logger.error(f"PlanExeDotEnv.load() The dotenv_values() modified the environment variables. count before: {len(env_before)}, count after: {len(os.environ)}")
-            logger.error(f"PlanExeDotEnv.load() The dotenv_values() modified the environment variables. content before: {env_before!r}, content after: {os.environ!r}")
-        else:
-            logger.debug(f"PlanExeDotEnv.load() Great! This is what is expected. The dotenv_values() did not modify the environment variables. number of items: {len(os.environ)}")
-        return cls(
-            dotenv_path=dotenv_path, 
-            dotenv_dict=dotenv_dict
-        )
+    # Load from .env if present, otherwise fall back to an empty dict.
+    dotenv_file_values = {}
+    if dotenv_path is not None:
+        dotenv_file_values = {k: v for k, v in dotenv_values(dotenv_path=dotenv_path).items() if v is not None}
+
+    # Merge .env file values with the real environment (environment variables take precedence).
+    dotenv_dict = {**dotenv_file_values, **os.environ}
+
+    if env_before != os.environ:
+        logger.error("PlanExeDotEnv.load() The dotenv_values() modified the environment variables. My assumption is that it doesn't do that. If you see this, please report it as a bug.")
+        logger.error(f"PlanExeDotEnv.load() The dotenv_values() modified the environment variables. count before: {len(env_before)}, count after: {len(os.environ)}")
+        logger.error(f"PlanExeDotEnv.load() The dotenv_values() modified the environment variables. content before: {env_before!r}, content after: {os.environ!r}")
+    else:
+        logger.debug(f"PlanExeDotEnv.load() Great! This is what is expected. The dotenv_values() did not modify the environment variables. number of items: {len(os.environ)}")
+    return PlanExeDotEnv(
+        dotenv_path=dotenv_path,
+        dotenv_dict=dotenv_dict,
+    )
 
     def update_os_environ(self):
         """Update os.environ with the resolved environment values."""

--- a/worker_plan/worker_plan_internal/utils/planexe_llmconfig.py
+++ b/worker_plan/worker_plan_internal/utils/planexe_llmconfig.py
@@ -36,34 +36,6 @@ class PlanExeLLMConfig:
         profile_key = model_profile.value if isinstance(model_profile, ModelProfileEnum) else model_profile
         return _load_cached(profile_key, llm_config_json_name_override)
 
-
-@cache
-def _load_cached(
-    profile_key: str | None,
-    llm_config_json_name_override: str | None,
-) -> PlanExeLLMConfig:
-    config = PlanExeConfig.load(
-        model_profile_override=profile_key,
-        llm_config_json_name_override=llm_config_json_name_override,
-    )
-    config.raise_if_required_files_not_found()
-    planexe_dotenv = PlanExeDotEnv.load()
-
-    llm_config_json_path = config.llm_config_json_path
-    llm_config_dict_raw = PlanExeLLMConfig.load_llm_config(llm_config_json_path)
-    # Filter before substituting so we don't warn about env vars
-    # belonging to entries that are about to be dropped (e.g. when
-    # PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=OpenRouter is set in
-    # production and OPENAI_API_KEY / DEEPSEEK_API_KEY are absent).
-    llm_config_dict = PlanExeLLMConfig.filter_by_whitelisted_classes(llm_config_dict_raw, planexe_dotenv.dotenv_dict)
-    llm_config_dict = PlanExeLLMConfig.substitute_env_vars(llm_config_dict, planexe_dotenv.dotenv_dict)
-
-    return PlanExeLLMConfig(
-        llm_config_json_path=llm_config_json_path,
-        llm_config_dict_raw=llm_config_dict_raw,
-        llm_config_dict=llm_config_dict,
-    )
-
     @classmethod
     def load_llm_config(cls, llm_config_json_path: Path) -> Dict[str, Any]:
         """Loads the configuration from a JSON file."""
@@ -137,6 +109,34 @@ def _load_cached(
 
     def __repr__(self):
         return f"PlanExeLLMConfig(llm_config_json_path={self.llm_config_json_path!r}, llm_config_dict.keys()={self.llm_config_dict.keys()!r})"
+
+
+@cache
+def _load_cached(
+    profile_key: str | None,
+    llm_config_json_name_override: str | None,
+) -> PlanExeLLMConfig:
+    config = PlanExeConfig.load(
+        model_profile_override=profile_key,
+        llm_config_json_name_override=llm_config_json_name_override,
+    )
+    config.raise_if_required_files_not_found()
+    planexe_dotenv = PlanExeDotEnv.load()
+
+    llm_config_json_path = config.llm_config_json_path
+    llm_config_dict_raw = PlanExeLLMConfig.load_llm_config(llm_config_json_path)
+    # Filter before substituting so we don't warn about env vars
+    # belonging to entries that are about to be dropped (e.g. when
+    # PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=OpenRouter is set in
+    # production and OPENAI_API_KEY / DEEPSEEK_API_KEY are absent).
+    llm_config_dict = PlanExeLLMConfig.filter_by_whitelisted_classes(llm_config_dict_raw, planexe_dotenv.dotenv_dict)
+    llm_config_dict = PlanExeLLMConfig.substitute_env_vars(llm_config_dict, planexe_dotenv.dotenv_dict)
+
+    return PlanExeLLMConfig(
+        llm_config_json_path=llm_config_json_path,
+        llm_config_dict_raw=llm_config_dict_raw,
+        llm_config_dict=llm_config_dict,
+    )
 
 if __name__ == "__main__":
     llm_config = PlanExeLLMConfig.load()

--- a/worker_plan/worker_plan_internal/utils/planexe_llmconfig.py
+++ b/worker_plan/worker_plan_internal/utils/planexe_llmconfig.py
@@ -4,6 +4,7 @@ Load PlanExe LLM profile configuration from the resolved llm_config/<profile>.js
 PROMPT> python -m worker_plan_internal.utils.planexe_llmconfig
 """
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Any, Dict
 import json
@@ -19,6 +20,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class PlanExeLLMConfig:
     llm_config_json_path: Path
@@ -31,23 +33,36 @@ class PlanExeLLMConfig:
         model_profile: ModelProfileEnum | str | None = None,
         llm_config_json_name_override: str | None = None,
     ):
-        config = PlanExeConfig.load(
-            model_profile_override=model_profile,
-            llm_config_json_name_override=llm_config_json_name_override,
-        )
-        config.raise_if_required_files_not_found()
-        planexe_dotenv = PlanExeDotEnv.load()
+        profile_key = model_profile.value if isinstance(model_profile, ModelProfileEnum) else model_profile
+        return _load_cached(profile_key, llm_config_json_name_override)
 
-        llm_config_json_path = config.llm_config_json_path
-        llm_config_dict_raw = cls.load_llm_config(llm_config_json_path)
-        llm_config_dict = cls.substitute_env_vars(llm_config_dict_raw, planexe_dotenv.dotenv_dict)
-        llm_config_dict = cls.filter_by_whitelisted_classes(llm_config_dict, planexe_dotenv.dotenv_dict)
 
-        return cls(
-            llm_config_json_path=llm_config_json_path,
-            llm_config_dict_raw=llm_config_dict_raw,
-            llm_config_dict=llm_config_dict
-        )
+@cache
+def _load_cached(
+    profile_key: str | None,
+    llm_config_json_name_override: str | None,
+) -> PlanExeLLMConfig:
+    config = PlanExeConfig.load(
+        model_profile_override=profile_key,
+        llm_config_json_name_override=llm_config_json_name_override,
+    )
+    config.raise_if_required_files_not_found()
+    planexe_dotenv = PlanExeDotEnv.load()
+
+    llm_config_json_path = config.llm_config_json_path
+    llm_config_dict_raw = PlanExeLLMConfig.load_llm_config(llm_config_json_path)
+    # Filter before substituting so we don't warn about env vars
+    # belonging to entries that are about to be dropped (e.g. when
+    # PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=OpenRouter is set in
+    # production and OPENAI_API_KEY / DEEPSEEK_API_KEY are absent).
+    llm_config_dict = PlanExeLLMConfig.filter_by_whitelisted_classes(llm_config_dict_raw, planexe_dotenv.dotenv_dict)
+    llm_config_dict = PlanExeLLMConfig.substitute_env_vars(llm_config_dict, planexe_dotenv.dotenv_dict)
+
+    return PlanExeLLMConfig(
+        llm_config_json_path=llm_config_json_path,
+        llm_config_dict_raw=llm_config_dict_raw,
+        llm_config_dict=llm_config_dict,
+    )
 
     @classmethod
     def load_llm_config(cls, llm_config_json_path: Path) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Follow-up to #671. That PR cached `_load_llm_config` in `llm_factory`, but the underlying loaders still re-parsed on every direct caller — most visibly `run_plan_pipeline.resolve_luigi_workers` calling `PlanExeLLMConfig.load(...)` directly. Each `PlanExeLLMConfig.load` also fans out into two `PlanExeConfig.load` calls (one direct, one via `PlanExeDotEnv.load`), so the production logs kept emitting:

```
INFO  planexe_config        - Optional file '.env' not found …
INFO  planexe_config        - Optional configuration file '.env' not found; relying on environment variables only.
WARN  planexe_llmconfig     - Environment variable 'OPENAI_API_KEY' not found.
WARN  planexe_llmconfig     - Environment variable 'DASHSCOPE_API_KEY' not found.
WARN  planexe_llmconfig     - Environment variable 'DEEPSEEK_API_KEY' not found.
INFO  planexe_llmconfig     - Applied PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=…
```

…on essentially every Luigi task.

### Changes

**Move the body of each loader's `load(...)` classmethod into a module-level `@functools.cache`-decorated `_load_cached(...)` helper.**

- `PlanExeConfig.load(...)`
- `PlanExeDotEnv.load()` (singleton — no args)
- `PlanExeLLMConfig.load(...)`

The classmethod normalizes inputs to hashable form (stripping `ModelProfileEnum` to its `str` value) and delegates. Cache keys are plain tuples of normalized inputs. `cache_clear()` is available on each `_load_cached` if a test ever needs to reset.

**Reorder `PlanExeLLMConfig.load`: filter by whitelisted classes BEFORE substituting env vars.** With `PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=OpenRouter` in production, entries that need `OPENAI_API_KEY` / `DASHSCOPE_API_KEY` / `DEEPSEEK_API_KEY` are dropped before substitution looks for those vars — those warnings stop firing entirely, even on first cache miss.

Each Luigi worker subprocess still parses once on startup. That's a hard limit of in-process caching across subprocess boundaries — expect one batch of warnings per fresh process, not zero.

## Test plan

- [ ] Run a full plan in production. Verify `Optional file '.env' not found` / `Environment variable 'X' not found` lines appear at most once per worker process (not once per task).
- [ ] With `PLANEXE_LLM_CONFIG_WHITELISTED_CLASSES=OpenRouter`, verify `OPENAI_API_KEY` / `DASHSCOPE_API_KEY` / `DEEPSEEK_API_KEY` warnings no longer appear at all.
- [ ] Confirm `get_llm("openrouter-…")` still resolves to a working model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)