### PR TITLE
fix + cleanup: Q&A report section, drop HTML artifact, normalize naming

### DIFF
--- a/worker_plan/worker_plan_api/filenames.py
+++ b/worker_plan/worker_plan_api/filenames.py
@@ -126,7 +126,6 @@ class FilenameEnum(str, Enum):
     SCHEDULE_GANTT_MACHAI_CSV = "schedule_gantt_machai.csv"
     QUESTIONS_AND_ANSWERS_RAW = "questions_and_answers_raw.json"
     QUESTIONS_AND_ANSWERS_MARKDOWN = "questions_and_answers.md"
-    QUESTIONS_AND_ANSWERS_HTML = "questions_and_answers.html"
     PREMORTEM_RAW = "premortem_raw.json"
     PREMORTEM_MARKDOWN = "premortem.md"
     SELF_AUDIT_RAW = "self_audit_raw.json"

--- a/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
@@ -1,7 +1,7 @@
 """QuestionsAndAnswersTask - Generates Q&A about the plan."""
 from llama_index.core.llms.llm import LLM
 from worker_plan_internal.plan.run_plan_pipeline import PlanTask
-from worker_plan_internal.questions_answers.questions_answers import QuestionsAnswers
+from worker_plan_internal.questions_answers.questions_and_answers import QuestionsAnswers
 from worker_plan_api.filenames import FilenameEnum
 from worker_plan_internal.plan.nodes.strategic_decisions_markdown import StrategicDecisionsMarkdownTask
 from worker_plan_internal.plan.nodes.scenarios_markdown import ScenariosMarkdownTask

--- a/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
@@ -26,7 +26,6 @@ class QuestionsAndAnswersTask(PlanTask):
         return {
             'raw': self.local_target(FilenameEnum.QUESTIONS_AND_ANSWERS_RAW),
             'markdown': self.local_target(FilenameEnum.QUESTIONS_AND_ANSWERS_MARKDOWN),
-            'html': self.local_target(FilenameEnum.QUESTIONS_AND_ANSWERS_HTML)
         }
 
     def requires(self):
@@ -98,5 +97,3 @@ class QuestionsAndAnswersTask(PlanTask):
         question_answers.save_raw(json_path)
         markdown_path = self.output()['markdown'].path
         question_answers.save_markdown(markdown_path)
-        html_path = self.output()['html'].path
-        question_answers.save_html(html_path)

--- a/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
@@ -1,7 +1,7 @@
 """QuestionsAndAnswersTask - Generates Q&A about the plan."""
 from llama_index.core.llms.llm import LLM
 from worker_plan_internal.plan.run_plan_pipeline import PlanTask
-from worker_plan_internal.questions_answers.questions_and_answers import QuestionsAndAnswers
+from worker_plan_internal.questions_and_answers.questions_and_answers import QuestionsAndAnswers
 from worker_plan_api.filenames import FilenameEnum
 from worker_plan_internal.plan.nodes.strategic_decisions_markdown import StrategicDecisionsMarkdownTask
 from worker_plan_internal.plan.nodes.scenarios_markdown import ScenariosMarkdownTask

--- a/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/questions_and_answers.py
@@ -1,7 +1,7 @@
 """QuestionsAndAnswersTask - Generates Q&A about the plan."""
 from llama_index.core.llms.llm import LLM
 from worker_plan_internal.plan.run_plan_pipeline import PlanTask
-from worker_plan_internal.questions_answers.questions_and_answers import QuestionsAnswers
+from worker_plan_internal.questions_answers.questions_and_answers import QuestionsAndAnswers
 from worker_plan_api.filenames import FilenameEnum
 from worker_plan_internal.plan.nodes.strategic_decisions_markdown import StrategicDecisionsMarkdownTask
 from worker_plan_internal.plan.nodes.scenarios_markdown import ScenariosMarkdownTask
@@ -90,7 +90,7 @@ class QuestionsAndAnswersTask(PlanTask):
         )
 
         # Invoke the LLM
-        question_answers = QuestionsAnswers.execute(llm, query)
+        question_answers = QuestionsAndAnswers.execute(llm, query)
 
         # Save the results.
         json_path = self.output()['raw'].path

--- a/worker_plan/worker_plan_internal/plan/nodes/report.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/report.py
@@ -85,7 +85,7 @@ class ReportTask(PlanTask):
         rg.append_markdown('Expert Criticism', self.input()['expert_review'].path)
         rg.append_csv('Work Breakdown Structure', self.input()['wbs_project123']['csv'].path)
         rg.append_markdown('Review Plan', self.input()['review_plan']['markdown'].path)
-        rg.append_html('Questions & Answers', self.input()['questions_and_answers']['html'].path)
+        rg.append_markdown('Questions & Answers', self.input()['questions_and_answers']['markdown'].path)
         rg.append_markdown_with_tables('Premortem', self.input()['premortem']['markdown'].path)
         rg.append_markdown_with_tables('Self Audit', self.input()['self_audit']['markdown'].path)
         rg.append_initial_prompt_vetted(

--- a/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
@@ -1,7 +1,7 @@
 """
 For a reader of the plan that is unfamiliar with the domain, provide a list of Q&A pairs that are relevant to the plan.
 
-PROMPT> python -m worker_plan_internal.questions_answers.questions_and_answers
+PROMPT> python -m worker_plan_internal.questions_and_answers.questions_and_answers
 """
 import json
 import time

--- a/worker_plan/worker_plan_internal/questions_answers/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/questions_answers/questions_and_answers.py
@@ -1,7 +1,7 @@
 """
 For a reader of the plan that is unfamiliar with the domain, provide a list of Q&A pairs that are relevant to the plan.
 
-PROMPT> python -m worker_plan_internal.questions_answers.questions_answers
+PROMPT> python -m worker_plan_internal.questions_answers.questions_and_answers
 """
 import json
 import time

--- a/worker_plan/worker_plan_internal/questions_answers/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/questions_answers/questions_and_answers.py
@@ -76,7 +76,7 @@ Use the following JSON models:
 SECOND_USER_PROMPT = "Generate 5 additional question and answer pairs from the document, focusing on clarifying the risks, ethical considerations, controversial aspects, or broader implications discussed in the plan."
 
 @dataclass
-class QuestionsAnswers:
+class QuestionsAndAnswers:
     """
     Identify what questions and answers are relevant to the plan.
     """
@@ -87,7 +87,7 @@ class QuestionsAnswers:
     markdown: str
 
     @classmethod
-    def execute(cls, llm: LLM, user_prompt: str) -> 'QuestionsAnswers':
+    def execute(cls, llm: LLM, user_prompt: str) -> 'QuestionsAndAnswers':
         """
         Invoke LLM with the project description.
         """
@@ -185,7 +185,7 @@ class QuestionsAnswers:
 
         markdown = cls.convert_to_markdown(DocumentDetails(**merged_response))
 
-        result = QuestionsAnswers(
+        result = QuestionsAndAnswers(
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             response=merged_response,
@@ -242,7 +242,7 @@ if __name__ == "__main__":
     )
     print(f"Query: {query}")
 
-    physical_locations = QuestionsAnswers.execute(llm, query)
+    physical_locations = QuestionsAndAnswers.execute(llm, query)
     json_response = physical_locations.to_dict(include_system_prompt=False, include_user_prompt=False)
     print("\n\nResponse:")
     print(json.dumps(json_response, indent=2))

--- a/worker_plan/worker_plan_internal/questions_answers/questions_answers.py
+++ b/worker_plan/worker_plan_internal/questions_answers/questions_answers.py
@@ -3,7 +3,6 @@ For a reader of the plan that is unfamiliar with the domain, provide a list of Q
 
 PROMPT> python -m worker_plan_internal.questions_answers.questions_answers
 """
-import html
 import json
 import time
 import logging
@@ -86,7 +85,6 @@ class QuestionsAnswers:
     response: dict
     metadata: dict
     markdown: str
-    html: str
 
     @classmethod
     def execute(cls, llm: LLM, user_prompt: str) -> 'QuestionsAnswers':
@@ -186,7 +184,6 @@ class QuestionsAnswers:
         }
 
         markdown = cls.convert_to_markdown(DocumentDetails(**merged_response))
-        html = cls.convert_to_html(DocumentDetails(**merged_response))
 
         result = QuestionsAnswers(
             system_prompt=system_prompt,
@@ -194,7 +191,6 @@ class QuestionsAnswers:
             response=merged_response,
             metadata=metadata,
             markdown=markdown,
-            html=html
         )
         return result
     
@@ -231,21 +227,6 @@ class QuestionsAnswers:
     def save_markdown(self, output_file_path: str):
         with open(output_file_path, 'w', encoding='utf-8') as f:
             f.write(self.markdown)
-
-    @staticmethod
-    def convert_to_html(document_details: DocumentDetails) -> str:
-        """
-        Convert the raw document details to html.
-        """
-        rows = []
-        for index, item in enumerate(document_details.question_answer_pairs, start=1):
-            rows.append(f'<div class="question-answer-pair"><p><strong>{index}.</strong> {html.escape(item.question)}</p>')
-            rows.append(f'<p>{html.escape(item.answer)}</p></div>')
-        return "\n".join(rows)
-
-    def save_html(self, output_file_path: str):
-        with open(output_file_path, 'w', encoding='utf-8') as f:
-            f.write(self.html)
 
 if __name__ == "__main__":
     from worker_plan_internal.llm_factory import get_llm


### PR DESCRIPTION
## Summary

Started as a one-line fix to a wrong call in `ReportTask`, then cleaned up the now-orphaned Q&A HTML artifact and normalized the inconsistent `questions_answers` vs `questions_and_answers` naming.

### Commits
1. **fix: use markdown source for Questions & Answers section in report** — `ReportTask` was calling `rg.append_html` on the Q&A `.html` artifact, but `append_html` requires HTML wrapped in the report template's `HTML_HEAD_*` / `HTML_BODY_CONTENT_*` markers, which the Q&A HTML doesn't have. Switched to `append_markdown` against `FilenameEnum.QUESTIONS_AND_ANSWERS_MARKDOWN`, matching every other narrative section.
2. **refactor: drop unused Q&A HTML artifact** — with the report no longer consuming it, nothing reads `questions_and_answers.html`. Removes `QuestionsAndAnswers.convert_to_html` / `save_html` / the `html` field, the `'html'` Luigi output target on `QuestionsAndAnswersTask`, and `FilenameEnum.QUESTIONS_AND_ANSWERS_HTML`.
3. **refactor: rename `questions_answers.py` → `questions_and_answers.py`** — module file matches the class/concept name used everywhere else.
4. **refactor: rename class `QuestionsAnswers` → `QuestionsAndAnswers`** — aligns with module name and `QuestionsAndAnswersTask`.
5. **refactor: rename package `questions_answers/` → `questions_and_answers/`** — directory matches the module and class.

### Not changed
Two historical references to the old `questions_answers` module path remain in `docs/superpowers/plans/2026-04-02-split-run-plan-pipeline.md` and `docs/proposals/113-llm-error-traceability.md`. Both are frozen-in-time planning docs; leaving them alone.

## Test plan
- [ ] CI passes
- [ ] Generated report renders the Questions & Answers section as a normal collapsible markdown section
- [ ] No remaining importers of the old `worker_plan_internal.questions_answers.*` module path in code