### PR TITLE
docs: roadmap note on detecting silly / comedic prompts

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -100,6 +100,10 @@ a different set of levers, fixing typos.
 - User leaves out physical location(s). So PlanExe picks a random location in a different part of the world.
 - Confusing prompt. `Less than 100 employees`, that can be a solopreneur or a company with 99 employees. Better with a range 80..120 employees, and a number of people available to the project.
 
+Detect silly prompts, and maybe show a banner that it's garbage input.
+Currently PlanExe fails to recognize the comedic/weird prompts. Prompt has a playful tone, that isn't your typical enterprise project.
+It yields a non-sense plan. Instead it would make more sense to respond with a similar playful tone.
+
 **Ask for expert help:** Establish contact between people, for reviewing a plan, for executing the plan, for getting funding.
 The “Ask for expert help” section, serve the content from planexe.org. Either as an iframe or as javascript or be generated dynamic?
 


### PR DESCRIPTION
## Summary

Add a note to `docs/plan.md` under the prompt-quality section: PlanExe currently treats playful or comedic prompts as if they were enterprise projects and produces nonsense plans. Better behaviour would be to detect that tone, surface a banner indicating the input is garbage, and (optionally) respond with a matching playful tone.

## Test plan

- [ ] N/A — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)