### PR TITLE
feat(report): emit parallel markdown report for LLM consumption

### DIFF
--- a/worker_plan/worker_plan_api/filenames.py
+++ b/worker_plan/worker_plan_api/filenames.py
@@ -133,6 +133,7 @@ class FilenameEnum(str, Enum):
     PROMPT_ADHERENCE_RAW = "prompt_adherence_raw.json"
     PROMPT_ADHERENCE_MARKDOWN = "prompt_adherence.md"
     REPORT_HTML = "report.html"
+    REPORT_MARKDOWN = "report.md"
     PIPELINE_COMPLETE = "pipeline_complete.txt"
 
 class ExtraFilenameEnum(str, Enum):

--- a/worker_plan/worker_plan_internal/plan/nodes/report.py
+++ b/worker_plan/worker_plan_internal/plan/nodes/report.py
@@ -1,4 +1,4 @@
-"""ReportTask - Generates the final HTML report document."""
+"""ReportTask - Generates the final HTML and Markdown report documents."""
 from worker_plan_internal.plan.run_plan_pipeline import PlanTask, REPORT_EXECUTE_PLAN_SECTION_HIDDEN
 from worker_plan_internal.report.report_generator import ReportGenerator
 from worker_plan_api.filenames import FilenameEnum
@@ -30,9 +30,12 @@ from worker_plan_internal.plan.nodes.screen_planning_prompt import ScreenPlannin
 
 
 class ReportTask(PlanTask):
-    """Assemble all pipeline outputs into the final HTML report."""
+    """Assemble all pipeline outputs into the final HTML and Markdown reports."""
     def output(self):
-        return self.local_target(FilenameEnum.REPORT_HTML)
+        return {
+            'html': self.local_target(FilenameEnum.REPORT_HTML),
+            'markdown': self.local_target(FilenameEnum.REPORT_MARKDOWN),
+        }
 
     def requires(self):
         return {
@@ -97,4 +100,5 @@ class ReportTask(PlanTask):
             premise_attack_markdown_file_path=self.input()['premise_attack']['markdown'].path
         )
         rg.append_markdown_with_tables('Prompt Adherence', self.input()['prompt_adherence']['markdown'].path)
-        rg.save_report(self.output().path, title=title, execute_plan_section_hidden=REPORT_EXECUTE_PLAN_SECTION_HIDDEN)
+        rg.save_html_report(self.output()['html'].path, title=title, execute_plan_section_hidden=REPORT_EXECUTE_PLAN_SECTION_HIDDEN)
+        rg.save_markdown_report(self.output()['markdown'].path, title=title)

--- a/worker_plan/worker_plan_internal/plan/ping_llm.py
+++ b/worker_plan/worker_plan_internal/plan/ping_llm.py
@@ -117,8 +117,8 @@ def _build_ping_report_html(result: PingLLMResult) -> str:
 def _write_ping_report(output_path: Path, result: PingLLMResult) -> None:
     rg = ReportGenerator()
     ping_html = _build_ping_report_html(result)
-    rg.report_item_list.append(ReportDocumentItem("LLM Ping", ping_html))
-    rg.save_report(output_path, title=PING_LLM_REPORT_TITLE, execute_plan_section_hidden=True)
+    rg.report_html_item_list.append(ReportDocumentItem("LLM Ping", ping_html))
+    rg.save_html_report(output_path, title=PING_LLM_REPORT_TITLE, execute_plan_section_hidden=True)
 
 
 def run_ping_llm_report(

--- a/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
@@ -216,13 +216,9 @@ class QuestionsAndAnswers:
         rows = []
 
         for index, item in enumerate(document_details.question_answer_pairs, start=1):
-            rows.append(f"\n## Question Answer Pair {index}")
-            rows.append(f"**Question**: {item.question}")
-            rows.append(f"**Answer**: {item.answer}")
-            rows.append(f"**Rationale**: {item.rationale}")
-        
-        rows.append(f"\n## Summary\n{document_details.summary}")
-        return "\n".join(rows)
+            rows.append(f"{index}. **{item.question}**")
+            rows.append(item.answer)
+        return "\n\n".join(rows)
 
     def save_markdown(self, output_file_path: str):
         with open(output_file_path, 'w', encoding='utf-8') as f:

--- a/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
@@ -214,10 +214,9 @@ class QuestionsAndAnswers:
         Convert the raw document details to markdown.
         """
         rows = []
-
         for index, item in enumerate(document_details.question_answer_pairs, start=1):
-            rows.append(f"{index}. **{item.question}**")
-            rows.append(item.answer)
+            rows.append(f"Q{index}: **{item.question}**")
+            rows.append(f"A{index}: {item.answer}")
         return "\n\n".join(rows)
 
     def save_markdown(self, output_file_path: str):

--- a/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
+++ b/worker_plan/worker_plan_internal/questions_and_answers/questions_and_answers.py
@@ -215,7 +215,7 @@ class QuestionsAndAnswers:
         """
         rows = []
         for index, item in enumerate(document_details.question_answer_pairs, start=1):
-            rows.append(f"Q{index}: **{item.question}**")
+            rows.append(f"**Q{index}: {item.question}**")
             rows.append(f"A{index}: {item.answer}")
         return "\n\n".join(rows)
 

--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -25,10 +25,17 @@ class ReportDocumentItem:
     document_html_content: str
     css_classes: list[str] = field(default_factory=list)
 
+@dataclass
+class ReportMarkdownItem:
+    document_title: str
+    document_markdown_content: str
+
 class ReportGenerator:
     def __init__(self):
-        self.report_item_list: list[ReportDocumentItem] = []
+        self.report_html_item_list: list[ReportDocumentItem] = []
+        self.report_markdown_item_list: list[ReportMarkdownItem] = []
         self.top_banner_html: str = ""
+        self.top_banner_markdown: str = ""
         self.html_head_content: list[str] = []
         self.html_body_script_content: list[str] = []
 
@@ -99,17 +106,18 @@ class ReportGenerator:
         if json_data is None:
             logging.warning(f"Document: '{document_title}'. Could not read JSON file: {file_path}")
             return
-        
+
         # Convert the JSON data to a formatted string
         json_str = json.dumps(json_data, indent=2)
-        
+
         # Create markdown content with JSON in a code block
         markdown_content = f"```json\n{json_str}\n```"
-        
+
         # Convert markdown to HTML and add to report (fenced_code extension needed for ``` blocks)
         html = markdown.markdown(markdown_content, extensions=['fenced_code'])
-        self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
-        
+        self.report_html_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+        self.report_markdown_item_list.append(ReportMarkdownItem(document_title, markdown_content))
+
     def append_markdown(self, document_title: str, file_path: Path, css_classes: list[str] = []):
         """Append a markdown document to the report."""
         md_data = self.read_markdown_file(file_path)
@@ -117,7 +125,8 @@ class ReportGenerator:
             logging.warning(f"Document: '{document_title}'. Could not read markdown file: {file_path}")
             return
         html = markdown.markdown(md_data)
-        self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+        self.report_html_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+        self.report_markdown_item_list.append(ReportMarkdownItem(document_title, md_data))
 
     def append_markdown_with_tables(self, document_title: str, file_path: Path, css_classes: list[str] = []):
         """Append a markdown document to the report. Render markdown tables as HTML tables."""
@@ -126,8 +135,9 @@ class ReportGenerator:
             logging.warning(f"Document: '{document_title}'. Could not read markdown file: {file_path}")
             return
         html = markdown.markdown(md_data, extensions=['tables', 'fenced_code'])
-        self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
-    
+        self.report_html_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+        self.report_markdown_item_list.append(ReportMarkdownItem(document_title, md_data))
+
     def append_csv(self, document_title: str, file_path: Path, css_classes: list[str] = []):
         """Append a CSV to the report."""
         df_data = self.read_csv_file(file_path)
@@ -138,13 +148,21 @@ class ReportGenerator:
         # Remove any completely empty rows or columns
         df = df_data.dropna(how='all', axis=0).dropna(how='all', axis=1)
         html = df.to_html(classes='dataframe', index=False, na_rep='')
-        self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+        self.report_html_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+
+        csv_text = df.to_csv(index=False)
+        markdown_content = f"```csv\n{csv_text}```"
+        self.report_markdown_item_list.append(ReportMarkdownItem(document_title, markdown_content))
 
     def append_html(self, document_title: str, file_path: Path, css_classes: list[str] = []):
-        """Append an HTML document to the report."""
+        """Append an HTML document to the report.
+
+        HTML-only: not added to the markdown report (the markdown output is intended for LLM consumption,
+        and embedded JavaScript/HTML widgets are not useful there).
+        """
         with open(file_path, 'r') as f:
             html_raw = f.read()
-        
+
         # Extract the html_head content between <!--HTML_HEAD_START--> and <!--HTML_HEAD_END-->
         html_head_match = re.search(r'<!--HTML_HEAD_START-->(.*)<!--HTML_HEAD_END-->', html_raw, re.DOTALL)
         if html_head_match:
@@ -152,16 +170,16 @@ class ReportGenerator:
             self.html_head_content.append(html_head)
         else:
             logging.warning(f"Document: '{document_title}'. Could not find HTML_HEAD_START and HTML_HEAD_END in {file_path}")
-        
+
         # Extract the html_body content between <!--HTML_BODY_CONTENT_START--> and <!--HTML_BODY_CONTENT_END-->
         html_body_match = re.search(r'<!--HTML_BODY_CONTENT_START-->(.*)<!--HTML_BODY_CONTENT_END-->', html_raw, re.DOTALL)
         if html_body_match:
             html_body = html_body_match.group(1)
-            self.report_item_list.append(ReportDocumentItem(document_title, html_body))
+            self.report_html_item_list.append(ReportDocumentItem(document_title, html_body))
         else:
             logging.warning(f"Document: '{document_title}'. Could not find HTML_BODY_CONTENT_START and HTML_BODY_CONTENT_END in {file_path}")
             # If no markers found, use the entire content as the body
-            self.report_item_list.append(ReportDocumentItem(document_title, html_raw, css_classes=css_classes))
+            self.report_html_item_list.append(ReportDocumentItem(document_title, html_raw, css_classes=css_classes))
 
         # Extract the html_body_script content between <!--HTML_BODY_SCRIPT_START--> and <!--HTML_BODY_SCRIPT_END-->
         html_body_script_match = re.search(r'<!--HTML_BODY_SCRIPT_START-->(.*)<!--HTML_BODY_SCRIPT_END-->', html_raw, re.DOTALL)
@@ -190,7 +208,8 @@ class ReportGenerator:
                 screening_raw = _json.load(f)
             if screening_raw.get("verdict") == "UNUSABLE":
                 reason = screening_raw.get("reason", "unknown")
-                rationale = escape(screening_raw.get("rationale", ""))
+                rationale_raw = screening_raw.get("rationale", "")
+                rationale = escape(rationale_raw)
                 reason_display = reason.replace("_", " ").title()
                 screening_banner_html = f"""
         <div class="prompt-quality-warning">
@@ -203,11 +222,18 @@ class ReportGenerator:
         </div>
 """
                 self.top_banner_html = screening_banner_html
+                self.top_banner_markdown = (
+                    f"> **⚠ Prompt Quality Warning**\n>\n"
+                    f"> The initial prompt was classified as **UNUSABLE** ({reason_display}). "
+                    f"This plan is likely to contain hallucinated or nonsensical content. Garbage in, garbage out.\n>\n"
+                    f"> {rationale_raw}"
+                )
         except Exception as e:
             logging.warning(f"Document: '{document_title}'. Could not read screening result: {e}")
 
         # The screening markdown contains markdown tables.
         screening_html = ""
+        screening_markdown = ""
         try:
             with open(screen_planning_prompt_markdown_file_path, 'r', encoding='utf-8') as f:
                 screening_markdown = f.read()
@@ -242,7 +268,30 @@ class ReportGenerator:
         <p>Why this fails.</p>
         {premise_attack_html}
         """
-        self.report_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+        self.report_html_item_list.append(ReportDocumentItem(document_title, html, css_classes=css_classes))
+
+        markdown_parts = [
+            "## Initial Prompt",
+            "",
+            "```text",
+            initial_prompt_raw,
+            "```",
+            "",
+            "## Prompt Screening",
+            "",
+            screening_markdown,
+            "",
+            "## Redline Gate",
+            "",
+            redline_gate_markdown,
+            "",
+            "## Premise Attack",
+            "",
+            "Why this fails.",
+            "",
+            premise_attack_markdown,
+        ]
+        self.report_markdown_item_list.append(ReportMarkdownItem(document_title, "\n".join(markdown_parts)))
 
     def generate_html_report(self, title: Optional[str] = None, execute_plan_section_hidden: bool = True) -> str:
         """Generate an HTML report from the gathered data."""
@@ -291,7 +340,7 @@ class ReportGenerator:
             </div>
             """)
 
-        for item in self.report_item_list:
+        for item in self.report_html_item_list:
             add_section(item.document_title, item.document_html_content, item.css_classes)
 
         html_content = '\n'.join(html_parts)
@@ -310,17 +359,51 @@ class ReportGenerator:
 
         return html
 
-    def save_report(self, output_path: Path, title: Optional[str] = None, execute_plan_section_hidden: bool = True) -> None:
-        """Generate and save the report."""
+    def save_html_report(self, output_path: Path, title: Optional[str] = None, execute_plan_section_hidden: bool = True) -> None:
+        """Generate and save the HTML report."""
         html_report = self.generate_html_report(
-            title=title, 
+            title=title,
             execute_plan_section_hidden=execute_plan_section_hidden
         )
-        
+
         with open(output_path, 'w', encoding='utf-8') as f:
             f.write(html_report)
-        
-        logger.info(f"Report generated successfully: {output_path}")
+
+        logger.info(f"HTML report generated successfully: {output_path}")
+
+    def generate_markdown_report(self, title: Optional[str] = None) -> str:
+        """Generate a markdown report from the gathered data.
+
+        Intended for LLM consumption: no JavaScript, no embedded HTML widgets.
+        """
+        resolved_title = title if title else "PlanExe Project Report"
+
+        parts: list[str] = []
+        parts.append(f"# {resolved_title}")
+        parts.append("")
+        parts.append(f"Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} with PlanExe.")
+        parts.append("")
+
+        if self.top_banner_markdown:
+            parts.append(self.top_banner_markdown)
+            parts.append("")
+
+        for item in self.report_markdown_item_list:
+            parts.append(f"# {item.document_title}")
+            parts.append("")
+            parts.append(item.document_markdown_content)
+            parts.append("")
+
+        return "\n".join(parts)
+
+    def save_markdown_report(self, output_path: Path, title: Optional[str] = None) -> None:
+        """Generate and save the markdown report."""
+        md_report = self.generate_markdown_report(title=title)
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(md_report)
+
+        logger.info(f"Markdown report generated successfully: {output_path}")
 
 def main():
     from worker_plan_internal.plan.filenames import FilenameEnum
@@ -348,7 +431,8 @@ def main():
         return
     
     output_path = input_path / FilenameEnum.REPORT_HTML.value
-    
+    markdown_output_path = input_path / FilenameEnum.REPORT_MARKDOWN.value
+
     report_generator = ReportGenerator()
     report_generator.append_markdown('Initial Plan', input_path / FilenameEnum.INITIAL_PLAN.value)
     report_generator.append_markdown('Pitch', input_path / FilenameEnum.PITCH_MARKDOWN.value)
@@ -357,7 +441,8 @@ def main():
     report_generator.append_markdown('Team', input_path / FilenameEnum.TEAM_MARKDOWN.value)
     report_generator.append_markdown('Expert Criticism', input_path / FilenameEnum.EXPERT_CRITICISM_MARKDOWN.value)
     report_generator.append_csv('Work Breakdown Structure', input_path / FilenameEnum.WBS_PROJECT_LEVEL1_AND_LEVEL2_AND_LEVEL3_CSV.value)
-    report_generator.save_report(output_path, title="Demo Project Report", execute_plan_section_hidden=False)
+    report_generator.save_html_report(output_path, title="Demo Project Report", execute_plan_section_hidden=False)
+    report_generator.save_markdown_report(markdown_output_path, title="Demo Project Report")
         
     if not args.no_browser:
         # Try to open the report in the default browser

--- a/worker_plan/worker_plan_internal/report/report_generator.py
+++ b/worker_plan/worker_plan_internal/report/report_generator.py
@@ -381,7 +381,11 @@ class ReportGenerator:
         parts: list[str] = []
         parts.append(f"# {resolved_title}")
         parts.append("")
-        parts.append(f"Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} with PlanExe.")
+        parts.append(
+            f"Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} with PlanExe. "
+            f"[Discord](https://planexe.org/discord.html), "
+            f"[GitHub](https://github.com/PlanExeOrg/PlanExe)"
+        )
         parts.append("")
 
         if self.top_banner_markdown:

--- a/worker_plan/worker_plan_internal/report/report_template.html
+++ b/worker_plan/worker_plan_internal/report/report_template.html
@@ -126,29 +126,6 @@
             transition: max-height 0.2s ease-out;
         }
 
-        /* The "Question/Answer" section */
-        .question-answer-pair {
-            margin-bottom: 20px; /* Adds vertical space between each Q&A pair */
-            padding-bottom: 15px; /* Adds space below the Answer text before the separator */
-            border-bottom: 1px solid #eee; /* Adds a subtle grey line to separate pairs */
-        }
-        .question-answer-pair:first-of-type {
-            padding-top: 10px;
-        }
-        .question-answer-pair:last-of-type {
-            margin-bottom: 0;
-            padding-bottom: 20px;
-            border-bottom: none;
-        }
-        .question-answer-pair p:first-child {
-            font-weight: bold; /* Ensures the whole Question line is bold */
-            margin-bottom: 10px; /* Adds a small space between the Question and the Answer */
-            color: #34495e; /* Optional: makes the question color slightly different */
-        }
-        .question-answer-pair p:last-child {
-            margin-top: 5px; /* Adds a small space between the Question and the Answer */
-            margin-bottom: 0; /* Removes default bottom margin from the last paragraph */
-        }
     </style>
     <!--HTML_HEAD_INSERT_HERE-->
 </head>


### PR DESCRIPTION
## Summary

`ReportTask` now writes `report.md` alongside `report.html`. The markdown report is intended for downstream LLM consumption — no JavaScript, no embedded HTML widgets, no expand/collapse UI.

### `ReportGenerator` changes
- `report_item_list` renamed to `report_html_item_list`; new parallel `report_markdown_item_list` of `ReportMarkdownItem(document_title, document_markdown_content)`.
- Each `append_*` populates both lists, except:
  - `append_html` (used for the **Gantt Interactive** section) populates HTML only — suppressed from markdown.
  - `append_csv` emits a fenced ` ```csv ` block to the markdown list (preserves columns; markdown tables get unwieldy at WBS scale).
  - `append_json` emits a fenced ` ```json ` block.
  - `append_markdown` / `append_markdown_with_tables` append the source markdown verbatim.
  - `append_initial_prompt_vetted` builds a markdown composite (Initial Prompt → Prompt Screening → Redline Gate → Premise Attack), plus a markdown variant of the Prompt Quality Warning banner.
- `save_report` renamed to `save_html_report`; new `save_markdown_report` and `generate_markdown_report`.
- Each section is wrapped with a top-level `# {document_title}` header (no expand/collapse since markdown has no such concept).

### Other changes
- `FilenameEnum.REPORT_MARKDOWN = "report.md"` added.
- `ReportTask.output()` becomes a dict with `'html'` and `'markdown'` keys.
- `ping_llm.py` updated to the new method names (`report_html_item_list`, `save_html_report`).
- `report_generator.py` `main()` writes both formats.

## Test plan
- [ ] CI passes
- [x] Smoke-tested `ReportGenerator` end-to-end with synthetic md/csv/json inputs — produces a valid `report.md` with `#` section headers, fenced ` ```csv ` and ` ```json ` blocks, and verbatim markdown source for markdown sections; HTML output continues to render correctly.