### PR TITLE
refactor: rename FilenameEnum.REPORT to REPORT_HTML

### DIFF
--- a/worker_plan/app.py
+++ b/worker_plan/app.py
@@ -347,7 +347,7 @@ def run_report(run_id: str) -> FileResponse:
     if not run_dir.exists():
         raise HTTPException(status_code=404, detail=f"Run directory does not exist: {run_dir}")
 
-    report_path = run_dir / FilenameEnum.REPORT.value
+    report_path = run_dir / FilenameEnum.REPORT_HTML.value
     if not report_path.exists():
         raise HTTPException(status_code=404, detail=f"Report file not found for run {run_id}")
 
@@ -355,7 +355,7 @@ def run_report(run_id: str) -> FileResponse:
         return FileResponse(
             path=report_path,
             media_type="text/html",
-            filename=FilenameEnum.REPORT.value,
+            filename=FilenameEnum.REPORT_HTML.value,
         )
     except Exception as exc:
         logger.warning("Unable to serve report for run %s: %s", run_id, exc)

--- a/worker_plan/worker_plan_api/filenames.py
+++ b/worker_plan/worker_plan_api/filenames.py
@@ -133,7 +133,7 @@ class FilenameEnum(str, Enum):
     SELF_AUDIT_MARKDOWN = "self_audit.md"
     PROMPT_ADHERENCE_RAW = "prompt_adherence_raw.json"
     PROMPT_ADHERENCE_MARKDOWN = "prompt_adherence.md"
-    REPORT = "report.html"
+    REPORT_HTML = "report.html"
     PIPELINE_COMPLETE = "pipeline_complete.txt"
 
 class ExtraFilenameEnum(str, Enum):

--- a/worker_plan/worker_plan_internal/plan/nodes/report.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/report.py
@@ -32,7 +32,7 @@ from worker_plan_internal.plan.nodes.screen_planning_prompt import ScreenPlannin
 class ReportTask(PlanTask):
     """Assemble all pipeline outputs into the final HTML report."""
     def output(self):
-        return self.local_target(FilenameEnum.REPORT)
+        return self.local_target(FilenameEnum.REPORT_HTML)
 
     def requires(self):
         return {

--- a/worker_plan/worker_plan_internal/plan/ping_llm.py
+++ b/worker_plan/worker_plan_internal/plan/ping_llm.py
@@ -153,7 +153,7 @@ def run_ping_llm_report(
         error_message=str(error) if error else None,
     )
 
-    report_path = run_id_dir / FilenameEnum.REPORT.value
+    report_path = run_id_dir / FilenameEnum.REPORT_HTML.value
     _write_ping_report(report_path, result)
 
     if error is None:

--- a/worker_plan/worker_plan_internal/plan/run_plan_pipeline.py
+++ b/worker_plan/worker_plan_internal/plan/run_plan_pipeline.py
@@ -372,7 +372,7 @@ class ExecutePipeline:
 
     @property
     def has_report_file(self) -> bool:
-        file_path = self.run_id_dir / FilenameEnum.REPORT.value
+        file_path = self.run_id_dir / FilenameEnum.REPORT_HTML.value
         return file_path.exists()
 
     @property

--- a/worker_plan/worker_plan_internal/plan/tests/test_ping_llm.py
+++ b/worker_plan/worker_plan_internal/plan/tests/test_ping_llm.py
@@ -27,7 +27,7 @@ class TestPingLLMReport(unittest.TestCase):
             self.assertFalse(result.attempts[0].success)
             self.assertTrue(result.attempts[1].success)
 
-            report_path = run_id_dir / FilenameEnum.REPORT.value
+            report_path = run_id_dir / FilenameEnum.REPORT_HTML.value
             self.assertTrue(report_path.exists())
             report_html = report_path.read_text(encoding="utf-8")
             self.assertIn("PONG ok", report_html)

--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -347,7 +347,7 @@ def main():
         print(f"Error: Input path does not exist: {input_path}")
         return
     
-    output_path = input_path / FilenameEnum.REPORT.value
+    output_path = input_path / FilenameEnum.REPORT_HTML.value
     
     report_generator = ReportGenerator()
     report_generator.append_markdown('Initial Plan', input_path / FilenameEnum.INITIAL_PLAN.value)

--- a/worker_plan_database/app.py
+++ b/worker_plan_database/app.py
@@ -1205,7 +1205,7 @@ def execute_pipeline_for_job(
     logger.info(f"Pipeline for {run_id_dir!r} executed in {duration_in_seconds:.2f} seconds")
 
     # Collect artifacts for storage.
-    report_path = run_id_dir / FilenameEnum.REPORT.value
+    report_path = run_id_dir / FilenameEnum.REPORT_HTML.value
     report_html: Optional[str] = None
     if pipeline_instance.has_report_file and report_path.exists():
         try:
@@ -1341,7 +1341,7 @@ def execute_pipeline_for_job(
                 logger.debug(f"WBS_LEVEL1_PROJECT_TITLE file found at {title_path!r}. Using the plan_name: {plan_name!r}.")
             else:
                 logger.warning(f"WBS_LEVEL1_PROJECT_TITLE file not found at {title_path!r}. Using the default plan_name: {plan_name!r}.")
-            machai_instance.post_confirmation_ok_with_file(session_id=user_id, path=run_id_dir / FilenameEnum.REPORT.value, plan_name=plan_name)
+            machai_instance.post_confirmation_ok_with_file(session_id=user_id, path=run_id_dir / FilenameEnum.REPORT_HTML.value, plan_name=plan_name)
         else:
             machai_instance.post_confirmation_error(session_id=user_id, message=str(machai_error_message))
     else:
@@ -1349,7 +1349,7 @@ def execute_pipeline_for_job(
 
     # Upload report to worker_plan service (internal, independent of MachAI).
     if pipeline_instance.has_report_file:
-        upload_report_to_worker_plan(run_id=str(task_id), report_path=run_id_dir / FilenameEnum.REPORT.value)
+        upload_report_to_worker_plan(run_id=str(task_id), report_path=run_id_dir / FilenameEnum.REPORT_HTML.value)
 
 def process_pending_tasks() -> bool:
     """


### PR DESCRIPTION
## Summary
- Rename `FilenameEnum.REPORT` to `FilenameEnum.REPORT_HTML` to make the file format explicit at call sites and align with the naming convention used by other entries in the enum (e.g. `PREMORTEM_RAW` vs `PREMORTEM_MARKDOWN`).
- Updates the enum definition in `worker_plan/worker_plan_api/filenames.py` and all 10 references across 9 files.

## Test plan
- [ ] CI passes