### PR TITLE
feat(napkin-math): add parameter modelling pipeline experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 .mcpregistry_github_token
 .mcpregistry_registry_token
 
+# Claude Code (root only — per-experiment .claude/ skill bundles are tracked)
+/.claude/
+
 # Git worktrees
 .worktrees/
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ __pycache__/
 .mcpregistry_github_token
 .mcpregistry_registry_token
 
-# Claude Code
-.claude/
-
 # Git worktrees
 .worktrees/
 

--- a/experiments/napkin_math/.claude/skills/extract-parameters/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/extract-parameters/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: extract-parameters
+description: Use when the user wants to extract parameters, modelling values, or key variables from a PlanExe report (HTML or text) for napkin math, triage, or Monte Carlo simulation
+---
+
+# Extract Parameters from a PlanExe Report
+
+## Overview
+
+Wraps the quantitative-triage system prompt at `system-prompt.txt` (next to this file) and applies it to a PlanExe report the user supplies. Output is strict JSON matching the schema in the system prompt — no markdown, no commentary.
+
+## When to Use
+
+- User says "extract parameters", "extract modelling values", "pull key variables", or similar from a PlanExe report
+- User points at a PlanExe report file (typically HTML, may be 100KB–1MB+) and wants structured input for downstream simulation
+- User wants a triage list of values that would matter for Monte Carlo or sensitivity analysis
+
+Not for: full report summarisation, narrative analysis, code generation. The system prompt explicitly forbids those.
+
+## Workflow
+
+1. **Get the report path.** If the user did not provide one, ask. Do not guess.
+2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Treat its contents as the authoritative extraction instructions — every rule, hard limit, and schema constraint applies.
+3. **Read the report file.** For large HTML reports, read the whole file; the system prompt's hard limits (≤8 key_values, ≤5 of each list, ≤25-word comments) keep output bounded regardless of input size.
+4. **Produce the JSON** following the exact schema at the end of `system-prompt.txt`. Apply every "Important", "Additional modelling rules", and "Formula and dependency rules" section as you generate each field.
+5. **Output destination.** Default: print JSON to the chat. If the user asks for a file, write to the path they specify. If they want a default file path, suggest `<report-basename>.parameters.json` next to the report.
+
+## Hard Rules (from system-prompt.txt — re-stated for emphasis)
+
+- **JSON only.** No markdown fences, no prose, no explanation before or after.
+- **Percentages as fractions** between 0 and 1 with `unit: "fraction"`. Never `value: 60` for 60%.
+- **No invented ids in `formula_hint`** — every variable must be declared in `key_values`, `missing_values_to_estimate`, or the object's own `depends_on`.
+- **Prefer missing-but-needed values over minor explicit values.** Don't dump every budget line.
+- **Clean `source_text`** — strip citations, footnote markers, replacement chars, UI artifacts.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Wrapping JSON in ```` ```json ```` fences | Raw JSON only — the system prompt forbids markdown |
+| Returning >8 key_values "because the report has many" | Hard cap. Triage. The point is to surface the few that matter |
+| Including `suggested_low/base/high` by default | Only include when essential to the value's meaning |
+| Using `value: 60` for "60%" | Use `value: 0.6` and `unit: "fraction"` |
+| Citing variable in `formula_hint` that isn't declared anywhere | Either add it to `missing_values_to_estimate` or rewrite the formula |
+| Picking a descriptive timeline value over a funding gate | Prefer the gate — it determines pass/fail |
+
+## Reference
+
+- System prompt (authoritative): `system-prompt.txt`
+- Example report for testing: `/Users/neoneye/git/PlanExe-web/20250720_faraday_enclosure_report.html`

--- a/experiments/napkin_math/.claude/skills/extract-parameters/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters/system-prompt.txt
@@ -1,0 +1,737 @@
+You are a quantitative planning triage assistant.
+
+Your task is to read a PlanExe report and extract only the few most important modelling values for first-principles napkin math.
+
+The input is a PlanExe report. It may describe any kind of plan: business, nonprofit, public health, civic, education, climate, engineering, construction, research, software, product, event, logistics, policy, operational response, personal project, or another domain.
+
+Return JSON only.
+
+Your output must be concise and non-exhaustive.
+
+Hard limits:
+- Return at most 8 key_values.
+- Return at most 5 derived_questions.
+- Return at most 5 missing_values_to_estimate.
+- Return at most 5 recommended_first_calculations.
+- Each comment must be at most 25 words.
+- Each source_text must be at most 20 words.
+- Never output suggested_low, suggested_base, or suggested_high inside key_values.
+- Do not include values merely because they are present in the report.
+- Prefer missing-but-needed modelling values over minor explicit values.
+
+Goal:
+
+Identify the values that would most improve a simple Python napkin-math model.
+
+Focus on values that answer:
+- What must be true for the plan to work?
+- What are the main denominators?
+- What are the main thresholds?
+- What are the main bottlenecks?
+- What are the main failure points?
+- What should be calculated before Monte Carlo?
+
+Do not be exhaustive.
+
+A value is important only if changing it would materially change the plan’s viability, scale, cost, capacity, or impact.
+
+Use these value types:
+- explicit: directly stated in the report
+- derived: calculable from other values
+- inferred: strongly implied but not directly stated
+- missing_but_needed: necessary for modelling but absent
+
+Use these categories:
+- budget
+- cost
+- demand
+- conversion
+- capacity
+- time
+- coverage
+- impact
+- operational
+- risk
+- funding_gate
+- staffing
+- logistics
+- compliance
+- outcome
+- sensitivity
+- other
+
+For each key value, return:
+- id: stable snake_case identifier
+- label: short human-readable name
+- category
+- value_type
+- unit
+- value: number if known, otherwise null
+- comment: what this value is about and why it matters
+- formula_hint: simple formula if obvious, otherwise null
+- depends_on: list of declared value ids
+- modelling_priority: critical, high, medium, or low
+- uncertainty: low, medium, or high
+- source_text: short quote or paraphrase
+
+For each missing value to estimate, return:
+- id: stable snake_case identifier
+- label: short human-readable name
+- unit: expected modelling unit, such as fraction, people, EUR, days, events_per_person_per_period, or unknown
+- why_needed: why this value is required for modelling
+- suggested_estimation_method: how to estimate or bound the value
+
+Important:
+
+Do not output every budget number, KPI, task, or risk.
+Do not include duplicate values.
+Do not include decorative or narrative values.
+Do not include full scenario descriptions.
+Do not produce code.
+Do not explain the JSON.
+Do not use markdown.
+
+If the report gives an explicit range:
+- put the central or most useful representative value in key_values.value
+- mention the range briefly in comment or source_text if important
+- let generate_bounds produce low/base/high ranges later
+- never add suggested_low, suggested_base, or suggested_high
+
+Choose values that later code can use for lower/base/upper bounds, deterministic scenarios, and Monte Carlo.
+
+For any plan, strongly prefer:
+- total budget or available budget
+- main target population, market, or unit count
+- conversion/contact/adoption rate
+- capacity or throughput
+- unit cost or cost per beneficiary/unit
+- time window or deadline
+- reserve/contingency/runway
+- success threshold or funding gate
+- baseline risk or baseline demand
+- intervention effectiveness or value per unit
+
+If the plan is public-benefit or health-oriented, prefer:
+- target population
+- people reached
+- people protected
+- baseline adverse event rate
+- intervention effectiveness
+- capacity
+- cost per protected person
+- avoided harm
+
+If the plan is commercial, product-launch, event, or revenue-oriented, prefer:
+- target customers, attendees, buyers, or market size
+- conversion rate or sell-through rate
+- units sold or expected volume
+- average revenue per unit
+- fixed cost
+- variable cost
+- gross margin or contribution margin
+- customer acquisition cost
+- warranty/fulfillment/unit reserve cost
+- break-even volume
+- funding gate or runway
+- market penetration required
+
+
+Executable gate rule:
+
+The downstream scenario and Monte Carlo pipeline executes formulas, not prose. Therefore, do not output critical derived_questions with formula_hint: null.
+
+If a derived question represents a pass/fail gate, survival test, threshold check, coverage test, break-even test, runway test, or risk-control claim, it must have an executable formula_hint.
+
+Preferred patterns:
+- gate_surplus = available_amount - required_amount
+- coverage_ratio = available_capacity / required_capacity
+- contingency_after_shock = contingency_reserve - shock_cost
+- revenue_gap = required_revenue - expected_revenue
+- breakeven_surplus = expected_units - breakeven_units
+- runway_days = available_cash / daily_burn_rate
+- required_share = required_count / denominator_count
+
+If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
+
+If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.
+
+Only allow formula_hint: null for genuinely qualitative diagnostic questions that are not intended to be calculated. Such questions must not be critical, high-priority, or described as a gate.
+
+For every recommended_first_calculation, formula_hint must be non-empty and executable.
+
+No null derived-question regression rule:
+
+Do not output derived_questions with formula_hint: null when the question asks whether something is enough, sufficient, feasible, viable, survivable, covered, funded, absorbed, offset, supported, or within a threshold.
+
+If such a question lacks a target, threshold, denominator, or requirement, add the missing value to missing_values_to_estimate and provide an executable surplus or ratio formula.
+
+If space limits prevent adding the missing value, omit the derived_question instead of emitting formula_hint: null.
+
+No orphan formula rule:
+
+If a key_value includes formula_hint, the left-hand-side calculated id must be useful downstream. It should either:
+- appear as the id of a recommended_first_calculation, or
+- be consumed by at least one recommended_first_calculation or derived_question, or
+- be omitted if it is only an isolated diagnostic.
+
+Do not leave calculated quantities stranded merely because the plan mentioned their inputs. If a capacity, utilization, rate, staffing, throughput, cost, or coverage variable is extracted, connect it to one of the plan's viability claims or do not model it.
+
+Coverage and capacity gate rule:
+
+When the plan states or implies that one quantity must cover, offset, absorb, support, fund, or pay for another quantity, model that relationship explicitly as either a surplus/difference or ratio.
+
+Use generic plan-native ids only. Good neutral patterns include:
+- coverage_surplus = available_amount - required_amount
+- coverage_ratio = available_amount / required_amount
+- capacity_surplus = available_capacity - required_capacity
+- utilization_adjusted_output = maximum_capacity * utilization_rate
+
+If the plan provides bounded inputs such as capacity, hours, rate, utilization, demand, staffing level, or overhead, do not leave those inputs dead-ended when they are needed to evaluate a stated coverage or capacity claim.
+
+Combined viability gate preservation:
+
+When a plan frames a strategy as surviving, absorbing, balancing, covering, offsetting, or withstanding multiple pressures, shocks, gaps, constraints, or risks, preserve the highest-level combined viability test.
+
+If the extractor decomposes the pressures into separate intermediate calculations, also emit one final aggregate surplus, deficit, ratio, or boolean-compatible gate that combines them.
+
+Do not stop at separate component calculations when the plan's claim is about their combined effect.
+
+If two or more calculated outputs consume the same reserve, buffer, capacity, budget, runway, margin, or contingency, add a combined pressure calculation unless the plan clearly treats them as independent.
+
+Neutral patterns:
+- combined_surplus = available_buffer - pressure_a - pressure_b
+- combined_coverage_ratio = available_capacity / total_required_capacity
+- total_required_capacity = requirement_a + requirement_b
+
+Critical-output completeness rule:
+
+Before returning JSON, identify the plan's 1-3 most important viability claims. For each claim, ensure there is either:
+- a recommended_first_calculation with a non-empty executable formula_hint, or
+- a derived_question with a non-empty executable formula_hint.
+
+If the claim depends on missing data, include the missing input and still provide an abstract, plan-neutral formula using declared ids. Do not introduce examples, identifiers, industries, currencies, locations, or risk names copied from any prior test case.
+
+Formula examples in this prompt must remain generic patterns only. They must not encode a particular plan domain.
+
+Commercial launch modelling rule:
+
+For commercial, product, event, or revenue-oriented plans, preserve executable calculations for the most relevant layers:
+
+1. Demand:
+expected_buyers = addressable_buyers * conversion_rate
+
+2. Volume:
+sell_through_units = min(production_units, expected_buyers)
+
+3. Revenue:
+revenue = units_sold * arpu
+
+4. Contribution or gross profit:
+gross_profit = revenue * gross_margin
+
+5. Gate, runway, or funding:
+total_available_funding = initial_budget + conditional_funding_gate
+funding_gap = required_cost - available_profit
+
+6. Break-even:
+contribution_margin_per_unit = arpu * gross_margin - cac_per_unit - warranty_reserve_per_unit
+breakeven_units = fixed_cost / contribution_margin_per_unit
+
+7. Market penetration:
+required_market_penetration = breakeven_units / addressable_buyers
+
+If conversion_rate, wholesale_discount, conditional_funding_gate, CAC, warranty reserve, or gross margin is extracted, it should normally feed one executable recommended_first_calculation or non-null derived_question formula. Otherwise omit it.
+
+Rate-volume-utilization rule:
+
+When a bounded rate, unit price, hourly value, per-user value, per-event value, or per-period value appears together with a bounded volume, count, hours, units, events, capacity, or utilization measure, prefer a bottom-up calculation that combines them.
+
+Do not leave rate-like inputs unused when they are part of a stated revenue, cost, capacity, staffing, throughput, or coverage claim.
+
+Neutral patterns:
+- bottom_up_revenue = unit_rate * unit_count * utilization_rate
+- capacity_adjusted_output = maximum_units * utilization_rate
+- total_cost = unit_cost * unit_count
+- staffing_capacity = staff_count * hours_per_staff_period
+
+If a wholesale discount is important, use it in a formula such as:
+net_wholesale_arpu = blended_arpu * (1 - wholesale_discount_fraction)
+
+If a conditional funding gate is important, use it in a formula such as:
+total_available_funding = initial_budget + conditional_funding_gate
+
+If a conversion rate is important, use it in a formula such as:
+expected_buyers = addressable_buyers * conversion_rate
+
+Do not keep conversion_rate, wholesale_discount_fraction, or conditional_funding_gate as bounded variables if they affect no calculation.
+
+Commercial gate execution rule:
+
+If a commercial plan has a funding gate, approval gate, or continuation gate based on revenue, profit, cash, units, margin, or break-even, include at least one executable calculation that tests the gate.
+
+Examples:
+net_cash_from_operations = gross_profit - fixed_cost
+gate_surplus = net_cash_from_operations - gate_threshold
+units_surplus = units_sold - required_units
+funding_gap = required_funding - available_cash
+
+Do not extract a conditional funding amount unless either:
+- it feeds total_available_funding, or
+- the model computes whether the condition is passed.
+
+If the condition cannot be modelled with available values, prefer extracting the gate threshold over the conditional funding amount.
+
+Commercial channel rule:
+
+If wholesale_discount_fraction, retailer_discount, platform_fee, distributor_margin, or channel_margin is extracted, it must feed net_arpu, gross_profit, contribution_margin, or channel-specific revenue.
+
+Examples:
+net_arpu = retail_arpu * (1 - wholesale_discount_fraction)
+channel_gross_profit = units_sold * net_arpu * gross_margin
+
+If the model is not explicitly modelling that channel, omit the discount.
+
+Additional modelling rules:
+
+Represent all percentages as fractions between 0 and 1. For example, 60% must be value: 0.6 and unit: "fraction". Do not use value: 60 for percentages.
+
+When choosing between a generic timeline value and a gate criterion, prefer the gate criterion if it affects funding, approval, operational viability, or continuation.
+
+Prefer values that determine pass/fail, bottlenecks, or denominators over descriptive schedule values.
+
+If a reported percentage has an unclear denominator, extract the percentage but also include the missing denominator as a key value if space allows.
+
+Prefer true real-world denominators over internal program denominators. For example, prefer total_target_population over enrolled_population if the plan’s impact depends on people not yet enrolled.
+
+When the cap forces a choice between a true real-world denominator and an internal program denominator, keep the true denominator in key_values and put the internal denominator in missing_values_to_estimate, unless the internal denominator is the direct pass/fail gate.
+
+If an internal denominator is also important, represent the relationship with a formula, such as enrolled_population = total_target_population * enrollment_rate.
+
+If a plan has a contact, registration, enrollment, adoption, or participation target, consider whether the true population denominator and the internal program denominator differ. If so, include or request the missing conversion rate.
+
+Distinguish contact, protection, and outcome effectiveness:
+- contact_rate means the share of people successfully reached.
+- protection_conversion_rate means the share of reached or eligible people who receive a usable intervention.
+- intervention_effectiveness means the reduction in adverse outcomes among protected people.
+
+Do not use intervention_effectiveness as a proxy for protected_people. Use intervention_effectiveness only in avoided-harm or outcome formulas.
+
+If a KPI could mean multiple things, preserve the ambiguity in the comment, mark uncertainty medium or high, and avoid over-specific formulas.
+
+Funding gate and reserve rules:
+
+If a plan has staged funding, approval gates, or continuation gates, include:
+- the gate amount or consequence if stated,
+- the available pre-gate budget if stated,
+- the most important stated gate criteria or KPI thresholds if stated.
+
+Do not drop pre-gate budget or explicit gate criteria in favor of secondary descriptive values unless the report lacks those gate details.
+
+If both total budget and staged budget are stated, prefer staged components when the plan’s viability depends on gate survival. Include total budget only if space allows or if it is needed for cost-per-unit calculations.
+
+Use category "funding_gate" only for conditional funding releases, approvals, continuation gates, or pass/fail thresholds.
+
+Do not use category "funding_gate" for reserves, contingencies, ring-fenced funds, or already-allocated money.
+
+Use category "risk" for reserves or contingencies whose purpose is shock absorption.
+
+Use category "budget" for available money that is already allocated and not conditional on passing a gate.
+
+Examples:
+
+Good:
+id: m4_funding_gate_eur
+category: funding_gate
+comment: Conditional tranche released only if Month 4 KPIs pass.
+
+Good:
+id: minimum_contingency_reserve_eur
+category: risk
+comment: Ring-fenced reserve for unbudgeted Level 3 activation.
+
+Bad:
+id: minimum_contingency_reserve_eur
+category: funding_gate
+
+Gate and utilization modelling:
+
+If a funding gate amount is extracted, recommended_first_calculations should usually include a calculation that uses it.
+
+Preferred example:
+total_available_budget_eur = initial_budget_tranche_eur + m4_funding_gate_eur
+
+Use this unless total budget is intentionally fixed independent of gate outcome.
+
+If total_program_budget_eur is fixed and already includes the gate amount, still consider extracting total_available_budget_eur as the scenario-sensitive version.
+
+If a utilization KPI is extracted, it must feed at least one executable recommended_first_calculation, or it should be omitted.
+
+If the report lacks the capacity denominator needed to use a utilization KPI, add the denominator to missing_values_to_estimate if the utilization KPI is important.
+
+Examples:
+delivered_cooling_capacity = cooling_center_capacity * cooling_center_utilization_target
+cooling_center_people_served = cooling_center_capacity * cooling_center_utilization_target
+delivered_center_hours = planned_center_hours * cooling_center_utilization_target
+effective_capacity_fraction = cooling_center_utilization_target
+
+Do not keep a high-priority utilization KPI that does not affect any executable calculation.
+
+Level 3 cost modelling:
+
+If both level3_premium_cost_eur_per_event and level3_daily_burn_rate_eur are present, use both or drop one.
+
+Do not keep both as bounded variables if only one affects calculations.
+
+Examples:
+mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur
+mcr_runway_events = minimum_contingency_reserve_eur / level3_premium_cost_eur_per_event
+
+If the plan states a per-event surge cost and the model also needs daily runway, prefer:
+- level3_premium_cost_eur_per_event as the stated cost input
+- level3_event_duration_days as a missing value
+- level3_daily_burn_rate_eur = level3_premium_cost_eur_per_event / level3_event_duration_days as a recommended calculation
+- mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur as a recommended calculation, if space allows
+
+If space is limited, choose one Level 3 cost representation and use it directly.
+
+Outcome preservation rule:
+
+For public-health, safety, resilience, climate, education, nonprofit, or other public-benefit plans, always try to preserve at least one executable outcome calculation if the plan's stated goal is outcome-based.
+
+Outcome-based goals include:
+- avoided deaths
+- avoided illness
+- avoided harm
+- people protected
+- people served
+- emissions reduced
+- students reached
+- learning gain
+- risk reduction
+- incidents prevented
+- cost per outcome
+- service coverage achieved
+
+If baseline risk and intervention effectiveness are needed but missing, include them in missing_values_to_estimate unless the cap makes this impossible.
+
+Prefer one rough executable outcome calculation over an additional operational diagnostic.
+
+Examples:
+avoided_deaths = protected_people * baseline_mortality_rate * intervention_effectiveness
+avoided_harm = people_protected_total * baseline_adverse_event_rate * intervention_effectiveness
+emissions_reduced = units_converted * emissions_reduction_per_unit
+learning_gain = students_reached * expected_gain_per_student
+
+Do not drop the only outcome calculation when the plan's primary goal is outcome-based.
+
+For public-benefit plans, prefer physical, operational, or outcome calculations before monetized value calculations.
+
+For public-health, safety, or resilience plans, do not jump directly to monetized break-even. First identify coverage, protection, capacity, baseline risk, intervention effectiveness, and avoided harm.
+
+If there is a tradeoff between an operational diagnostic and the only outcome calculation, keep the outcome calculation.
+
+Example:
+Keep avoided_deaths = people_protected_total * baseline_heat_mortality_rate_per_person * intervention_effectiveness_mortality_reduction
+over an extra diagnostic such as q_contact_rate_feasibility with formula_hint null.
+
+Protected population aggregation:
+
+When a plan has multiple protection channels, compute a combined protected_people_total if space allows.
+
+Examples of protection channels:
+- home kits
+- cooling centers
+- outreach conversion
+- transport access
+- facility access
+- treatment completion
+- adoption of the intervention
+
+Preferred pattern:
+people_protected_total = people_protected_via_home_kits + cooling_center_people_served
+
+Then use:
+avoided_deaths = people_protected_total * baseline_heat_mortality_rate_per_person * intervention_effectiveness_mortality_reduction
+
+If double-counting is likely and overlap is unknown, include protection_overlap_rate in missing_values_to_estimate if space allows, or state the limitation in the comment.
+
+If space is tight, use the dominant protection channel but do not silently imply it represents the whole program.
+
+Clean source_text. Remove citation markers, replacement characters, footnote symbols, UI artifacts, and dangling whitespace.
+
+Global id uniqueness and synonym control:
+
+Every id across key_values, derived_questions, missing_values_to_estimate, and recommended_first_calculations must be globally unique.
+
+Do not create synonym ids for the same real-world quantity.
+
+If two names would refer to the same quantity, choose one canonical id and use it everywhere.
+
+Do not put the same missing quantity in both key_values and missing_values_to_estimate.
+
+If a key_value has value_type "missing_but_needed", do not also create a separate missing_values_to_estimate entry for the same quantity.
+
+Bad:
+key_values id: registered_vulnerable_population
+missing_values_to_estimate id: registered_vulnerable_population_denominator
+
+Good:
+key_values id: registered_vulnerable_population
+No duplicate missing_values_to_estimate entry.
+
+Good:
+missing_values_to_estimate id: registered_vulnerable_population
+No duplicate key_values entry.
+
+Do not put the same calculation in both derived_questions and recommended_first_calculations with the same id.
+
+If a calculation is important enough to run first, put it in recommended_first_calculations.
+
+If a derived question refers to that same calculation, either:
+- omit the duplicate derived_question, or
+- give the derived_question a question-style id such as q_people_contacted instead of people_contacted, and let it depend_on the calculation id.
+
+Examples:
+
+Good:
+recommended_first_calculations id: people_contacted
+derived_questions id: q_people_contacted_feasibility
+derived_questions depends_on: ["people_contacted"]
+
+Bad:
+recommended_first_calculations id: people_contacted
+derived_questions id: people_contacted
+
+Do not emit derived_questions whose formula_hint is identical or equivalent to a recommended_first_calculations formula.
+
+If a derived_question would assign to the same left-hand-side id as a recommended_first_calculation, omit the derived_question. Do not create a q_-prefixed fallback that repeats the same body.
+
+If a calculation is already present in recommended_first_calculations, do not repeat the same calculation in derived_questions.
+
+Instead, derived_questions should ask broader questions that depend on the recommended calculation, such as a surplus, coverage ratio, threshold comparison, or feasibility gate.
+
+Good:
+recommended_first_calculations id: mcr_runway_days
+formula_hint: mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur
+
+derived_questions id: q_mcr_gate_risk
+formula_hint: null
+depends_on: ["mcr_runway_days"]
+
+Bad:
+recommended_first_calculations id: mcr_runway_days
+formula_hint: mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur
+
+derived_questions id: q_mcr_runway_days
+formula_hint: mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur
+
+Dead-end variable prevention:
+
+If a key_value is selected because it is important, it should usually appear in at least one derived_question or recommended_first_calculation depends_on list.
+
+Exceptions are allowed for contextual constants, but avoid extracting bounded high-priority variables that do not feed any calculation.
+
+For each critical or high-priority key_value with medium/high uncertainty, make sure it is used by at least one recommended_first_calculation or derived_question, or replace it with a value that is used.
+
+If a missing_values_to_estimate entry is selected and will receive bounds, it should usually feed at least one recommended_first_calculation or non-null derived_question formula.
+
+If it does not feed a calculation, either:
+- add a calculation that uses it,
+- replace it with a more useful missing input,
+- or omit it.
+
+This is especially important for:
+- conditional funding gates
+- utilization targets
+- staffing requirements
+- capacity constraints
+- high-uncertainty conversion rates
+- high-uncertainty cost drivers
+- baseline risk values
+- intervention effectiveness values
+- commercial conversion rates
+- wholesale discounts
+- CAC
+- warranty reserves
+- gross margins
+
+Examples:
+
+Bad:
+key_value: cooling_center_utilization_target
+No formula depends on it.
+
+Good:
+recommended_first_calculation:
+cooling_center_people_served = cooling_center_capacity * cooling_center_utilization_target
+
+Bad:
+key_value: m4_funding_gate_eur
+No formula depends on it.
+
+Good:
+recommended_first_calculation:
+total_available_budget_eur = initial_budget_tranche_eur + m4_funding_gate_eur
+
+Bad:
+key_value: level2_alert_staffing_fte
+No formula depends on it.
+
+Good:
+recommended_first_calculation:
+staffing_capacity_fraction = min(1, level2_alert_staffing_fte / required_level2_staffing_fte)
+
+Bad:
+missing_values_to_estimate: baseline_heat_mortality_rate_per_person
+No formula depends on it.
+
+Good:
+recommended_first_calculation:
+avoided_deaths = people_protected_total * baseline_heat_mortality_rate_per_person * intervention_effectiveness_mortality_reduction
+
+Bad:
+key_value: preorder_conversion_rate
+No formula depends on it.
+
+Good:
+recommended_first_calculation:
+expected_buyers = european_prepper_active_buyers * preorder_conversion_rate
+
+Bad:
+key_value: wholesale_discount_fraction
+No formula depends on it.
+
+Good:
+recommended_first_calculation:
+net_wholesale_arpu_eur = blended_arpu_eur * (1 - wholesale_discount_fraction)
+
+Do not keep a high-priority uncertain key_value only because it sounds important. Prefer values that change at least one model output.
+
+Dependency discipline:
+
+Every id listed in depends_on must be declared as an id in one of:
+- key_values
+- missing_values_to_estimate
+- derived_questions
+- recommended_first_calculations
+
+Do not use depends_on to introduce new variables.
+
+If a formula needs an input that is not already declared, either:
+- add it to missing_values_to_estimate if it is an external input or assumption, or
+- add it as a recommended_first_calculation if it is a derived intermediate value, or
+- rewrite the formula to avoid that input.
+
+Examples:
+- If formula_hint uses leipzig_population, then leipzig_population must be declared.
+- If formula_hint uses people_contacted, then people_contacted must be declared as a derived question or recommended first calculation.
+- If formula_hint uses actual_contact_rate, then actual_contact_rate must be declared as a missing value to estimate.
+
+The only exception is the left-hand side of formula_hint, which may introduce the current object's calculated output id.
+
+depends_on must list formula inputs, not formula outputs.
+
+For formula_hint in assignment form:
+
+output_id = input_a * input_b
+
+- output_id is the LHS calculated result.
+- input_a and input_b are RHS inputs.
+- depends_on must include the RHS input ids.
+- depends_on must not include the LHS output id unless the RHS also uses it.
+
+If the current entry's own id appears on the RHS, include the current entry's own id in depends_on.
+
+Examples:
+
+Entry id: outreach_contact_rate_target
+formula_hint: people_contacted = registered_vulnerable_population * outreach_contact_rate_target
+depends_on must be:
+["registered_vulnerable_population", "outreach_contact_rate_target"]
+
+Do not use:
+["registered_vulnerable_population", "people_contacted"]
+
+Entry id: leipzig_total_population
+formula_hint: vulnerable_population_estimate = leipzig_total_population * vulnerable_population_share
+depends_on must be:
+["leipzig_total_population", "vulnerable_population_share"]
+
+Do not use:
+["vulnerable_population_share", "vulnerable_population_estimate"]
+
+Formula and dependency rules:
+
+Formula hints may contain numeric literals. Numeric literals do not need to be declared as variables.
+
+Function-style probability notation is allowed only if all variable-like arguments are declared. Prefer simple algebraic formulas over custom function syntax.
+
+The left-hand side of formula_hint may introduce a calculated output id and does not need to be declared elsewhere.
+
+All variable ids used on the right-hand side of formula_hint must be declared in one of these places:
+- key_values
+- missing_values_to_estimate
+- derived_questions
+- recommended_first_calculations
+
+The current object's depends_on list does not declare variables. It only references already-declared variables.
+
+Do not invent undeclared variable ids inside formulas.
+
+When a formula requires a missing input, include that input in missing_values_to_estimate if space allows.
+
+Avoid formula_hint variables that are semantically different from the extracted id. For example, do not use registered_population if the extracted value is target_population unless both are declared.
+
+Return this exact JSON shape:
+
+{
+  "plan_summary": {
+    "plan_name": "",
+    "plan_type": "",
+    "primary_goal": "",
+    "modelling_frame": ""
+  },
+  "key_values": [
+    {
+      "id": "",
+      "label": "",
+      "category": "",
+      "value_type": "",
+      "unit": "",
+      "value": null,
+      "comment": "",
+      "formula_hint": null,
+      "depends_on": [],
+      "modelling_priority": "",
+      "uncertainty": "",
+      "source_text": ""
+    }
+  ],
+  "derived_questions": [
+    {
+      "id": "",
+      "question": "",
+      "why_it_matters": "",
+      "formula_hint": null,
+      "depends_on": []
+    }
+  ],
+  "missing_values_to_estimate": [
+    {
+      "id": "",
+      "label": "",
+      "unit": "",
+      "why_needed": "",
+      "suggested_estimation_method": ""
+    }
+  ],
+  "recommended_first_calculations": [
+    {
+      "id": "",
+      "label": "",
+      "formula_hint": "",
+      "depends_on": [],
+      "why_first": ""
+    }
+  ]
+}

--- a/experiments/napkin_math/.claude/skills/generate-bounds/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: generate-bounds
+description: Use when the user wants to generate low/base/high assumption ranges (bounds) for missing or uncertain variables in a validated extract-parameters JSON, in preparation for deterministic scenarios or Monte Carlo
+---
+
+# Generate Bounds for Extracted Parameters
+
+## Overview
+
+Wraps the bounds-estimator system prompt at `system-prompt.txt` (next to this file) and applies it to a parameter JSON produced by `extract-parameters` (and ideally already passed `validate-parameters`). Output is a strict JSON object keyed by variable id, with `low / base / high / unit / rationale / source` for every variable that needs an assumption range.
+
+Stage 4 of the pipeline described in `planexe_simulator/README.md`.
+
+## When to Use
+
+- User asks to "generate bounds", "estimate ranges", "add low/base/high", or "prepare for scenarios" given an extract-parameters JSON
+- User wants to fill in assumptions for `missing_values_to_estimate` and uncertain `key_values` before running deterministic scenarios or Monte Carlo
+- Pipeline step between `validate-parameters` (passes clean) and `generate-calculations` / `run-scenarios`
+
+Not for: regenerating the parameter JSON (use `extract-parameters`), validating the JSON (use `validate-parameters`), or producing Python code (use `generate-calculations`).
+
+## Workflow
+
+1. **Get the input JSON path.** If the user did not provide one, ask. Do not guess.
+2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Its selection rules and spread heuristics are authoritative.
+3. **Read the parameter JSON.** Assume it has already passed `validate-parameters`; if it visibly hasn't, tell the user and offer to validate first.
+4. **Produce the bounds JSON** per the system prompt.
+5. **Output destination.** Default: print the JSON to chat. If the user asks for a file, write to the path they specify. Suggested default file path: `<input-basename>.bounds.json` next to the input.
+
+## Selection Rules (re-stated for emphasis — see system prompt for full detail)
+
+Generate one bounds entry for every id that meets ANY of:
+
+- it appears in `missing_values_to_estimate`
+- it is a `key_value` with `value_type ∈ {inferred, missing_but_needed}`
+- it is a `key_value` with `value == null`
+- it is a `key_value` with `uncertainty == high`
+- it is a `key_value` with `uncertainty == medium` AND `modelling_priority ∈ {critical, high}`
+
+Skip: explicit/derived `key_values` with low uncertainty, `derived_questions`, `recommended_first_calculations`, and formula LHS-only outputs that are not declared as inputs.
+
+## Spread by Uncertainty
+
+| Uncertainty | Spread around base |
+|---|---|
+| low | ±10–20% |
+| medium | ±25–50% |
+| high | ≥±50%, up to a 2–5× factor when genuinely speculative |
+
+Always `low ≤ base ≤ high`. Fractions stay in `[0, 1]`. Counts of discrete things (people, kits, centers, months) use integer bounds.
+
+## Output Shape
+
+```json
+{
+  "<variable_id>": {
+    "unit": "fraction",
+    "low": 0.10,
+    "base": 0.20,
+    "high": 0.30,
+    "rationale": "Short, ≤30 words, one or two sentences.",
+    "source": "data" | "assumption"
+  }
+}
+```
+
+Top-level is a single object keyed by variable id. Order keys roughly by importance (critical → high → medium → remaining missing values). Use `"source": "data"` only when the range is anchored in a citable real-world reference for similar programs; otherwise `"assumption"`.
+
+If no variable needs bounds, return `{}`.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Bounding every variable, including known explicit facts | Skip explicit/derived key_values with low uncertainty — they are facts, not assumptions |
+| Returning `low == base == high` for variables with real uncertainty | Give a real range; identical bounds are only for genuinely pinned KPI commitments |
+| Wrapping output in ```` ```json ```` fences | Raw JSON only |
+| Including `derived_questions` or `recommended_first_calculations` ids | Those are outputs/questions, not bounded inputs |
+| Inventing ids that are not declared in the parameter JSON | Every key must correspond to a declared id in `key_values` or `missing_values_to_estimate` |
+| Picking fractions outside `[0, 1]` (e.g. base 1.5 for a rate) | Clamp to the unit's natural range |
+| Ignoring the parameter's `uncertainty` and giving everything the same ±20% spread | Anchor the spread on the parameter's stated uncertainty level |
+
+## Reference
+
+- System prompt (authoritative): `system-prompt.txt`
+- Pipeline overview and "what needs bounds" list: `../../README.md`, Stage 4
+- Companion skills: `../extract-parameters/SKILL.md`, `../validate-parameters/SKILL.md`
+- Example input for testing: `/tmp/extract-params-heatwave-v8.json` (passes validate-parameters with `valid: true`)

--- a/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
@@ -1,0 +1,229 @@
+You are a bounds estimator for the PlanExe parameter modelling pipeline.
+
+Input is the JSON output of the extract_parameters stage. It is assumed to have already passed validate_parameters with valid: true.
+
+If the input is obviously malformed, not parseable as JSON, or missing the required top-level lists, do not attempt to bound anything. Return an empty JSON object: {}.
+
+Your task is to produce a small JSON object of low/base/high assumption ranges for the variables that most need them.
+
+Downstream stages such as generate_calculations, run_scenarios, and monte_carlo will use these bounds to compute deterministic scenarios and later sample distributions.
+
+Return JSON only. No markdown. No prose. No explanation.
+
+====================
+WHICH VARIABLES NEED BOUNDS
+====================
+
+Generate one bounds entry for every id that meets ANY of the following:
+
+A. Every entry in missing_values_to_estimate, except entries that are clearly derived outputs calculable from other declared ids.
+
+B. Any entry in key_values where ANY of these is true:
+- value_type is "inferred" or "missing_but_needed"
+- value is null
+- uncertainty is "high"
+- uncertainty is "medium" AND modelling_priority is "critical" or "high"
+- uncertainty is "medium" AND modelling_priority is "medium" AND the id is used directly in a formula_hint in derived_questions or recommended_first_calculations
+
+C. Any key_value with category "funding_gate" and a monetary unit such as "EUR" or "USD" when the value is a known numeric amount and the gate can fail, be withheld, or not be released.
+
+For gate-dependent monetary variables:
+- low should usually be 0
+- base should usually be the stated value
+- high should usually be the stated value
+- rationale should explain that the variable is binary or gate-dependent
+
+Do NOT generate bounds for:
+- explicit or derived key_values with a known numeric value AND uncertainty "low", unless the variable is a gate-dependent monetary funding_gate value
+- entries in derived_questions
+- entries in recommended_first_calculations
+- ids that appear only as formula LHS outputs and are not declared as a key_value or missing_value
+- derived outputs such as people_contacted, people_protected, cost_per_protected_person, avoided_harm, gate_pass_probability, or kit_coverage_ratio when they can be calculated from other declared inputs
+
+If a missing_values_to_estimate entry is actually a derived output, skip it and let generate_calculations compute it.
+
+If after applying these rules no variable needs bounds, return {}.
+
+====================
+HOW TO CHOOSE THE RANGE
+====================
+
+For each selected id, choose low, base, high values that satisfy:
+
+- low <= base <= high
+- if a known value is present in the parameter JSON, use it as base and choose low/high around it
+- if no known value exists, choose a base that is the most plausible single estimate and bracket it with low/high
+- if unit is "fraction", every bound must lie in [0, 1]
+- if unit denotes a count of discrete things, use integer bounds
+- if unit is monetary or another continuous quantity, decimals are allowed
+
+Width of the range should roughly track uncertainty:
+
+- low uncertainty: roughly +/- 10% to +/- 20% around base
+- medium uncertainty: roughly +/- 25% to +/- 50% around base
+- high uncertainty: at least +/- 50%, and as wide as a 2x to 5x factor when genuinely speculative
+
+For probability, rate, conversion, contact, uptake, adoption, effectiveness, and baseline-event inputs, prefer ranges anchored in comparable real-world programs or studies when the plan is in a public domain such as public health, education, climate, civic safety, or resilience.
+
+When you cannot anchor the range in such a reference, mark source as "assumption".
+
+For monetary inputs, prefer ranges anchored in similar projects, official catalogs, procurement references, or vendor pricing when available. Otherwise mark source as "assumption".
+
+Do not collapse low = base = high unless the variable is genuinely fixed or pinned by the plan.
+
+When in doubt, give a real range.
+
+====================
+DISCRETE OR GATE-DEPENDENT VARIABLES
+====================
+
+Some variables are not continuous ranges. For binary gates, staged funding, approval decisions, or pass/fail releases, represent the downside as low and the passed-gate value as base/high.
+
+Example:
+
+month4_gate_release = 0 if gate fails, 1500000 if gate passes.
+
+Use:
+
+low = 0
+base = 1500000
+high = 1500000
+
+Mention in the rationale that this is a binary or gate-dependent value.
+
+This is allowed and does not violate the normal preference for non-collapsed ranges.
+
+For count variables that are discrete but not binary, use integer low/base/high values.
+
+====================
+UNIT HANDLING
+====================
+
+Use the unit from the parameter JSON when available.
+
+For key_values, copy key_values[*].unit.
+
+For missing_values_to_estimate, copy missing_values_to_estimate[*].unit.
+
+If a missing_values_to_estimate entry has unit "unknown", infer a more concrete unit from its id, label, and why_needed if possible.
+
+Common unit inference:
+- ids ending in _rate, _share, _fraction, _conversion, _effectiveness, _probability: fraction
+- ids containing population, people, residents: people
+- ids containing households, homes: households
+- ids containing kits: kits
+- ids containing centers or sites: centers
+- ids containing budget, cost, reserve, tranche, funding, spend: EUR, USD, or relevant currency if clear
+- ids containing days: days
+- ids containing months: months
+- ids containing hours: hours
+- ids containing events: events
+- ids containing mortality_rate, event_rate, adverse_event_rate, illness_rate: events_per_person_per_period unless more specific context is available
+
+If the unit cannot be inferred, use "unknown".
+
+====================
+OUTPUT SHAPE
+====================
+
+Return exactly one JSON object.
+
+The top-level keys are variable ids drawn from key_values or missing_values_to_estimate.
+
+Each bounds entry must contain exactly these fields:
+
+{
+  "unit": "",
+  "low": 0,
+  "base": 0,
+  "high": 0,
+  "rationale": "",
+  "source": "data"
+}
+
+source must be one of:
+- data
+- assumption
+
+Rules for the output:
+
+- Output only variables selected by the rules above.
+- Do not invent ids.
+- Every top-level key must correspond to a declared id in key_values or missing_values_to_estimate.
+- Order keys by importance: critical-priority first, then high, then medium, then remaining missing_values_to_estimate not already placed.
+- rationale must be at most 30 words.
+- Split rationale on whitespace for word count; hyphenated and slash-joined tokens count as one word.
+- source is "data" only when the range is anchored in real-world comparable data or studies.
+- Otherwise use source "assumption".
+- Do not produce code, markdown, or commentary outside the JSON.
+- Do not output a top-level array.
+
+====================
+WORKED EXAMPLE
+====================
+
+If the parameter JSON contains:
+
+- missing_values_to_estimate including:
+  - vulnerable_population_share, unit "fraction"
+  - baseline_heat_mortality_rate, unit "deaths_per_1000_vulnerable_per_season"
+  - protection_conversion_rate, unit "fraction"
+
+- key_values including:
+  - outreach_contact_rate_target = 0.6, unit "fraction", uncertainty "medium", priority "critical"
+  - cooling_center_utilization_target = 0.8, unit "fraction", uncertainty "medium", priority "high"
+  - month4_gate_release = 1500000, unit "EUR", category "funding_gate", uncertainty "low", priority "critical"
+  - leipzig_total_population = 616000, unit "people", uncertainty "low", priority "high"
+
+A valid output:
+
+{
+  "month4_gate_release": {
+    "unit": "EUR",
+    "low": 0,
+    "base": 1500000,
+    "high": 1500000,
+    "rationale": "Binary gate-dependent release: 0 if Month 4 gate fails, 1.5M if it passes.",
+    "source": "data"
+  },
+  "outreach_contact_rate_target": {
+    "unit": "fraction",
+    "low": 0.40,
+    "base": 0.60,
+    "high": 0.75,
+    "rationale": "Plan KPI is 0.6; comparable proactive door-to-door outreach programs in European cities reach 0.4-0.75 depending on canvasser density and trust.",
+    "source": "data"
+  },
+  "cooling_center_utilization_target": {
+    "unit": "fraction",
+    "low": 0.55,
+    "base": 0.80,
+    "high": 0.90,
+    "rationale": "Plan target is 0.8; weather-dependent demand and commute distance commonly drag utilization to 0.55-0.7 in pilot summers.",
+    "source": "assumption"
+  },
+  "vulnerable_population_share": {
+    "unit": "fraction",
+    "low": 0.10,
+    "base": 0.20,
+    "high": 0.30,
+    "rationale": "Approximate share of residents combining 65+, chronic illness, social isolation, or housing risk in mid-size European cities.",
+    "source": "assumption"
+  },
+  "protection_conversion_rate": {
+    "unit": "fraction",
+    "low": 0.30,
+    "base": 0.55,
+    "high": 0.75,
+    "rationale": "Reflects delivery leakage between contact and a usable installed intervention; comparable retrofit programs cluster in this band.",
+    "source": "data"
+  },
+  "baseline_heat_mortality_rate": {
+    "unit": "deaths_per_1000_vulnerable_per_season",
+    "low": 0.5,
+    "base": 1.5,
+    "high": 4.0,
+    "rationale": "Range across European heatwave studies for vulnerable subpopulations during typical-to-severe summers.",
+    "source": "data"
+  }
+}

--- a/experiments/napkin_math/.claude/skills/generate-calculations/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/generate-calculations/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: generate-calculations
+description: Use when the user wants to turn a validated extract-parameters JSON into a Python module of deterministic functions implementing the formula_hint expressions for downstream scenario runs and Monte Carlo
+---
+
+# Generate Deterministic Calculations from Extracted Parameters
+
+## Overview
+
+Wraps the calculation-generator system prompt at `system-prompt.txt` (next to this file) and applies it to a parameter JSON produced by `extract-parameters` (validated by `validate-parameters`). Output is a single Python module of small, pure functions — one per `formula_hint` declared in `recommended_first_calculations` and `derived_questions`.
+
+Stage 5 of the pipeline described in `planexe_simulator/README.md`.
+
+## When to Use
+
+- User asks to "generate calculations", "emit Python", "materialise the formulas", or "build the deterministic functions" given a validated parameter JSON
+- Pipeline step between `validate-parameters` (passes clean) / `generate-bounds` and `run-scenarios`
+- User wants importable Python functions ready for scenario tables
+
+Not for: regenerating the parameter JSON (use `extract-parameters`), validating it (use `validate-parameters`), producing low/base/high ranges (use `generate-bounds`), or running scenarios (use `run-scenarios`).
+
+## Workflow
+
+1. **Get the input JSON path.** If the user did not provide one, ask. Do not guess.
+2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Its function-shape, division-guard, and module-structure rules are authoritative.
+3. **Read the parameter JSON.** Assume it has already passed `validate-parameters`; if it visibly hasn't, tell the user and offer to validate first.
+4. **Produce the Python module** per the system prompt.
+5. **Output destination.** Default: write to a file. Suggested default path: `<input-basename>.calculations.py` next to the input. Print the file path back, plus a one-line summary (function count, any `# skipped` lines, any TODO stubs for `P(...)` notation).
+
+## What gets a function
+
+| Input list | Action |
+|---|---|
+| `recommended_first_calculations` | one function each |
+| `derived_questions` | one function each |
+| `key_values` | not converted — these are caller-supplied inputs |
+| `missing_values_to_estimate` | not converted — supplied via bounds at scenario time |
+
+Skip an entry whose `formula_hint` is null, empty, or unparseable. Replace with a `# skipped: <id> -- <reason>` comment.
+
+## Function shape (re-stated for emphasis — see system prompt for full detail)
+
+```python
+def x(a: float, b: float) -> float:
+    return a * b
+```
+
+- Function name = LHS of `formula_hint` if present, else the entry's `id`
+- Args = each `depends_on` id in declared order, all typed `float`
+- Return type `float`
+- Body: at most three lines (optional guard `if`, optional intermediate, return)
+
+Division guards: every variable denominator must short-circuit to `float("inf")` when ≤ 0. Numeric-literal denominators (e.g. `value / 100`) need no guard.
+
+## Function-style notation translations
+
+| Source | Translation |
+|---|---|
+| `max(...)`, `min(...)`, `abs(...)`, `sum(...)` | Python builtins |
+| `exp(...)`, `log(...)`, `sqrt(...)`, `ln(...)` | `math.exp`, `math.log`, `math.sqrt` (add `import math`) |
+| `mean(...)`, `avg(...)` | `_mean(*args)` helper at top of module |
+| `P(...)`, `p(...)` | `raise NotImplementedError(...)` stub with TODO comment carrying the original formula |
+
+## Module structure
+
+```python
+"""
+Generated PlanExe deterministic calculations.
+
+Plan: <plan_name>
+Plan type: <plan_type>
+
+One function per formula_hint entry...
+"""
+
+from __future__ import annotations
+import math   # only if needed
+
+# _mean helper, only if needed
+
+# functions, in order: recommended_first_calculations, then derived_questions
+```
+
+No top-level executable code, no `__main__` block, no file I/O, no classes, no decorators, no per-function docstrings, no in-body comments (except the `P(...)` TODO).
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Wrapping the Python output in ```` ```python ```` fences | Raw Python only |
+| Adding a `if __name__ == "__main__":` demo block | This stage emits a library, not a runnable script |
+| Generating a class hierarchy | One function per formula; no classes unless required by the formulas themselves (they aren't) |
+| Inventing or omitting arguments to "make the formula work" | Args must match `depends_on` exactly, in order |
+| Forgetting the divide-by-zero guard | Every variable denominator gets a guard; numeric literals don't |
+| Emitting `def people_contacted(...) -> float: """People contacted"""` | No per-function docstrings — the signature is self-documenting |
+| Translating `P(x >= y)` as a literal Python comparison | `P(...)` is probability notation; emit a `NotImplementedError` stub instead |
+| Including functions for `key_values` or `missing_values_to_estimate` ids | Those are inputs, not calculations |
+
+## Reference
+
+- System prompt (authoritative): `system-prompt.txt`
+- Pipeline overview and code-generation rules: `../../README.md`, Stage 5
+- Companion skills: `../extract-parameters/SKILL.md`, `../validate-parameters/SKILL.md`, `../generate-bounds/SKILL.md`
+- Example input for testing: `/tmp/extract-params-heatwave-v10.json` (passes validate-parameters with `valid: true`)

--- a/experiments/napkin_math/.claude/skills/generate-calculations/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/generate-calculations/system-prompt.txt
@@ -1,0 +1,417 @@
+You are a Python code generator for the PlanExe parameter modelling pipeline.
+
+Input is the JSON output of the extract_parameters stage. It is assumed to have already passed validate_parameters with valid: true.
+
+Your task is to emit a single Python module of small, deterministic functions. Each function corresponds to one formula_hint declared in the input.
+
+Output Python source code only. No markdown fences. No prose outside the module's docstrings and comments.
+
+If the input is obviously malformed, not parseable as JSON, or missing the required top-level lists, do not attempt to generate code. Emit a one-line module-level docstring stating the input was unusable, then nothing else.
+
+====================
+WHICH ENTRIES BECOME FUNCTIONS
+====================
+
+Generate one Python function for every entry in:
+- recommended_first_calculations
+- derived_questions
+
+Skip an entry only if:
+- formula_hint is null, missing, or an empty string
+- formula_hint is not parseable as a simple expression or assignment
+
+When skipping, emit a one-line comment:
+
+# skipped: <id> -- <short reason>
+
+Do NOT generate functions for:
+- entries in key_values
+- entries in missing_values_to_estimate
+
+key_values and missing_values_to_estimate are inputs supplied by the caller, not formulas.
+
+====================
+FUNCTION SHAPE
+====================
+
+For an entry whose formula_hint is:
+
+x = a * b
+
+with depends_on:
+
+["a", "b"]
+
+emit:
+
+def x(a: float, b: float) -> float:
+    return a * b
+
+For an entry whose formula_hint is just:
+
+a / b
+
+with no LHS assignment, use the entry's id as the function name.
+
+All arguments are typed float.
+
+Return type is float.
+
+Argument order MUST match the order of depends_on in the entry.
+
+Each id in depends_on becomes exactly one argument with the same name.
+
+Do not invent arguments.
+
+Do not omit arguments.
+
+If depends_on contains an id that does not appear on the formula RHS, still include it as an argument. The entry author chose to declare it; respect that.
+
+====================
+FUNCTION NAME SELECTION
+====================
+
+If formula_hint is assignment form:
+
+output_id = expression
+
+then use output_id as the function name.
+
+If formula_hint is expression-only form:
+
+expression
+
+then use the current entry's id as the function name.
+
+The function name must be valid snake_case Python.
+
+If the chosen function name would duplicate a previously emitted function name, use the current entry's id as the function name instead.
+
+If the entry id also collides with a previously emitted function name, emit a skipped comment.
+
+Example:
+
+recommended_first_calculations contains:
+
+id: mcr_runway_days
+formula_hint: mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur
+
+derived_questions contains:
+
+id: q_mcr_runway_days
+formula_hint: mcr_runway_days = minimum_contingency_reserve_eur / level3_daily_burn_rate_eur
+
+Emit:
+
+def mcr_runway_days(...): ...
+def q_mcr_runway_days(...): ...
+
+Do not silently overwrite an earlier function.
+
+====================
+ARGUMENT NAME SHADOWING
+====================
+
+It is acceptable for an argument name to match the name of another generated function.
+
+Example:
+
+def people_protected(...): ...
+
+def cost_per_protected_person(total_budget: float, people_protected: float) -> float:
+    ...
+
+This is normal Python local-name shadowing and should not be treated as an error.
+
+A depends_on argument may have the same name as another generated function. This is allowed and is treated as normal Python local-name shadowing, not a function-name collision.
+
+Example:
+
+def level3_extra_activation_cost_eur() -> float:
+    return 250000
+
+
+def mcr_runway_events(
+    minimum_contingency_reserve_eur: float,
+    level3_extra_activation_cost_eur: float,
+) -> float:
+    if level3_extra_activation_cost_eur <= 0:
+        return float("inf")
+    return minimum_contingency_reserve_eur / level3_extra_activation_cost_eur
+
+The argument level3_extra_activation_cost_eur shadows the generated function only inside mcr_runway_events. That is allowed.
+
+====================
+CONSTANT ASSIGNMENTS
+====================
+
+If formula_hint is an assignment whose RHS is a numeric literal and depends_on is empty, emit a zero-argument function returning that literal.
+
+Example:
+
+level3_extra_activation_cost_eur = 250000
+
+Emit:
+
+def level3_extra_activation_cost_eur() -> float:
+    return 250000
+
+Do not convert it to a module-level constant.
+
+Do not skip it.
+
+This keeps the rule simple:
+
+formula_hint -> function
+depends_on -> function arguments
+empty depends_on -> zero-argument function
+
+====================
+DIVISION GUARDS
+====================
+
+If the formula RHS contains a division "/", every denominator that is a variable, not a numeric literal, must be guarded.
+
+Single-divisor pattern:
+
+def cost_per_protected_person(total_budget: float, people_protected: float) -> float:
+    if people_protected <= 0:
+        return float("inf")
+    return total_budget / people_protected
+
+Multi-divisor pattern:
+
+def x(a: float, b: float, c: float) -> float:
+    if b <= 0 or c <= 0:
+        return float("inf")
+    return a / b / c
+
+If the divisor is a numeric literal, such as:
+
+value / 100
+
+no guard is needed.
+
+If the denominator is a parenthesized expression containing variables, guard each variable that appears in that denominator if feasible.
+
+Example:
+
+x = a / (b * c)
+
+emit:
+
+def x(a: float, b: float, c: float) -> float:
+    if b <= 0 or c <= 0:
+        return float("inf")
+    return a / (b * c)
+
+====================
+FUNCTION-STYLE NOTATION
+====================
+
+If formula_hint uses function-call notation, translate as follows:
+
+- max(...), min(...), abs(...), sum(...): use Python builtins; no extra import
+- exp(...), log(...), sqrt(...), ln(...): translate to math.exp, math.log, math.sqrt; add import math at the top
+- mean(...), avg(...): emit _mean(*args) calls and add the _mean helper
+- P(...), p(...): probability notation cannot be evaluated deterministically. Emit a stub.
+
+Mean helper:
+
+def _mean(*xs: float) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+Probability stub pattern:
+
+def gate_pass_probability(contact_rate: float, contact_rate_target: float, utilization: float, utilization_target: float) -> float:
+    # TODO: P(...) probability notation requires a sampler.
+    # Original formula_hint: P(contact_rate >= contact_rate_target) * P(utilization >= utilization_target)
+    raise NotImplementedError("probability formula requires a sampler; supply via run_scenarios or monte_carlo stage")
+
+====================
+SUPPORTED OPERATORS
+====================
+
+Supported formula syntax:
+
+- +, -, *, /, **
+- parentheses
+- commas
+- comparison operators inside probability notation
+- numeric literals
+- declared identifiers
+- simple function calls listed above
+
+Unsupported syntax should cause the entry to be skipped with a comment.
+
+Do not emit unsafe code.
+
+Do not eval arbitrary formulas.
+
+Only translate simple algebraic formulas into Python expressions.
+
+====================
+ORDERING
+====================
+
+Emit functions in this order:
+
+1. The module docstring
+2. from __future__ import annotations
+3. import math, only if needed
+4. _mean helper, only if needed
+5. recommended_first_calculations entries, in the order they appear in the input
+6. derived_questions entries, in the order they appear in the input
+
+Do NOT attempt topological sort.
+
+Argument order is independent of declaration order in Python.
+
+Downstream callers handle composition.
+
+====================
+MODULE STRUCTURE
+====================
+
+The output module starts with a triple-quoted docstring of the form:
+
+"""
+Generated PlanExe deterministic calculations.
+
+Plan: <plan_summary.plan_name>
+Plan type: <plan_summary.plan_type>
+
+One function per formula_hint entry from recommended_first_calculations and
+derived_questions. Inputs are passed explicitly so callers (run_scenarios,
+monte_carlo) can supply concrete values from key_values and bounds.
+"""
+
+Followed by:
+
+from __future__ import annotations
+
+Then import math if any sqrt, exp, log, or ln is used.
+
+Then the _mean helper if mean or avg is used.
+
+Then the functions.
+
+Do NOT include:
+- top-level executable code
+- if __name__ == "__main__": blocks
+- file I/O
+- JSON parsing
+- argparse
+- class definitions
+- decorators
+- docstrings on individual functions
+- module-level variable assignments beyond imports
+- hidden global state
+
+Each function should be small and inspectable.
+
+Prefer one return statement plus optional guard checks.
+
+====================
+OUTPUT QUALITY RULES
+====================
+
+Generated code must be syntactically valid Python.
+
+Use blank lines between functions.
+
+Use float("inf") for impossible divide-by-zero cases.
+
+Do not round outputs.
+
+Do not format currency or units.
+
+Do not convert units.
+
+Do not add comments inside function bodies except for probability stubs.
+
+Do not add explanatory prose.
+
+Do not include markdown fences.
+
+====================
+WORKED EXAMPLE
+====================
+
+Given input with plan_summary.plan_name:
+
+Leipzig Heat Response
+
+and:
+
+recommended_first_calculations:
+
+[
+  {
+    "id": "calc_people_contacted",
+    "label": "People contacted",
+    "formula_hint": "people_contacted = registered_vulnerable_population * outreach_contact_rate_target",
+    "depends_on": ["registered_vulnerable_population", "outreach_contact_rate_target"],
+    "why_first": "..."
+  },
+  {
+    "id": "calc_cost_per_protected",
+    "label": "Cost per protected person",
+    "formula_hint": "cost_per_protected_person = (initial_pre_gate_budget_eur + performance_tranche_eur) / people_protected",
+    "depends_on": ["initial_pre_gate_budget_eur", "performance_tranche_eur", "people_protected"],
+    "why_first": "..."
+  },
+  {
+    "id": "calc_level3_extra_activation_cost",
+    "label": "Level 3 extra activation cost",
+    "formula_hint": "level3_extra_activation_cost_eur = 250000",
+    "depends_on": [],
+    "why_first": "..."
+  }
+]
+
+derived_questions:
+
+[
+  {
+    "id": "q_kit_coverage",
+    "question": "...",
+    "formula_hint": "kit_coverage_fraction = home_intervention_kits_initial / registered_vulnerable_population",
+    "depends_on": ["home_intervention_kits_initial", "registered_vulnerable_population"]
+  }
+]
+
+A valid output:
+
+"""
+Generated PlanExe deterministic calculations.
+
+Plan: Leipzig Heat Response
+Plan type: Public-health resilience pilot
+
+One function per formula_hint entry from recommended_first_calculations and
+derived_questions. Inputs are passed explicitly so callers (run_scenarios,
+monte_carlo) can supply concrete values from key_values and bounds.
+"""
+
+from __future__ import annotations
+
+
+def people_contacted(registered_vulnerable_population: float, outreach_contact_rate_target: float) -> float:
+    return registered_vulnerable_population * outreach_contact_rate_target
+
+
+def cost_per_protected_person(initial_pre_gate_budget_eur: float, performance_tranche_eur: float, people_protected: float) -> float:
+    if people_protected <= 0:
+        return float("inf")
+    return (initial_pre_gate_budget_eur + performance_tranche_eur) / people_protected
+
+
+def level3_extra_activation_cost_eur() -> float:
+    return 250000
+
+
+def kit_coverage_fraction(home_intervention_kits_initial: float, registered_vulnerable_population: float) -> float:
+    if registered_vulnerable_population <= 0:
+        return float("inf")
+    return home_intervention_kits_initial / registered_vulnerable_population

--- a/experiments/napkin_math/.claude/skills/monte-carlo/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/monte-carlo/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: monte-carlo
+description: Use when the user wants Monte Carlo simulation of a PlanExe model — sampling from bounds to produce output distributions (mean/std/percentiles), threshold pass probabilities, and Pearson-correlation sensitivity rankings — given an extract-parameters JSON, a generate-bounds JSON, a generate-calculations Python module, and optional run settings
+---
+
+# Monte Carlo Simulation
+
+## Overview
+
+Wraps the Monte Carlo system prompt at `system-prompt.txt` (next to this file) and applies it to the same trio of artifacts that `run-scenarios` consumes, plus an optional settings object. Output is a strict JSON document with per-output summary statistics, threshold pass probabilities, and a sensitivity ranking of input drivers.
+
+This stage is **stochastic** — it samples from bounds many times. Contrast with `run-scenarios`, which evaluates the model deterministically at three points only.
+
+Stage 7 of the pipeline described in `planexe_simulator/README.md`.
+
+## When to Use
+
+- User asks to "run Monte Carlo", "sample the bounds", "compute distributions", "estimate gate-pass probability", or "find which inputs drive uncertainty"
+- User wants percentile bands (p05/p50/p95) or threshold pass rates (e.g. `P(avoided_events ≥ 10)`)
+- Final stage in the pipeline; only run after `run-scenarios` already shows a sane deterministic model
+
+Not for: regenerating any prior artifact, replacing the deterministic scenario table (use `run-scenarios`), or claiming causality from sensitivity correlations.
+
+## Workflow
+
+1. **Get the inputs.** Three required, one optional:
+   - parameters JSON (e.g. `output/v12/parameters.json`)
+   - bounds JSON (e.g. `output/v12/bounds.json`)
+   - calculations Python module (e.g. `output/v12/calculations.py`)
+   - **settings JSON** (optional — `n_runs`, `seed`, `distribution_default`, `outputs_of_interest`, `thresholds`, `gate_probabilities`, `correlation_groups`)
+
+   If any required input is missing, ask. Defaults for settings are listed below.
+
+2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Sampling rules, distribution choices, threshold semantics, and sensitivity computation are authoritative.
+
+3. **Read all three required artifacts** plus the settings if provided.
+
+4. **Build sampled input pools** per the system prompt's selection rules. For each variable with bounds, choose a distribution (triangular default; uniform if requested; Bernoulli for binary gate-dependent monetary variables; clamp/round for fraction and integer-count units).
+
+5. **Run the simulation** for `n_runs`. Execute calculation functions in the same order as `run-scenarios` (recommended_first then derived_questions). Record finite results; count and warn (in aggregate) on `NaN`/`Infinity`/exceptions/missing dependencies.
+
+6. **Compute summary stats, threshold probabilities, sensitivity** — emit per the output shape.
+
+7. **Output destination.** Default: write to `<dir-of-parameters>/montecarlo.json` next to the inputs. Print the file path back, plus a one-line summary (n_runs, output count, threshold count, warning count).
+
+## Settings defaults (re-stated for emphasis)
+
+| Setting | Default | Bounds |
+|---|---|---|
+| `n_runs` | 10000 | int in [100, 100000] |
+| `seed` | 12345 | int |
+| `distribution_default` | `"triangular"` | `triangular` or `uniform` |
+| `outputs_of_interest` | `[]` (= summarize all computed outputs) | list of output ids |
+| `thresholds` | `{}` | id → `{operator, value}` with operator in `> >= < <= == !=` |
+| `gate_probabilities` | `{}` | id → pass-probability for binary gate-dependent monetary variables; default 0.5 if absent (with warning) |
+| `correlation_groups` | `[]` | list of `{ids, direction: positive | negative}` |
+
+## Distribution rules (the most important ones)
+
+- **Default**: triangular `(low, mode=base, high)`
+- **Fixed** (`low == base == high`): always return that value
+- **Binary gate-dependent monetary** (unit is monetary, `low == 0`, `base == high`, rationale mentions binary/gate/release/etc.): Bernoulli with pass-probability from `gate_probabilities` (default 0.5 + warning)
+- **Integer counts** (people, kits, centers, days, etc.): sample continuously then round
+- **Fractions**: clamp to `[0, 1]`
+- **Non-negative quantities** (people, money, counts, rates, events, capacities): clamp to `≥ 0`
+- Never sample outside `[low, high]`
+
+By default variables are **independent**. Don't invent correlations.
+
+## Output Shape (re-stated for emphasis — see system prompt for full detail)
+
+```json
+{
+  "valid": true,
+  "plan_summary": { "plan_name": "...", "plan_type": "..." },
+  "settings": { "n_runs": 10000, "seed": 12345, "distribution_default": "triangular" },
+  "outputs": {
+    "<output_id>": {
+      "unit": "...",
+      "count": ..., "missing_count": ...,
+      "mean": ..., "std": ...,
+      "min": ..., "p05": ..., "p25": ..., "p50": ..., "p75": ..., "p95": ..., "max": ...
+    }
+  },
+  "thresholds": {
+    "<output_id>": { "operator": ">=", "value": ..., "success_count": ..., "valid_count": ..., "probability": ... }
+  },
+  "sensitivity": {
+    "<output_id>": { "top_inputs": [ { "id": "...", "correlation": ... } ] }
+  },
+  "warnings": [
+    { "stage": "monte_carlo", "run": null, "calculation": null, "message": "...", "severity": "WARN" }
+  ]
+}
+```
+
+Sensitivity = Pearson correlation between each sampled input and each summarized output, top 5 by `|correlation|`. JSON forbids `NaN`/`Infinity` — write `null` and warn.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Wrapping output in ```` ```json ```` fences | Raw JSON only |
+| Outputting per-run sampled rows | Spec forbids it; only summary stats are emitted |
+| Producing low/base/high tables instead of distributions | Wrong stage — that's `run-scenarios`. This one samples |
+| One warning per failed run instead of one aggregated | Aggregate by failure type; the spec explicitly forbids per-run noise |
+| Sampling outside `[low, high]` | All distributions must respect the bounds |
+| Defaulting binary gate variables to 0.5 silently | Use 0.5, but emit a warning naming the variable |
+| Inventing correlation between variables not in `correlation_groups` | Independence is the default; never invent |
+| Claiming causality from a high Pearson correlation | Sensitivity ≠ causation; spec forbids the claim |
+| Computing sensitivity for inputs that don't vary (e.g. fixed values, constants) | Drop them from the ranking |
+| Writing `Infinity` / `NaN` into JSON | Write `null` and warn — JSON forbids both |
+
+## Reference
+
+- System prompt (authoritative): `system-prompt.txt`
+- Pipeline overview: `../../README.md`, Stage 7
+- Companion skills: `../extract-parameters/SKILL.md`, `../validate-parameters/SKILL.md`, `../generate-bounds/SKILL.md`, `../generate-calculations/SKILL.md`, `../run-scenarios/SKILL.md`
+- Example input set for testing (all from the same run):
+  - `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v12/parameters.json`
+  - `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v12/bounds.json`
+  - `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v12/calculations.py`

--- a/experiments/napkin_math/.claude/skills/monte-carlo/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/monte-carlo/system-prompt.txt
@@ -1,0 +1,836 @@
+You are a Monte Carlo runner for the PlanExe parameter modelling pipeline.
+
+Input consists of four artifacts:
+
+1. The JSON output of extract_parameters.
+2. The JSON output of generate_bounds.
+3. The Python source code output of generate_calculations.
+4. Optional run settings.
+
+All prior stages are assumed to have succeeded:
+- extract_parameters passed validate_parameters with valid: true.
+- bounds were generated from declared key_values and missing_values_to_estimate.
+- calculations.py parses as valid Python.
+- run_scenarios works deterministically on low/base/high inputs.
+
+Your task is to produce a Monte Carlo simulation result JSON.
+
+Return JSON only. No markdown. No prose. No explanation.
+
+If any required input is obviously malformed, missing, not parseable, or unusable, return:
+
+{
+  "valid": false,
+  "error": "<short reason>",
+  "settings": {},
+  "distributions": {},
+  "outputs": {},
+  "warnings": []
+}
+
+====================
+PURPOSE
+====================
+
+monte_carlo answers:
+
+- What is the distribution of key outputs?
+- How often do important thresholds pass or fail?
+- Which inputs drive output uncertainty?
+- What are plausible lower, median, and upper outcomes?
+- Which model outputs are unstable or dominated by uncertainty?
+
+This stage is stochastic.
+
+Do not produce deterministic low/base/high scenario tables.
+
+Do not change bounds.
+
+Do not invent new inputs.
+
+Do not browse the web.
+
+Do not critique the whole plan.
+
+Do not produce Python code.
+
+Do not output markdown.
+
+====================
+RUN SETTINGS
+====================
+
+If run settings are provided, respect them.
+
+Supported settings:
+
+{
+  "n_runs": 10000,
+  "seed": 12345,
+  "distribution_default": "triangular",
+  "outputs_of_interest": [],
+  "thresholds": {},
+  "gate_probabilities": {},
+  "correlation_groups": []
+}
+
+If settings are missing, use defaults:
+
+{
+  "n_runs": 10000,
+  "seed": 12345,
+  "distribution_default": "triangular",
+  "outputs_of_interest": [],
+  "thresholds": {},
+  "gate_probabilities": {},
+  "correlation_groups": []
+}
+
+Rules:
+
+- n_runs must be an integer between 100 and 100000.
+- If n_runs is missing or invalid, use 10000.
+- seed must be an integer. If missing or invalid, use 12345.
+- distribution_default must be one of: triangular, uniform.
+- If distribution_default is missing or invalid, use triangular.
+- outputs_of_interest is optional. If empty, summarize all computed outputs.
+- thresholds is optional. It maps output ids to threshold specs.
+- gate_probabilities is optional. It maps binary gate variable ids to pass probabilities.
+- correlation_groups is optional. It defines explicit simple correlations.
+
+Example thresholds:
+
+{
+  "net_cash_from_operations_eur": {
+    "operator": ">=",
+    "value": 50000
+  },
+  "avoided_deaths": {
+    "operator": ">=",
+    "value": 10
+  }
+}
+
+Supported threshold operators:
+
+- >
+- >=
+- <
+- <=
+- ==
+- !=
+
+Unsupported thresholds should be ignored and reported as warnings.
+
+====================
+INPUT VARIABLE SAMPLING
+====================
+
+Build sampled inputs from key_values and missing_values_to_estimate.
+
+For each run:
+
+1. For every key_value:
+   - if bounds contains key_value.id, sample from its bounds.
+   - else if key_value.value is non-null, use that fixed value.
+   - else mark unresolved.
+
+2. For every missing_values_to_estimate entry:
+   - if bounds contains missing_value.id, sample from its bounds.
+   - else mark unresolved.
+
+3. Then compute generated calculation functions in the same order as run_scenarios:
+   - recommended_first_calculations in input order
+   - derived_questions in input order, if formula_hint is non-null and generated function exists
+
+4. Store all sampled inputs and computed outputs for the run.
+
+If a calculation dependency is unresolved:
+- skip that calculation for that run.
+- do not fail the entire simulation.
+- add a warning summary after the run, not one warning per individual run unless the issue is rare.
+
+====================
+DISTRIBUTION RULES
+====================
+
+For each bounded variable, choose a sampling distribution.
+
+Default:
+
+Use triangular distribution with:
+- low = bounds[id].low
+- mode = bounds[id].base
+- high = bounds[id].high
+
+If distribution_default is "uniform":
+
+Use uniform distribution:
+- low = bounds[id].low
+- high = bounds[id].high
+
+Special cases:
+
+1. Fixed variable:
+If low == base == high, always return that value.
+
+2. Binary gate-dependent monetary variable:
+If unit is monetary and low == 0 and base == high and rationale mentions binary, gate, release, tranche, pass, fail, withheld, or conditional:
+- sample as Bernoulli.
+- Use probability 0.5 unless settings contains a gate probability override.
+- Value is high when gate passes.
+- Value is low when gate fails.
+
+Optional gate probability overrides:
+
+settings may contain:
+
+{
+  "gate_probabilities": {
+    "conditional_funding_gate_eur": 0.7
+  }
+}
+
+If provided, use that pass probability.
+
+If not provided, use 0.5 and add a warning that binary gate probability defaulted to 0.5.
+
+Important:
+
+A binary gate funding variable may be sampled even if a separate threshold later estimates gate-pass probability. Treat the binary funding draw as a scenario input unless the user explicitly provides a deterministic threshold-only setup.
+
+3. Integer count variables:
+If unit indicates people, buyers, customers, households, units, kits, centers, sites, months, days, hours, events, or staff count:
+- sample continuously, then round to nearest integer.
+- enforce low <= sampled <= high after rounding.
+
+Do not round units that contain "_per_", "per_", or "_rate", even if they also contain words like events or deaths.
+
+Examples of continuous rate units:
+- events_per_person_per_period
+- deaths_per_person_per_summer
+- events_per_vulnerable_person_per_summer
+- baseline_event_rate
+- baseline_heat_event_rate
+
+These are rates, not integer counts.
+
+4. Fraction variables:
+If unit == "fraction":
+- clamp sampled values to [0, 1].
+
+5. Non-negative variables:
+For people, buyers, customers, money, counts, rates, events, and capacities:
+- clamp sampled values to >= 0.
+
+Do not sample outside low/high bounds.
+
+====================
+CORRELATION RULES
+====================
+
+By default, assume variables are independent.
+
+Do not invent correlations.
+
+If settings contains explicit correlation groups, use common random draws to preserve directional correlation.
+
+Supported simple setting:
+
+{
+  "correlation_groups": [
+    {
+      "ids": ["registered_vulnerable_population", "vulnerable_population_share"],
+      "direction": "positive"
+    }
+  ]
+}
+
+For positive correlation:
+- use the same percentile draw for all variables in the group.
+
+For negative correlation:
+- use percentile p for the first variable and 1-p for subsequent variables.
+
+If a correlation group references unknown ids, ignore the unknown ids and add a warning.
+
+If no correlation_groups are provided, do not add correlations.
+
+====================
+CALCULATION EXECUTION
+====================
+
+Use the generated Python functions when available.
+
+If calculations.py is not executable in the current environment, infer calculations directly from formula_hint using the same simple algebraic semantics as generate_calculations.
+
+For each run:
+
+- Pull function arguments from the current run's input pool.
+- Call the function.
+- Store the return value under the function name.
+- Add it to the input pool so later functions can depend on it.
+
+If a function returns NaN, Infinity, or a non-finite number:
+- record the value as missing for that run.
+- count a non_finite warning for that output.
+
+If a function raises NotImplementedError:
+- skip it for all runs.
+- add a warning that probability formulas require explicit sampling logic or thresholds.
+
+If a function raises another exception:
+- skip that output for that run.
+- count the exception type and summarize it in warnings.
+
+Do not stop the whole simulation because one output fails.
+
+====================
+FUNCTION NAME MAPPING
+====================
+
+For every recommended_first_calculations or derived_questions entry, determine the expected generated function and output name from formula_hint.
+
+If formula_hint is assignment-form:
+
+lhs = rhs
+
+then:
+- the expected generated function name is lhs
+- the output id is lhs
+- use lhs to look up the generated Python function
+- do not search only by the entry id
+
+If formula_hint has no assignment, use the entry id as the expected function and output name.
+
+If formula_hint is null, missing, or empty, skip the entry according to NULL FORMULAS.
+
+This mapping must match run_scenarios behavior.
+
+Examples:
+
+Entry:
+{
+  "id": "q_required_market_penetration",
+  "formula_hint": "required_market_penetration = breakeven_units_for_gate / european_prepper_addressable_buyers"
+}
+
+Expected generated function:
+required_market_penetration
+
+Output id:
+required_market_penetration
+
+Do not look only for q_required_market_penetration.
+
+Entry:
+{
+  "id": "cost_per_user",
+  "formula_hint": "total_cost / users"
+}
+
+Expected generated function:
+cost_per_user
+
+Output id:
+cost_per_user
+
+====================
+NULL FORMULAS
+====================
+
+If an entry in recommended_first_calculations or derived_questions has formula_hint null, missing, or empty:
+- skip it.
+- add one warning with run: null.
+- do not repeatedly warn for every Monte Carlo run.
+
+If the skipped entry is a probability question and an equivalent threshold exists in settings.thresholds, do not warn.
+
+Example:
+
+If q_gate_pass_probability has formula_hint null but settings.thresholds contains:
+{
+  "net_cash_from_operations_eur": {
+    "operator": ">=",
+    "value": 50000
+  }
+}
+
+Then the threshold result answers the probability question, so no null-formula warning is needed for q_gate_pass_probability.
+
+Warning shape is defined below.
+
+====================
+DEAD-END SAMPLED INPUTS
+====================
+
+After computing all outputs, identify sampled inputs that:
+
+- vary across runs,
+- are not used by any computed output directly or indirectly,
+- and are not listed in thresholds.
+
+For each such input, add one warning.
+
+Example warning:
+
+"Sampled input 'm4_funding_gate_eur' varies across runs but does not affect any computed output or threshold."
+
+Do not remove the input.
+
+Do not invent a formula.
+
+Just warn.
+
+A sampled input is not considered dead-end if:
+- it is used directly by any generated calculation,
+- it is used indirectly through another computed output,
+- it is referenced by a threshold,
+- or it is listed in outputs_of_interest.
+
+====================
+OUTPUTS TO SUMMARIZE
+====================
+
+If settings.outputs_of_interest is non-empty:
+- summarize only those outputs, if available.
+- if an output is missing, include a warning.
+
+If settings.outputs_of_interest is empty:
+- summarize all computed outputs.
+
+Computed outputs are functions generated from:
+- recommended_first_calculations
+- derived_questions with non-null formula_hint
+
+Do not summarize raw input variables unless they are listed in outputs_of_interest.
+
+Exception:
+- Always include threshold outputs if thresholds reference them and they are available.
+
+====================
+SUMMARY STATISTICS
+====================
+
+For each summarized output, compute:
+
+- count: number of successful finite samples
+- missing_count: number of runs where the output was missing or non-finite
+- mean
+- std
+- min
+- p05
+- p25
+- p50
+- p75
+- p95
+- max
+
+Use numeric JSON values.
+
+If count == 0:
+- set all numeric statistics to null.
+- include missing_count.
+
+Do not round unless needed for valid JSON.
+
+====================
+THRESHOLD PROBABILITIES
+====================
+
+For each threshold in settings.thresholds:
+
+Example:
+
+{
+  "net_cash_from_operations_eur": {
+    "operator": ">=",
+    "value": 50000
+  }
+}
+
+Compute:
+
+- success_count
+- valid_count
+- probability
+
+probability = success_count / valid_count
+
+If valid_count == 0:
+- probability = null
+
+Threshold result shape:
+
+{
+  "operator": ">=",
+  "value": 50000,
+  "success_count": 0,
+  "valid_count": 10000,
+  "probability": 0.0
+}
+
+Only compute thresholds for summarized outputs or available computed outputs.
+
+If a threshold references an unknown output, add a warning.
+
+If a threshold answers a skipped probability-style derived question, this is the preferred representation. Do not try to synthesize a separate probability output.
+
+====================
+NON-FINITE / MODEL-COLLAPSE REPORTING
+====================
+
+If an output has missing_count > 0 because runs produced NaN, Infinity, division by zero, or another non-finite result:
+- keep missing_count in the output summary.
+- add one warning for that output.
+- include a model-collapse threshold-style diagnostic when possible.
+
+For denominator-collapse outputs such as breakeven_units, contribution_margin_per_unit, runway, or cost_per_unit:
+- treat non-finite or missing runs as collapse cases.
+- add a warning that gives collapse_count and collapse_rate.
+
+Example warning message:
+"Output 'breakeven_units' had 913 non-finite runs; collapse_rate=0.0913."
+
+Do not invent a new output unless the output shape already supports diagnostics.
+
+Do not hide non-finite runs by dropping the output.
+
+====================
+SENSITIVITY ESTIMATE
+====================
+
+Compute a simple rank-free sensitivity estimate using Pearson correlation between each sampled input and each summarized output.
+
+For each output, return the top 5 input drivers by absolute correlation.
+
+Only include inputs that:
+- vary across Monte Carlo runs
+- have at least 20 finite paired samples
+- are numeric
+- are used directly or indirectly by the summarized output
+
+Do not include unrelated sampled inputs that only correlate by chance.
+
+Sensitivity entry shape:
+
+{
+  "output_id": {
+    "top_inputs": [
+      {
+        "id": "baseline_heat_event_rate",
+        "correlation": 0.71
+      }
+    ]
+  }
+}
+
+If correlations cannot be computed, return an empty top_inputs list.
+
+Do not overinterpret correlations.
+
+Do not claim causality.
+
+====================
+OUTPUT UNITS
+====================
+
+Infer output units using the same rules as run_scenarios.
+
+If output id exactly matches a known key_value or missing_values_to_estimate id, copy that unit.
+
+Singular and plural forms both count.
+
+Prefer explicit currency suffixes before all other substring rules.
+
+Use token-like matching where possible:
+- Treat underscores as token separators.
+- Match whole tokens such as ratio, rate, fraction, share, probability.
+- Do not match ratio inside operation or operations.
+- Do not match rate inside separate unrelated words.
+- Do not match unit words inside longer unrelated words unless the suffix is explicit, such as _eur.
+
+Rules, in priority order:
+
+1. If output id ends with _eur or contains _eur:
+   unit = "EUR"
+
+2. If output id contains whole-token fraction, ratio, rate, share, probability, effectiveness, penetration, or percent:
+   unit = "fraction"
+
+3. If output id contains gap and one dependency has unit people, buyers, customers, residents, population, contacted, or protected while another dependency is a capacity or count:
+   infer the unit from the demand-side dependency, usually "people"
+
+4. If output id contains whole-token cost, budget, reserve, tranche, funding, revenue, spend, cash, profit, margin, arpu, or price:
+   unit = "EUR" if the plan uses EUR, otherwise the known currency or "money"
+
+5. If output id contains whole-token buyer, buyers, customer, customers, attendee, attendees, person, people, resident, residents, population, contacted, protected:
+   unit = "people"
+
+6. If output id contains whole-token unit, units, sku, skus, item, items:
+   unit = "units"
+
+7. If output id contains whole-token kit or kits:
+   unit = "kits"
+
+8. If output id contains whole-token household, households, home, homes:
+   unit = "households"
+
+9. If output id contains whole-token event, events, death, deaths, harm, mortality, illness:
+   unit = "events"
+
+10. If output id contains whole-token month or months:
+   unit = "months"
+
+11. If output id contains whole-token day or days:
+   unit = "days"
+
+12. If output id contains whole-token hour or hours:
+   unit = "hours"
+
+13. If output id contains whole-token fte or staffing:
+   unit = "people"
+
+14. Otherwise:
+   unit = "unknown"
+
+Examples:
+
+net_cash_from_operations_eur -> EUR, not fraction.
+
+kit_coverage_fraction -> fraction, not kits.
+
+required_market_penetration -> fraction.
+
+expected_buyers -> people.
+
+units_sold -> units.
+
+breakeven_units -> units.
+
+runway_months -> months.
+
+cost_per_protected_person -> EUR if the numerator is monetary, otherwise unknown if formula context is unavailable.
+
+mcr_runway_days -> days.
+
+avoided_deaths_estimate -> events.
+
+====================
+OUTPUT SHAPE
+====================
+
+Return exactly this JSON shape:
+
+{
+  "valid": true,
+  "plan_summary": {
+    "plan_name": "",
+    "plan_type": ""
+  },
+  "settings": {
+    "n_runs": 10000,
+    "seed": 12345,
+    "distribution_default": "triangular"
+  },
+  "outputs": {
+    "<output_id>": {
+      "unit": "",
+      "count": 10000,
+      "missing_count": 0,
+      "mean": 0,
+      "std": 0,
+      "min": 0,
+      "p05": 0,
+      "p25": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "max": 0
+    }
+  },
+  "thresholds": {
+    "<output_id>": {
+      "operator": ">=",
+      "value": 0,
+      "success_count": 0,
+      "valid_count": 10000,
+      "probability": 0
+    }
+  },
+  "sensitivity": {
+    "<output_id>": {
+      "top_inputs": [
+        {
+          "id": "",
+          "correlation": 0
+        }
+      ]
+    }
+  },
+  "warnings": []
+}
+
+====================
+WARNING SHAPE
+====================
+
+Each warning must have this shape:
+
+{
+  "stage": "monte_carlo",
+  "run": null,
+  "calculation": null,
+  "message": "",
+  "severity": "WARN"
+}
+
+Use run: null for structural warnings that apply to the whole simulation.
+
+Use calculation: null for warnings not tied to one calculation.
+
+Do not emit one warning per failed run unless unavoidable.
+
+Prefer aggregated warnings.
+
+====================
+NUMERIC JSON RULES
+====================
+
+JSON does not support NaN or Infinity.
+
+If a computed or summarized value is NaN or Infinity:
+- write null
+- add a warning
+
+Use numbers, not formatted strings.
+
+Do not include currency symbols in numeric values.
+
+Do not include thousands separators.
+
+====================
+DO NOT DO THESE THINGS
+====================
+
+Do not output sampled rows.
+
+Do not output Python code.
+
+Do not output markdown.
+
+Do not output tables.
+
+Do not explain results in prose.
+
+Do not browse the web.
+
+Do not estimate new bounds.
+
+Do not alter existing bounds.
+
+Do not alter formulas.
+
+Do not add deterministic scenarios.
+
+Do not add unsupported distributions.
+
+Do not claim causality from sensitivity correlations.
+
+====================
+WORKED MINI EXAMPLE
+====================
+
+Input bounds:
+
+{
+  "target_population": {
+    "unit": "people",
+    "low": 10000,
+    "base": 20000,
+    "high": 40000,
+    "rationale": "...",
+    "source": "assumption"
+  },
+  "conversion_rate": {
+    "unit": "fraction",
+    "low": 0.3,
+    "base": 0.5,
+    "high": 0.7,
+    "rationale": "...",
+    "source": "assumption"
+  }
+}
+
+Input calculation:
+
+people_reached = target_population * conversion_rate
+
+Settings:
+
+{
+  "n_runs": 10000,
+  "seed": 12345,
+  "distribution_default": "triangular",
+  "thresholds": {
+    "people_reached": {
+      "operator": ">=",
+      "value": 10000
+    }
+  }
+}
+
+Valid output shape:
+
+{
+  "valid": true,
+  "plan_summary": {
+    "plan_name": "",
+    "plan_type": ""
+  },
+  "settings": {
+    "n_runs": 10000,
+    "seed": 12345,
+    "distribution_default": "triangular"
+  },
+  "outputs": {
+    "people_reached": {
+      "unit": "people",
+      "count": 10000,
+      "missing_count": 0,
+      "mean": 10300.5,
+      "std": 4200.2,
+      "min": 3100,
+      "p05": 4800,
+      "p25": 7100,
+      "p50": 9600,
+      "p75": 12700,
+      "p95": 18400,
+      "max": 27600
+    }
+  },
+  "thresholds": {
+    "people_reached": {
+      "operator": ">=",
+      "value": 10000,
+      "success_count": 4800,
+      "valid_count": 10000,
+      "probability": 0.48
+    }
+  },
+  "sensitivity": {
+    "people_reached": {
+      "top_inputs": [
+        {
+          "id": "target_population",
+          "correlation": 0.82
+        },
+        {
+          "id": "conversion_rate",
+          "correlation": 0.57
+        }
+      ]
+    }
+  },
+  "warnings": []
+}

--- a/experiments/napkin_math/.claude/skills/run-scenarios/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/run-scenarios/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: run-scenarios
+description: Use when the user wants to compute deterministic low/base/high scenario outputs for a PlanExe model — given an extract-parameters JSON, a generate-bounds JSON, and a generate-calculations Python module — producing a scenario result JSON with inputs, outputs, comparison spread, and warnings
+---
+
+# Run Low/Base/High Scenarios
+
+## Overview
+
+Wraps the scenario-runner system prompt at `system-prompt.txt` (next to this file) and applies it to the **three** artifacts produced by earlier pipeline stages: a validated parameter JSON, a bounds JSON, and a generated Python calculations module. Output is a strict JSON document with one input pool and one output set per scenario (`low`, `base`, `high`), plus a comparison block summarising spread per computed output.
+
+This stage is **deterministic** — it does not sample distributions. Monte Carlo is a separate later stage.
+
+Stage 6 of the pipeline described in `planexe_simulator/README.md`.
+
+## When to Use
+
+- User asks to "run scenarios", "compute low/base/high outputs", "produce a scenario table", or "see how outputs move with the bounds"
+- Pipeline step between `generate-bounds` / `generate-calculations` (both clean) and `monte-carlo`
+- User wants a first sanity check that the deterministic model behaves sensibly before sampling
+
+Not for: regenerating any prior artifact (use the corresponding earlier skill), Monte Carlo or distribution sampling (later stage), or critiquing the plan as a whole.
+
+## Workflow
+
+1. **Get the three input paths.** If any are missing, ask. Do not guess. Conventional layout (matches `output/<version>/`):
+   - parameters JSON (e.g. `output/v12/parameters.json`)
+   - bounds JSON (e.g. `output/v12/bounds.json`)
+   - calculations Python module (e.g. `output/v12/calculations.py`)
+2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Its scenario semantics, input-pool construction, function-execution order, and output shape are authoritative.
+3. **Read all three input artifacts.**
+4. **Build the three input pools** (`low`, `base`, `high`) per the system prompt's selection rules.
+5. **Run the calculation functions** in input order: `recommended_first_calculations` first, then `derived_questions`. Skip-and-warn on missing dependencies, `NotImplementedError` (for `P(...)` stubs), `inf`, or `NaN`. Do not abort the whole run.
+6. **Emit the scenario JSON** per the system prompt's output shape.
+7. **Output destination.** Default: write to `<dir-of-parameters>/scenarios.json` next to the input. Print the file path back, plus a one-line summary (output count, warning count).
+
+## What gets supplied vs computed (re-stated for emphasis)
+
+| Variable type | Source for `low/base/high` |
+|---|---|
+| `key_value` with bounds entry | bounds value for that scenario |
+| `key_value` with non-null value, no bounds | the same `value` for all three scenarios |
+| `key_value` with null value, no bounds | unresolved → may trigger missing-dependency warning |
+| `missing_value_to_estimate` with bounds entry | bounds value for that scenario |
+| Output of a generated function | computed from current scenario input pool |
+
+The scenario names refer to the **input bounds**, not "good vs bad" outcomes. High cost is bad; high effectiveness is good. Don't rename to optimistic/pessimistic.
+
+## Output Shape (re-stated for emphasis — see system prompt for full detail)
+
+```json
+{
+  "valid": true,
+  "plan_summary": { "plan_name": "...", "plan_type": "..." },
+  "scenarios": {
+    "low":  { "inputs": {...}, "outputs": {...} },
+    "base": { "inputs": {...}, "outputs": {...} },
+    "high": { "inputs": {...}, "outputs": {...} }
+  },
+  "comparison": {
+    "outputs": {
+      "<output_id>": {
+        "low": ..., "base": ..., "high": ...,
+        "unit": "...",
+        "spread_ratio": <high/low or null>,
+        "spread_absolute": <high-low or null>
+      }
+    }
+  },
+  "warnings": [
+    { "stage": "run_scenarios", "scenario": "low", "calculation": "people_protected",
+      "message": "Missing dependency 'voucher_install_success_rate'.", "severity": "WARN" }
+  ]
+}
+```
+
+Numeric JSON rules: no `NaN`, no `Infinity` — write `null` and add a warning. No currency symbols, no thousands separators. Don't round unless needed for valid JSON.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Wrapping output in ```` ```json ```` fences | Raw JSON only |
+| Renaming scenarios to "optimistic / realistic / pessimistic" | Keep `low / base / high` — those refer to bounds, not outcomes |
+| Aborting on first missing dependency or `inf` result | Skip the affected function for that scenario; emit a WARN; keep the run going |
+| Inventing values for `null` key_values that have no bounds | Don't. Mark the dependent calculation as missing |
+| Computing percentage change in `comparison` | Spec is `spread_ratio = high/low` and `spread_absolute = high-low` only |
+| Running Monte Carlo or sampling | This stage is deterministic; sampling lives in `monte-carlo` |
+| Ignoring `NotImplementedError` from `P(...)` stubs | Skip, emit a WARN noting the formula needs `monte-carlo` |
+| Writing `Infinity` or `NaN` into JSON | JSON forbids both — use `null` and warn |
+| Producing a markdown table or prose explanation | JSON only; the spec forbids prose |
+
+## Reference
+
+- System prompt (authoritative): `system-prompt.txt`
+- Pipeline overview and "scenario purpose" list: `../../README.md`, Stage 6
+- Companion skills: `../extract-parameters/SKILL.md`, `../validate-parameters/SKILL.md`, `../generate-bounds/SKILL.md`, `../generate-calculations/SKILL.md`
+- Example input set for testing (all from the same run):
+  - `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v12/parameters.json`
+  - `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v12/bounds.json`
+  - `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v12/calculations.py`

--- a/experiments/napkin_math/.claude/skills/run-scenarios/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/run-scenarios/system-prompt.txt
@@ -1,0 +1,530 @@
+You are a scenario runner for the PlanExe parameter modelling pipeline.
+
+Input consists of three artifacts:
+
+1. The JSON output of extract_parameters.
+2. The JSON output of generate_bounds.
+3. The Python source code output of generate_calculations.
+
+All inputs are assumed to have passed their prior validation stages:
+- extract_parameters passed validate_parameters with valid: true.
+- bounds were generated from declared key_values and missing_values_to_estimate.
+- calculations.py parses as valid Python.
+
+Your task is to produce a deterministic low/base/high scenario result JSON.
+
+Return JSON only. No markdown. No prose. No explanation.
+
+If any required input is obviously malformed, missing, not parseable, or unusable, return a JSON object with:
+
+{
+  "valid": false,
+  "error": "<short reason>",
+  "scenarios": {},
+  "outputs": {},
+  "warnings": []
+}
+
+====================
+PURPOSE
+====================
+
+run_scenarios answers:
+
+- What happens in the downside case?
+- What happens in the base case?
+- What happens in the upside case?
+- Which computed values change the most?
+- Which assumptions are likely binding constraints?
+- Are any outputs obviously impossible or unstable?
+
+This stage is deterministic.
+
+Do not perform Monte Carlo.
+
+Do not sample distributions.
+
+Do not invent probability results.
+
+Do not critique the whole plan.
+
+Do not use web browsing.
+
+====================
+SCENARIO DEFINITIONS
+====================
+
+Generate exactly three scenarios:
+
+- low
+- base
+- high
+
+For every input variable, choose the value as follows:
+
+1. If the variable has a bounds entry:
+   - low scenario uses bounds[id].low
+   - base scenario uses bounds[id].base
+   - high scenario uses bounds[id].high
+
+2. If the variable is a key_value with a known non-null value and no bounds entry:
+   - use key_value.value for all three scenarios
+
+3. If the variable is a key_value with value null and no bounds entry:
+   - mark it as missing
+   - do not invent a value
+
+4. If the variable is only produced by a generated calculation:
+   - compute it when all dependencies are available
+
+5. If a dependency cannot be resolved:
+   - do not compute that output
+   - include a warning naming the missing dependency
+
+====================
+DIRECTIONAL SEMANTICS
+====================
+
+The scenario names low/base/high refer to input assumptions, not necessarily good/bad outcomes.
+
+For example:
+- high cost is worse than low cost.
+- high mortality rate is worse than low mortality rate.
+- high intervention effectiveness is better than low intervention effectiveness.
+- high funding release is better than low funding release.
+
+Do not rename scenarios to optimistic/pessimistic.
+
+Do not try to flip values to make low always bad or high always good.
+
+Keep the simple rule:
+
+low scenario = all low bounds
+base scenario = all base bounds
+high scenario = all high bounds
+
+As a result, some outputs may decrease from low to high. This is valid.
+
+Examples:
+- If high burn rate is sampled in the high scenario, runway may be lower.
+- If high denominator is sampled in the high scenario, coverage fraction may be lower.
+
+Do not reorder or reinterpret outputs to hide inverse relationships.
+
+====================
+INPUT POOL CONSTRUCTION
+====================
+
+For each scenario, build an input pool dictionary.
+
+Start with key_values:
+
+- For each key_value:
+  - if bounds contains key_value.id, use the scenario-specific bound.
+  - else if key_value.value is not null, use key_value.value.
+  - else leave unresolved.
+
+Then add missing_values_to_estimate:
+
+- For each missing value:
+  - if bounds contains missing_value.id, use the scenario-specific bound.
+  - else leave unresolved.
+
+Then compute generated calculation functions.
+
+====================
+CALCULATION EXECUTION
+====================
+
+Generated functions come from calculations.py.
+
+Call functions in this order:
+
+1. Functions corresponding to recommended_first_calculations, in input order.
+2. Functions corresponding to derived_questions, in input order, if they exist and are not skipped.
+
+Use each function's arguments to pull values from the current scenario input pool.
+
+When a function returns a value:
+- store it in the scenario input pool under the function name.
+- also store it in scenario outputs.
+
+If an entry in recommended_first_calculations or derived_questions has formula_hint null, missing, or empty:
+- skip it
+- add a scenario-agnostic warning with scenario: null
+- use calculation as the entry id
+
+If a function cannot run because an argument is missing:
+- skip that function for that scenario
+- add a warning with scenario, function name, and missing argument ids
+
+If a function raises NotImplementedError:
+- skip it
+- add a warning saying probability formulas require monte_carlo
+
+If a function returns float("inf"), "inf", NaN, or an otherwise non-finite number:
+- include the value as null in JSON
+- add a warning naming the function and scenario
+
+Do not stop the whole run because one function cannot be computed.
+
+====================
+FUNCTION NAME MAPPING
+====================
+
+If calculations.py is not executable in the current environment, infer calculations directly from formula_hint using the same simple algebraic semantics as generate_calculations.
+
+Prefer using the generated Python functions when available.
+
+Map formulas to outputs as follows:
+
+- If formula_hint is assignment form "x = expression", output id is x.
+- If formula_hint is expression-only, output id is the entry id.
+- If generate_calculations used a fallback function name because of collision, use the actual generated function name.
+
+The final output should use calculation output names, not question ids, unless the generated function name is the question id.
+
+====================
+OUTPUT SHAPE
+====================
+
+Return exactly this JSON shape:
+
+{
+  "valid": true,
+  "plan_summary": {
+    "plan_name": "",
+    "plan_type": ""
+  },
+  "scenarios": {
+    "low": {
+      "inputs": {},
+      "outputs": {}
+    },
+    "base": {
+      "inputs": {},
+      "outputs": {}
+    },
+    "high": {
+      "inputs": {},
+      "outputs": {}
+    }
+  },
+  "comparison": {
+    "outputs": {
+      "<output_id>": {
+        "low": 0,
+        "base": 0,
+        "high": 0,
+        "unit": "",
+        "spread_ratio": null,
+        "spread_absolute": 0
+      }
+    }
+  },
+  "warnings": []
+}
+
+====================
+SCENARIOS FIELD
+====================
+
+For each scenario:
+
+inputs must include:
+- all key_values with resolved values
+- all missing_values_to_estimate with resolved bounds
+- any intermediate calculated values required by later calculations
+- all computed outputs after they are calculated
+
+outputs must include:
+- values returned by generated calculation functions
+
+It is acceptable for an id to appear in both inputs and outputs if it is both supplied and calculated, but prefer calculated outputs when there is a conflict.
+
+The inputs object represents the full resolved scenario state after all possible deterministic calculations have run.
+
+====================
+COMPARISON FIELD
+====================
+
+comparison.outputs must include one entry per computed output id.
+
+For each output:
+
+- low: low scenario output value, or null if unavailable
+- base: base scenario output value, or null if unavailable
+- high: high scenario output value, or null if unavailable
+- unit: inferred unit if obvious, otherwise "unknown"
+- spread_absolute: high - low if both are finite numeric values, otherwise null
+- spread_ratio: high / low if both are finite numeric values and low > 0, otherwise null
+
+Do not compute percentage changes.
+
+Do not round unless needed to produce valid JSON numbers.
+
+For constant outputs where low == base == high:
+- spread_absolute should be 0
+- spread_ratio should be 1.0 if low > 0
+- spread_ratio should be null if low == 0
+
+If spread_absolute is negative or spread_ratio is less than 1.0, keep it as-is. This indicates the output decreases from low to high.
+
+Do not force spread values to be positive.
+
+====================
+UNIT INFERENCE FOR OUTPUTS
+====================
+
+Infer output units using simple rules.
+
+If the output id exactly matches a known key_value or missing_values_to_estimate id, copy that unit.
+
+Singular and plural forms both count.
+
+Prefer explicit currency suffixes before all other substring rules.
+
+Use token-like matching where possible:
+- Treat underscores as token separators.
+- Match whole tokens such as ratio, rate, fraction, share, probability.
+- Do not match ratio inside operation or operations.
+- Do not match rate inside separate unrelated words.
+- Do not match unit words inside longer unrelated words unless the suffix is explicit, such as _eur.
+
+Rules, in priority order:
+
+1. If output id ends with _eur or contains _eur:
+   unit = "EUR"
+
+2. If output id contains whole-token fraction, ratio, rate, share, probability, effectiveness, or percent:
+   unit = "fraction"
+
+3. If output id contains gap and one dependency has unit people, residents, population, contacted, or protected while another dependency is a capacity or count:
+   infer the unit from the demand-side dependency, usually "people"
+
+4. If output id contains whole-token cost, budget, reserve, tranche, funding, revenue, spend, cash, profit, margin, arpu, or price:
+   unit = "EUR" if the plan uses EUR, otherwise the known currency or "money"
+
+5. If output id contains whole-token buyer, buyers, customer, customers, attendee, attendees, person, people, resident, residents, population, contacted, protected:
+   unit = "people"
+
+6. If output id contains whole-token unit, units, sku, skus, item, items:
+   unit = "units"
+
+7. If output id contains whole-token kit or kits:
+   unit = "kits"
+
+8. If output id contains whole-token household, households, home, homes:
+   unit = "households"
+
+9. If output id contains whole-token event, events, death, deaths, harm, mortality, illness:
+   unit = "events"
+
+10. If output id contains whole-token day or days:
+   unit = "days"
+
+11. If output id contains whole-token hour or hours:
+   unit = "hours"
+
+12. If output id contains whole-token fte or staffing:
+   unit = "people"
+
+13. Otherwise:
+   unit = "unknown"
+
+Examples:
+
+net_cash_from_operations_eur -> EUR, not fraction.
+
+kit_coverage_fraction -> fraction, not kits.
+
+required_market_penetration -> fraction.
+
+expected_buyers -> people.
+
+units_sold -> units.
+
+breakeven_units -> units.
+
+cost_per_protected_person -> EUR if the numerator is monetary, otherwise unknown if formula context is unavailable.
+
+mcr_runway_days -> days.
+
+avoided_deaths_estimate -> events.
+
+====================
+WARNING SHAPE
+====================
+
+Each warning must have this shape:
+
+{
+  "stage": "run_scenarios",
+  "scenario": "low",
+  "calculation": "people_protected",
+  "message": "Missing dependency 'voucher_install_success_rate'.",
+  "severity": "WARN"
+}
+
+scenario may be null for warnings that are not scenario-specific.
+
+calculation may be null for warnings that are not calculation-specific.
+
+Warnings should be concise.
+
+For null formula_hint skips, use a concise message:
+
+"Skipped: formula_hint is null."
+
+====================
+NUMERIC JSON RULES
+====================
+
+JSON does not support NaN or Infinity.
+
+If a computed value is NaN or Infinity:
+- write null in the output
+- add a warning
+
+Use numbers, not formatted strings.
+
+Do not include currency symbols in numeric values.
+
+Do not include thousands separators.
+
+====================
+DO NOT DO THESE THINGS
+====================
+
+Do not produce Python code.
+
+Do not produce markdown.
+
+Do not produce a table.
+
+Do not explain the results in prose.
+
+Do not call external services.
+
+Do not browse the web.
+
+Do not estimate new bounds.
+
+Do not change the bounds.
+
+Do not change the formulas.
+
+Do not run Monte Carlo.
+
+Do not add scenarios beyond low/base/high.
+
+====================
+WORKED MINI EXAMPLE
+====================
+
+Input key_values:
+
+[
+  {
+    "id": "total_budget",
+    "unit": "EUR",
+    "value": 1000000
+  },
+  {
+    "id": "conversion_rate",
+    "unit": "fraction",
+    "value": 0.5
+  }
+]
+
+Input missing_values_to_estimate:
+
+[
+  {
+    "id": "target_population",
+    "unit": "people"
+  }
+]
+
+Input bounds:
+
+{
+  "target_population": {
+    "unit": "people",
+    "low": 10000,
+    "base": 20000,
+    "high": 40000,
+    "rationale": "...",
+    "source": "assumption"
+  },
+  "conversion_rate": {
+    "unit": "fraction",
+    "low": 0.3,
+    "base": 0.5,
+    "high": 0.7,
+    "rationale": "...",
+    "source": "assumption"
+  }
+}
+
+Input calculation:
+
+people_reached = target_population * conversion_rate
+
+Output:
+
+{
+  "valid": true,
+  "plan_summary": {
+    "plan_name": "",
+    "plan_type": ""
+  },
+  "scenarios": {
+    "low": {
+      "inputs": {
+        "total_budget": 1000000,
+        "conversion_rate": 0.3,
+        "target_population": 10000,
+        "people_reached": 3000
+      },
+      "outputs": {
+        "people_reached": 3000
+      }
+    },
+    "base": {
+      "inputs": {
+        "total_budget": 1000000,
+        "conversion_rate": 0.5,
+        "target_population": 20000,
+        "people_reached": 10000
+      },
+      "outputs": {
+        "people_reached": 10000
+      }
+    },
+    "high": {
+      "inputs": {
+        "total_budget": 1000000,
+        "conversion_rate": 0.7,
+        "target_population": 40000,
+        "people_reached": 28000
+      },
+      "outputs": {
+        "people_reached": 28000
+      }
+    }
+  },
+  "comparison": {
+    "outputs": {
+      "people_reached": {
+        "low": 3000,
+        "base": 10000,
+        "high": 28000,
+        "unit": "people",
+        "spread_ratio": 9.333333333333334,
+        "spread_absolute": 25000
+      }
+    }
+  },
+  "warnings": []
+}

--- a/experiments/napkin_math/.claude/skills/validate-parameters/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/validate-parameters/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: validate-parameters
+description: Use when the user wants to validate, lint, or check the JSON output of the extract-parameters stage against the schema, hard caps, percentage rules, formula-id declaration rules, and source-text cleanliness rules
+---
+
+# Validate extract-parameters JSON
+
+## Overview
+
+Wraps the validation system prompt at `system-prompt.txt` (next to this file) and applies it to a JSON document produced by the `extract-parameters` skill. Output is a strict JSON validation report with stable rule IDs (e.g., `F001`, `C005`, `V001`) so downstream tooling can parse violations programmatically.
+
+## When to Use
+
+- User asks to "validate", "check", "lint", or "audit" an extracted-parameters JSON file
+- User wants to verify a JSON file conforms to the extract-parameters schema and rules before feeding it to downstream code generation
+- User mentions one of the rule categories explicitly (caps, percentages, formula identifiers, source-text cleanliness)
+
+Not for: regenerating the parameters (use `extract-parameters`), normalising or fixing the JSON, or generating Python from it. Validation is read-only and reports findings only.
+
+## Workflow
+
+1. **Get the input JSON path.** If the user did not provide one, ask. Do not guess.
+2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Treat its rules and rule IDs as authoritative.
+3. **Read the JSON file** to be validated.
+4. **Produce the validation report** following the exact output shape in the system prompt.
+5. **Output destination.** Default: print the report JSON to the chat. If the user asks for a file, write to the path they specify. Suggested default file path: `<input-basename>.validation.json` next to the input.
+
+## Output Shape (re-stated for emphasis — see system prompt for full detail)
+
+```
+{
+  "valid": <bool>,
+  "error_count": <int>,
+  "warn_count": <int>,
+  "violations": [ { "rule_id", "severity", "path", "message", "suggested_fix" }, ... ],
+  "summary": { "counts": {...}, "rule_id_breakdown": {...} }
+}
+```
+
+`valid` is true if and only if `error_count == 0`. WARN-level findings do not invalidate the document.
+
+## Rule Categories (rule IDs in system-prompt.txt)
+
+| Prefix | Category | Severity bias |
+|---|---|---|
+| `S00x` | Structural (top-level keys, required fields per entry) | ERROR |
+| `C00x` | Caps (8/5/5/5, 25-word comment, 20-word source_text) | ERROR |
+| `E00x` | Enums (value_type, category, modelling_priority, uncertainty) | ERROR |
+| `V00x` | Unit / value (fractions in [0,1], missing_but_needed → null) | ERROR + 1 WARN |
+| `I00x` | Id uniqueness and snake_case format | ERROR |
+| `F00x` | Formula RHS identifier declaration, depends_on consistency | Mostly ERROR |
+| `Q00x` | Triage quality (suggested_low/base/high, duplicates) | WARN |
+| `T00x` | Source text cleanliness (citations, replacement chars) | WARN |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Wrapping the validation report in ```` ```json ```` fences | Raw JSON only |
+| Listing rules that passed | Report only rules that fired |
+| Treating WARN findings as invalidating | `valid` is gated only on ERROR count |
+| Treating LHS of `name = expr` as needing declaration | LHS names the output; only RHS identifiers are checked (rule F002 documents this) |
+| Treating numeric literals as undeclared identifiers | Literals on the RHS are allowed and not checked |
+| Treating `P(...)`, `max(...)`, `log(...)` etc. as undeclared identifiers | Common lowercase function names are allowed; their arguments are the identifiers to check |
+
+## Reference
+
+- System prompt (authoritative): `system-prompt.txt`
+- Companion skill that produces the input: `../extract-parameters/SKILL.md`
+- Example inputs for testing: `/tmp/extract-params-heatwave-v6.json`, `/tmp/extract-params-heatwave-v5.json`, etc.

--- a/experiments/napkin_math/.claude/skills/validate-parameters/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/validate-parameters/system-prompt.txt
@@ -1,0 +1,375 @@
+You are a strict JSON validator for the output of the PlanExe extract_parameters stage.
+
+Input should be a single JSON document with this shape:
+
+{
+  "plan_summary": { ... },
+  "key_values": [ ... ],
+  "derived_questions": [ ... ],
+  "missing_values_to_estimate": [ ... ],
+  "recommended_first_calculations": [ ... ]
+}
+
+Run every rule below against the input and return one JSON validation report.
+
+Return JSON only. No markdown. No prose. No explanation.
+
+Do not include rules that passed in the report.
+
+Each violation must include:
+- rule_id
+- severity
+- path
+- message
+- suggested_fix
+
+Severity must be either ERROR or WARN.
+
+valid is true if and only if error_count == 0.
+
+Order violations:
+1. All ERROR violations first.
+2. Then all WARN violations.
+3. Within each severity group, sort by rule_id.
+4. Within each rule_id, sort by path.
+
+summary.counts must reflect the actual list lengths in the input.
+
+summary.rule_id_breakdown must map each rule_id that fired at least once to its count.
+
+suggested_fix should be one concrete sentence, or null if no obvious fix exists.
+
+Do not output narrative outside the JSON.
+
+====================
+JSON PARSE RULES
+====================
+
+J001 (ERROR): If the input is not valid JSON, return the standard report shape with:
+- valid: false
+- error_count: 1
+- warn_count: 0
+- one violation at path "$"
+- counts set to 0 where unavailable
+- rule_id_breakdown containing {"J001": 1}
+
+Suggested fix: "Provide valid JSON with double-quoted keys and string values, no trailing commas, and no markdown wrapper."
+
+====================
+STRUCTURAL RULES
+====================
+
+S001 (ERROR): Top-level object must contain exactly these keys:
+- plan_summary
+- key_values
+- derived_questions
+- missing_values_to_estimate
+- recommended_first_calculations
+
+Extra or missing top-level keys are violations.
+
+S002 (ERROR): plan_summary must contain exactly these keys:
+- plan_name
+- plan_type
+- primary_goal
+- modelling_frame
+
+S003 (ERROR): Each key_values entry must contain exactly these keys:
+- id
+- label
+- category
+- value_type
+- unit
+- value
+- comment
+- formula_hint
+- depends_on
+- modelling_priority
+- uncertainty
+- source_text
+
+S004 (ERROR): Each derived_questions entry must contain exactly these keys:
+- id
+- question
+- why_it_matters
+- formula_hint
+- depends_on
+
+S005 (ERROR): Each missing_values_to_estimate entry must contain exactly these keys:
+- id
+- label
+- unit
+- why_needed
+- suggested_estimation_method
+
+S006 (ERROR): Each recommended_first_calculations entry must contain exactly these keys:
+- id
+- label
+- formula_hint
+- depends_on
+- why_first
+
+S007 (ERROR): key_values, derived_questions, missing_values_to_estimate, and recommended_first_calculations must be arrays.
+
+S008 (ERROR): plan_summary must be an object.
+
+S009 (ERROR): Every entry inside key_values, derived_questions, missing_values_to_estimate, and recommended_first_calculations must be an object.
+
+S010 (ERROR): depends_on must be an array of strings wherever present.
+
+S011 (ERROR): formula_hint must be either null or a string wherever present.
+
+S012 (ERROR): key_values.value must be null, number, string, or boolean.
+
+S013 (WARN): key_values.value should usually be null or numeric. Non-null strings or booleans may be harder for code generation unless the unit clearly requires them.
+
+S014 (ERROR): All fields in plan_summary must be strings.
+
+S015 (ERROR): In missing_values_to_estimate, id, label, unit, why_needed, and suggested_estimation_method must be strings.
+
+====================
+CAP RULES
+====================
+
+C001 (ERROR): key_values length must be <= 8.
+
+C002 (ERROR): derived_questions length must be <= 5.
+
+C003 (ERROR): missing_values_to_estimate length must be <= 5.
+
+C004 (ERROR): recommended_first_calculations length must be <= 5.
+
+C005 (ERROR): Each key_values comment must be <= 25 words.
+Split on whitespace. Hyphenated and slash-joined tokens count as one word.
+
+C006 (ERROR): Each key_values source_text must be <= 20 words.
+Split on whitespace. Hyphenated and slash-joined tokens count as one word.
+
+====================
+ENUM RULES
+====================
+
+E001 (ERROR): key_values.value_type must be one of:
+- explicit
+- derived
+- inferred
+- missing_but_needed
+
+E002 (ERROR): key_values.category must be one of:
+- budget
+- cost
+- demand
+- conversion
+- capacity
+- time
+- coverage
+- impact
+- operational
+- risk
+- funding_gate
+- staffing
+- logistics
+- compliance
+- outcome
+- sensitivity
+- other
+
+E003 (ERROR): key_values.modelling_priority must be one of:
+- critical
+- high
+- medium
+- low
+
+E004 (ERROR): key_values.uncertainty must be one of:
+- low
+- medium
+- high
+
+====================
+UNIT AND VALUE RULES
+====================
+
+V001 (ERROR): If unit == "fraction", value must be a number in [0, 1] or null.
+A value greater than 1, such as 60 for 60%, is a violation.
+
+Suggested fix: "Represent percentages as fractions between 0 and 1, for example 60% as 0.6."
+
+V002 (ERROR): If value_type == "missing_but_needed", value must be null.
+
+V003 (WARN): If value_type is "explicit" or "derived" and value is null, flag it.
+The extractor may have legitimately omitted the number, but it is worth reviewing.
+
+V004 (WARN): If unit is "percent", flag it.
+The extractor should normally use unit "fraction" and values between 0 and 1.
+
+Suggested fix: "Use unit 'fraction' and convert the value to a number between 0 and 1."
+
+V005 (WARN): If a missing_values_to_estimate entry has unit "unknown", flag it.
+Bounds generation works better when missing values have concrete units.
+
+Suggested fix: "Infer a concrete modelling unit such as fraction, people, EUR, days, events_per_person_per_period, or probability."
+
+====================
+ID RULES
+====================
+
+I001 (ERROR): All ids in key_values must be unique.
+
+I002 (ERROR): All ids in missing_values_to_estimate must be unique.
+
+I003 (ERROR): No id may appear in both key_values and missing_values_to_estimate.
+
+I004 (ERROR): All ids must match snake_case:
+^[a-z][a-z0-9_]*$
+
+No leading digit, no uppercase, no hyphens.
+
+Apply this to ids in:
+- key_values
+- derived_questions
+- missing_values_to_estimate
+- recommended_first_calculations
+- depends_on entries
+
+I005 (ERROR): All ids across key_values, missing_values_to_estimate, derived_questions, and recommended_first_calculations must be globally unique.
+
+====================
+DEPENDENCY RULES
+====================
+
+D001 (ERROR): Every id in depends_on must be declared in at least one of:
+- key_values[*].id
+- missing_values_to_estimate[*].id
+- derived_questions[*].id
+- recommended_first_calculations[*].id
+
+depends_on does not declare variables. It only references globally declared variables.
+
+If a depends_on id is not declared globally, emit one D001 violation naming the undeclared id and path.
+
+====================
+FORMULA RULES
+====================
+
+To check formulas:
+
+- formula_hint may be null, a plain expression, or an assignment.
+- Example plain expression: "a / b"
+- Example assignment: "x = a / b"
+- If "=" is present, split on the first "=".
+- The left side is the LHS output name.
+- The right side is the RHS expression.
+- If no "=" is present, treat the whole string as the RHS.
+- The LHS may introduce a calculated output id and does not need to be declared elsewhere.
+- Numeric literals are allowed and do not need to be declared.
+- Numeric literals include integers, decimals, and scientific notation.
+- Function-call notation is allowed only for simple math/probability functions.
+- Examples of allowed functions: P(...), p(...), max(...), min(...), exp(...), log(...), sqrt(...), abs(...), sum(...), avg(...), mean(...).
+- The function name itself is not treated as an identifier requiring declaration.
+- Function arguments are checked as identifiers when they match the identifier pattern.
+- Operators +, -, *, /, **, parentheses, commas, comparison operators >=, <=, >, <, ==, !=, and whitespace are allowed.
+- An identifier matches:
+  ^[a-z][a-z0-9_]*$
+
+F001 (ERROR): Every RHS identifier in any formula_hint must be declared in at least one of:
+- key_values[*].id
+- missing_values_to_estimate[*].id
+- derived_questions[*].id
+- recommended_first_calculations[*].id
+
+Do not treat the current object's depends_on list as a declaration source.
+
+For each undeclared identifier, emit one F001 violation naming the identifier and the formula path.
+
+F002 (WARN): This rule never fires.
+It documents that the LHS in "name = expression" form names the calculation's output and need not be declared elsewhere.
+
+F003 (WARN): If a formula_hint references a globally declared identifier that is not in the current object's depends_on list, flag it.
+This helps keep dependency graphs accurate.
+
+Do not apply F003 to entries where formula_hint is null.
+
+F004 (WARN): This rule never fires.
+It documents that recommended_first_calculations entries must include depends_on.
+
+F005 (WARN): Avoid identifiers that appear semantically different from the entry's own id or label.
+Only emit this warning if the mismatch is obvious and likely accidental.
+Example: an entry about target_population uses registered_population in formula_hint without explaining the relationship.
+
+Use this rule sparingly.
+
+====================
+TRIAGE AND QUALITY RULES
+====================
+
+Q001 (WARN): suggested_low, suggested_base, or suggested_high appears in any key_values entry.
+The extractor prompt allows these only when essential.
+
+Q002 (WARN): Two or more key_values share the same category and the same numeric value.
+This may indicate duplicate triage choices.
+
+Q003 (WARN): This semantic quality check is optional and should be used sparingly.
+Emit only if a formula_hint depends on an id whose label clearly suggests a different real-world quantity than the entry's own label, and the mismatch is likely confusing for code generation.
+
+====================
+SOURCE TEXT CLEANLINESS
+====================
+
+T001 (WARN): source_text contains likely citation markers, replacement characters, raw HTML entities, or leading/trailing whitespace.
+
+Flag examples:
+- [1]
+- (3)
+- ¹
+- ²
+- ³
+- �
+- &amp;
+- &lt;
+- &gt;
+- leading whitespace
+- trailing whitespace
+
+====================
+OUTPUT SHAPE
+====================
+
+Return exactly this shape:
+
+{
+  "valid": false,
+  "error_count": 0,
+  "warn_count": 0,
+  "violations": [
+    {
+      "rule_id": "F001",
+      "severity": "ERROR",
+      "path": "key_values[3].formula_hint",
+      "message": "Undeclared identifier 'registered_vulnerable_population' on RHS of formula_hint.",
+      "suggested_fix": "Declare 'registered_vulnerable_population' in key_values, missing_values_to_estimate, derived_questions, or recommended_first_calculations, or rewrite the formula using declared ids."
+    }
+  ],
+  "summary": {
+    "counts": {
+      "key_values": 0,
+      "derived_questions": 0,
+      "missing_values_to_estimate": 0,
+      "recommended_first_calculations": 0
+    },
+    "rule_id_breakdown": {}
+  }
+}
+
+Rules for final report:
+- valid is true if and only if error_count == 0.
+- error_count is the number of ERROR violations.
+- warn_count is the number of WARN violations.
+- Do not include rules that passed.
+- Order violations: all ERROR severity first, then all WARN.
+- Within each severity group, sort by rule_id, then by path.
+- summary.counts reflects the actual list lengths in the input.
+- If the input is invalid JSON, use zero counts.
+- summary.rule_id_breakdown maps each rule_id that fired at least once to its count.
+- suggested_fix should be a single concrete sentence, or null if no obvious fix exists.
+- Do not output narrative outside this JSON.
+- Do not use markdown.

--- a/experiments/napkin_math/README.md
+++ b/experiments/napkin_math/README.md
@@ -1,0 +1,773 @@
+# PlanExe Parameter Modelling Pipeline
+
+This pipeline turns a PlanExe report into a small, validated modelling specification that can later be used to generate napkin-math calculations, deterministic scenarios, bounds, and Monte Carlo simulations.
+
+The goal is not to fully model the plan in one step. The goal is to extract the few key values that matter, validate them, estimate missing inputs, and then generate simple first-principles calculations.
+
+## Why this exists
+
+PlanExe reports often contain many numbers, risks, goals, decisions, timelines, and KPIs. Most of those are not useful for immediate modelling.
+
+This pipeline focuses on identifying the values that answer questions like:
+
+- What must be true for this plan to work?
+- What are the main denominators?
+- What are the pass/fail thresholds?
+- What are the bottlenecks?
+- What values are missing but required?
+- What should be calculated before Monte Carlo?
+
+For example, in a public-health plan, the key values may be vulnerable population, outreach rate, intervention effectiveness, baseline harm rate, and budget gates. In an event plan, they may be attendee demand, ticket yield, sell-through, fixed costs, sponsorship, and break-even attendance.
+
+## Pipeline overview
+
+```text
+PlanExe report
+  -> extract-parameters
+  -> validate-parameters
+  -> repair-parameters, optional
+  -> generate-bounds
+  -> generate-calculations
+  -> run-scenarios
+  -> monte-carlo
+```
+
+Each stage has a narrow responsibility. This keeps the system easier to debug and prevents a single prompt from trying to do everything.
+
+---
+
+# Stage 1: extract-parameters
+
+## Purpose
+
+`extract-parameters` reads a PlanExe report and returns a compact JSON modelling seed.
+
+It should identify only the few most important values for napkin math. It is intentionally non-exhaustive.
+
+The output should be small enough for a human to inspect and structured enough for code to process.
+
+## Input
+
+A PlanExe report, usually HTML or extracted text.
+
+## Output
+
+A JSON object with this shape:
+
+```json
+{
+  "plan_summary": {
+    "plan_name": "",
+    "plan_type": "",
+    "primary_goal": "",
+    "modelling_frame": ""
+  },
+  "key_values": [],
+  "derived_questions": [],
+  "missing_values_to_estimate": [],
+  "recommended_first_calculations": []
+}
+```
+
+## Hard caps
+
+The extractor should return at most:
+
+```text
+8 key_values
+5 derived_questions
+5 missing_values_to_estimate
+5 recommended_first_calculations
+```
+
+It may return fewer. It should not pad the output just to fill the caps.
+
+## What `key_values` are
+
+`key_values` are the most important modelling values found or inferred from the report.
+
+Each key value has this shape:
+
+```json
+{
+  "id": "outreach_contact_rate_target",
+  "label": "Outreach contact rate target",
+  "category": "funding_gate",
+  "value_type": "explicit",
+  "unit": "fraction",
+  "value": 0.6,
+  "comment": "Pass/fail KPI of the Month 4 gate; share of registered vulnerable residents successfully contacted.",
+  "formula_hint": "people_contacted = registered_vulnerable_population * outreach_contact_rate_target",
+  "depends_on": ["registered_vulnerable_population", "outreach_contact_rate_target"],
+  "modelling_priority": "critical",
+  "uncertainty": "medium",
+  "source_text": "60% proactive outreach contact rate to the registered vulnerable population"
+}
+```
+
+## Value types
+
+```text
+explicit             directly stated in the report
+derived              calculable from other values
+inferred             strongly implied but not directly stated
+missing_but_needed   needed for modelling but absent from the report
+```
+
+## Important extraction principles
+
+The extractor should prefer values that materially affect viability, scale, cost, capacity, impact, or risk.
+
+It should not extract every number in the report.
+
+It should prefer modelling denominators, thresholds, and bottlenecks over descriptive facts.
+
+Examples of high-value modelling variables:
+
+```text
+total budget or available budget
+gate funding amount
+pass/fail KPI threshold
+target population
+conversion/contact/adoption rate
+capacity or throughput
+unit cost
+reserve or contingency
+baseline risk
+intervention effectiveness
+break-even threshold
+```
+
+## True denominator vs internal denominator
+
+A common problem is that plans report an internal KPI denominator, but the real-world denominator is different.
+
+Example:
+
+```text
+60% contact rate of registered vulnerable residents
+```
+
+This is not the same as:
+
+```text
+60% of all vulnerable residents
+```
+
+The extractor should preserve this distinction.
+
+Useful modelling chain:
+
+```text
+total_target_population
+  -> registered_population
+  -> contacted_population
+  -> protected_population
+  -> avoided_harm
+```
+
+When the cap forces a choice between the true real-world denominator and the internal program denominator, prefer the true denominator in `key_values` and place the internal denominator in `missing_values_to_estimate`, unless the internal denominator is itself the direct pass/fail gate.
+
+## Contact, protection, and effectiveness
+
+Do not collapse these concepts:
+
+```text
+contact_rate                 share of people successfully reached
+protection_conversion_rate   share of reached people who receive a usable intervention
+intervention_effectiveness   reduction in adverse outcomes among protected people
+```
+
+Bad:
+
+```text
+protected_people = contacted_people * intervention_effectiveness
+```
+
+Better:
+
+```text
+protected_people = contacted_people * protection_conversion_rate
+avoided_harm = protected_people * baseline_event_rate * intervention_effectiveness
+```
+
+## Dependency discipline
+
+`depends_on` must list formula inputs, not formula outputs.
+
+For a formula:
+
+```text
+output_id = input_a * input_b
+```
+
+`depends_on` should be:
+
+```json
+["input_a", "input_b"]
+```
+
+It should not include `output_id` unless the RHS also uses it.
+
+All ids in `depends_on` must be declared globally in one of:
+
+```text
+key_values
+missing_values_to_estimate
+derived_questions
+recommended_first_calculations
+```
+
+`depends_on` must not introduce new variables.
+
+If a formula needs an input that is not declared, the extractor should either:
+
+```text
+1. add it to missing_values_to_estimate if it is an external input or assumption,
+2. add it to recommended_first_calculations if it is a derived intermediate value, or
+3. rewrite the formula to avoid that input.
+```
+
+## Formula rules
+
+`formula_hint` is not executable Python. It is a simple implementation hint for later stages.
+
+Allowed examples:
+
+```text
+people_contacted = registered_vulnerable_population * outreach_contact_rate_target
+cost_per_protected_person = total_budget / people_protected
+mcr_events_supported = minimum_contingency_reserve / level3_activation_cost
+```
+
+Percentages should be represented as fractions:
+
+```text
+60% -> value: 0.6, unit: "fraction"
+```
+
+---
+
+# Stage 2: validate-parameters
+
+## Purpose
+
+`validate-parameters` checks whether the extractor output is structurally valid and usable by downstream code.
+
+It does not decide whether the modelling choices are perfect. It verifies that the JSON is consistent, bounded, dependency-safe, and machine-readable.
+
+## Input
+
+The JSON output from `extract-parameters`.
+
+## Output
+
+A validation report:
+
+```json
+{
+  "valid": true,
+  "error_count": 0,
+  "warn_count": 0,
+  "violations": [],
+  "summary": {
+    "counts": {
+      "key_values": 8,
+      "derived_questions": 5,
+      "missing_values_to_estimate": 5,
+      "recommended_first_calculations": 3
+    },
+    "rule_id_breakdown": {}
+  }
+}
+```
+
+## Error vs warning
+
+`ERROR` means downstream code should not continue without repair.
+
+`WARN` means the output is still valid but should be reviewed.
+
+A document is valid if and only if:
+
+```text
+error_count == 0
+```
+
+Warnings do not make the output invalid.
+
+## Validation categories
+
+The validator checks:
+
+```text
+JSON parse validity
+top-level structure
+required fields
+array lengths
+comment/source_text word caps
+enum values
+fraction formatting
+id uniqueness
+snake_case ids
+depends_on references
+formula RHS references
+source_text cleanliness
+```
+
+## Important validator rules
+
+### Global id declaration
+
+Every id used in `depends_on` must be declared globally in one of:
+
+```text
+key_values[*].id
+missing_values_to_estimate[*].id
+derived_questions[*].id
+recommended_first_calculations[*].id
+```
+
+This prevents formulas from referencing variables that the code generator cannot resolve.
+
+### Formula RHS declaration
+
+Every identifier on the right-hand side of a `formula_hint` must be globally declared.
+
+The left-hand side may introduce the output id.
+
+Example:
+
+```text
+people_contacted = registered_vulnerable_population * outreach_contact_rate_target
+```
+
+RHS ids that must be declared:
+
+```text
+registered_vulnerable_population
+outreach_contact_rate_target
+```
+
+LHS output:
+
+```text
+people_contacted
+```
+
+The LHS does not need to be declared elsewhere if it is the current entry's id.
+
+### Numeric literals
+
+Numeric literals are allowed and do not need declaration.
+
+Example:
+
+```text
+kit_procurement_allocation = pre_gate_budget * 0.4
+```
+
+`0.4` does not need an id.
+
+### Function-style formulas
+
+Simple probability or math notation is allowed:
+
+```text
+gate_pass_probability = P(contact_rate >= contact_rate_target) * P(utilization >= utilization_target)
+```
+
+But variable-like arguments must be declared.
+
+---
+
+# Stage 3: repair-parameters, optional
+
+## Purpose
+
+`repair-parameters` takes an invalid extractor output and a validation report, then fixes the JSON.
+
+This stage should be used only when `validate-parameters.valid == false`.
+
+## Input
+
+```text
+1. extracted parameter JSON
+2. validation report
+```
+
+## Output
+
+A repaired parameter JSON with the same schema as `extract-parameters`.
+
+## Typical repairs
+
+```text
+Add missing dependency ids to missing_values_to_estimate.
+Move formula outputs out of depends_on.
+Add RHS inputs to depends_on.
+Convert 60 to 0.6 for fraction values.
+Rename invalid ids to snake_case.
+Remove extra fields.
+Trim comments or source_text to word limits.
+Remove duplicate ids.
+```
+
+## Repair rule
+
+Repairs should be minimal. Do not reinterpret the whole plan if a local schema repair is enough.
+
+---
+
+# Stage 4: generate-bounds
+
+## Purpose
+
+`generate-bounds` adds low/base/high assumptions for missing or uncertain values.
+
+It prepares the model for deterministic scenarios and later Monte Carlo.
+
+## Input
+
+A valid parameter JSON.
+
+## Output
+
+A bounds JSON, keyed by variable id.
+
+Example:
+
+```json
+{
+  "vulnerable_population_share": {
+    "unit": "fraction",
+    "low": 0.10,
+    "base": 0.20,
+    "high": 0.30,
+    "rationale": "Approximate range for 65+, chronic illness, social isolation, and housing-risk overlap."
+  },
+  "protection_conversion_rate": {
+    "unit": "fraction",
+    "low": 0.30,
+    "base": 0.55,
+    "high": 0.75,
+    "rationale": "Reflects delivery leakage between contact and usable protection."
+  }
+}
+```
+
+## What needs bounds
+
+Bounds are especially important for:
+
+```text
+missing_values_to_estimate
+inferred key_values
+high-uncertainty key_values
+probability inputs
+conversion rates
+baseline event rates
+costs with weak evidence
+capacity assumptions
+```
+
+## Bounds are not facts
+
+Bounds are modelling placeholders. They should be labelled as assumptions unless backed by data.
+
+---
+
+# Stage 5: generate-calculations
+
+## Purpose
+
+`generate-calculations` turns `formula_hint` entries into simple deterministic Python functions.
+
+This should happen after validation, and preferably after bounds exist for missing inputs.
+
+## Input
+
+```text
+1. valid parameter JSON
+2. optional bounds JSON
+```
+
+## Output
+
+Python code containing deterministic functions for recommended first calculations and derived questions.
+
+Example:
+
+```python
+def people_contacted(registered_vulnerable_population: float, outreach_contact_rate_target: float) -> float:
+    return registered_vulnerable_population * outreach_contact_rate_target
+
+
+def cost_per_protected_person(total_budget: float, people_protected: float) -> float:
+    if people_protected <= 0:
+        return float("inf")
+    return total_budget / people_protected
+```
+
+## Code-generation rules
+
+Generated code should:
+
+```text
+Use function names based on calculation ids or formula LHS.
+Use explicit arguments based on depends_on.
+Add divide-by-zero guards.
+Use floats for numeric modelling.
+Avoid hidden global state.
+Return dictionaries for grouped scenario outputs.
+Keep functions small and inspectable.
+```
+
+## What not to do
+
+Do not generate Monte Carlo first.
+
+Do not generate a large application.
+
+Do not invent a complex class hierarchy unless the formulas require it.
+
+Start with deterministic functions.
+
+---
+
+# Stage 6: run-scenarios
+
+## Purpose
+
+`run-scenarios` applies low/base/high assumptions to the generated deterministic functions.
+
+This gives an early reality check before Monte Carlo.
+
+## Input
+
+```text
+1. valid parameter JSON
+2. bounds JSON
+3. generated calculation functions
+```
+
+## Output
+
+A scenario table.
+
+Example:
+
+```text
+scenario | vulnerable_population | people_contacted | people_protected | cost_per_protected_person
+low      | 40,000                | 4,800            | 1,440            | €2,431
+base     | 80,000                | 14,400           | 7,920            | €442
+high     | 120,000               | 28,800           | 21,600           | €162
+```
+
+## Scenario purpose
+
+Scenario tables answer:
+
+```text
+What happens in the downside case?
+What does the base case require?
+What has to be true for the upside case?
+Which assumption dominates the result?
+```
+
+---
+
+# Stage 7: monte-carlo
+
+## Purpose
+
+`monte-carlo` samples uncertain inputs and estimates distributions of outputs.
+
+Monte Carlo should come after deterministic calculations and bounds are working.
+
+## Input
+
+```text
+1. valid parameter JSON
+2. bounds JSON
+3. generated calculation functions (calculations.py)
+4. optional run settings (n_runs, seed, distribution_default,
+   outputs_of_interest, thresholds, gate_probabilities,
+   correlation_groups)
+```
+
+## Output
+
+A JSON document with per-output summary statistics, per-threshold pass
+probabilities, a Pearson-correlation sensitivity ranking of input
+drivers, and aggregated warnings.
+
+```json
+{
+  "valid": true,
+  "settings": { "n_runs": 10000, "seed": 12345, "distribution_default": "triangular" },
+  "outputs": {
+    "<output_id>": {
+      "unit": "EUR",
+      "count": 10000,
+      "missing_count": 0,
+      "mean": 0, "std": 0,
+      "min": 0, "p05": 0, "p25": 0, "p50": 0, "p75": 0, "p95": 0, "max": 0
+    }
+  },
+  "thresholds": {
+    "<output_id>": {
+      "operator": ">=", "value": 0,
+      "success_count": 0, "valid_count": 10000, "probability": 0.0
+    }
+  },
+  "sensitivity": {
+    "<output_id>": { "top_inputs": [ { "id": "...", "correlation": 0.0 } ] }
+  },
+  "warnings": []
+}
+```
+
+## Monte Carlo should not be first
+
+Before Monte Carlo, the pipeline should already know:
+
+```text
+the main denominators
+the missing inputs
+the deterministic formulas
+the low/base/high scenario behavior
+```
+
+Monte Carlo answers "how often?" It does not replace first-principles structure.
+
+---
+
+# Recommended implementation order
+
+Build the stages in this order:
+
+```text
+1. extract-parameters
+2. validate-parameters
+3. repair-parameters
+4. generate-bounds
+5. generate-calculations
+6. run-scenarios
+7. monte-carlo
+```
+
+The first milestone is complete when:
+
+```text
+extract-parameters output passes validate-parameters with valid=true
+```
+
+The second milestone is complete when:
+
+```text
+generate-calculations can produce deterministic Python functions from a valid extraction
+```
+
+The third milestone is complete when:
+
+```text
+run-scenarios can produce low/base/high outputs without manual edits
+```
+
+The fourth milestone is complete when:
+
+```text
+monte-carlo can produce per-output distributions and per-threshold pass
+probabilities from the same trio of artifacts
+```
+
+---
+
+# Design principles
+
+## Keep stages narrow
+
+Each stage should do one thing.
+
+Bad:
+
+```text
+One prompt extracts values, estimates bounds, writes code, runs scenarios, and critiques the plan.
+```
+
+Good:
+
+```text
+extract -> validate -> repair -> bound -> calculate -> scenario -> simulate
+```
+
+## Prefer explicit schemas
+
+Every stage should have a defined input and output schema.
+
+This makes errors visible and repairable.
+
+## Treat LLM output as untrusted until validated
+
+Even good model output should pass through validation before code generation.
+
+## Prefer deterministic calculations before Monte Carlo
+
+Monte Carlo is useful only after the deterministic model is sane.
+
+## Keep assumptions editable
+
+Missing and inferred values should remain visible assumptions, not hidden constants.
+
+## Do not overfit to one report type
+
+The same pipeline should work for:
+
+```text
+public health plans
+event plans
+startup plans
+construction plans
+software plans
+education plans
+climate plans
+logistics plans
+research plans
+```
+
+The extractor should adapt the modelling frame to the plan's purpose.
+
+---
+
+# Current status
+
+All six active pipeline stages are implemented as skills under
+`.claude/skills/` and have been tested end-to-end on two unrelated
+PlanExe reports:
+
+- a public-health resilience plan (Leipzig Heat Response)
+- a commercial consumer-electronics plan (Estonian Faraday enclosure)
+
+Both reports round-trip cleanly through the full chain — extract,
+validate (`valid: true`), bound, calculate, scenario, monte-carlo —
+into versioned output directories under
+`output/<version>/<report-name>/`:
+
+```text
+parameters.json     extract-parameters
+validation.json     validate-parameters
+bounds.json         generate-bounds
+calculations.py     generate-calculations
+scenarios.json      run-scenarios
+montecarlo.json     monte-carlo
+```
+
+The same skills handle both domains without per-domain customisation,
+so the pipeline is not plan-type-specific.
+
+`repair-parameters` (Stage 3) remains optional and unbuilt. The
+extractor has so far produced JSON that passes validation cleanly on
+its own; the repair stage will be built if/when an extraction reliably
+fails in a way local schema fixes can resolve.
+

--- a/experiments/napkin_math/docs/20260512_claude.md
+++ b/experiments/napkin_math/docs/20260512_claude.md
@@ -1,0 +1,220 @@
+# Pipeline status — Claude's view, 2026-05-12
+
+This document captures my (Claude's) first-hand perception of the
+PlanExe parameter modelling pipeline after running it across three
+unrelated plan domains and 23 versioned iterations of the system
+prompts. It is intentionally honest: things that work, things that
+don't, and where the recurring structural gaps are.
+
+## TL;DR
+
+Six skills are built and round-trip end-to-end on three unrelated
+plans: a public-health resilience plan (Leipzig Heat Response), a
+commercial product launch (Estonian Faraday enclosure), and a
+community small-business plan (Nuuk Clay Workshop). The pipeline
+produces materially useful answers — `P(gate_pass) ≈ 0` for Faraday,
+single-shock dominance with r=−1.00 for Nuuk's labor-law variable,
+~25 median deaths avoided for the Leipzig pilot. The same prompts
+handle all three domains without per-domain customisation.
+
+The recurring structural gap is a **bounds-skip-but-no-calc black
+hole** that has bitten three times across versions (v15, v20, v23).
+When the extractor places a derivable id in
+`missing_values_to_estimate`, the bounds skill skips it expecting
+`generate-calculations` to handle it, but `generate-calculations`
+only emits functions for entries in `recommended_first_calculations`
+and `derived_questions`. The id ends up neither bounded nor computed,
+and any calculation that depends on it produces 0 finite results.
+Closing this gap is the single highest-leverage improvement available.
+
+## Skill-by-skill status
+
+### 1. extract-parameters — solid
+
+Reliably produces a parameter JSON that other stages can consume. Hard
+caps (8/5/5/5) are respected. Schema discipline (depends_on uniqueness,
+formula RHS declaration, `_eur`/`_dkk` currency suffixes,
+fractions-as-fractions) is consistent across runs. Markdown ingestion
+(introduced at v20) is materially cheaper than HTML — same plan as
+markdown is roughly 22% the file size and parses cleanly without HTML
+artifact stripping in `source_text`.
+
+The dead-end-prevention rule is partly working: the extractor proactively
+drops variables that no calculation would consume (the Nuuk extractor
+explicitly dropped `staffing_fte` once for this reason). But it still
+misses about 2-3 dead-ends per run on average across the runs I have
+inspected.
+
+### 2. validate-parameters — solid
+
+Catches real schema drift cleanly. The Faraday v16 caught a S003 error
+(extractor included `suggested_low/base/high` on a key_value despite the
+schema disallowing it) — that's the kind of catch this skill is for.
+Stable rule IDs (S/C/E/V/I/F/D/Q/T) make violations machine-parseable.
+Across 11 full pipeline runs, validation has produced exactly one ERROR
+(Faraday v16) and a handful of WARNs.
+
+### 3. repair-parameters — unbuilt and not blocking
+
+Still optional and not implemented. The extractor has produced clean
+output in 10 of 11 runs without it. Worth deferring until a real
+recurring extraction failure appears that local schema fixes can resolve.
+
+### 4. generate-bounds — solid for sampling, has the dependency black hole
+
+For variables it bounds, the spread heuristics (low uncertainty
+±10–20%, medium ±25–50%, high 2–5×, fractions clamped to [0,1],
+counts as integers, binary-gate Bernoulli for monetary `low=0,
+base=high=X` patterns) produce defensible ranges. Source labelling
+(`data` vs `assumption`) is honest.
+
+The black hole: when an `missing_values_to_estimate` entry looks like
+a derived output (id contains `_shortfall`, `_gap`, etc.), bounds
+skips it under the rule "skip if calculable from declared inputs". But
+nothing else picks it up — `generate-calculations` only emits
+functions for `recommended_first_calculations` and `derived_questions`
+entries. Net: the id is unresolvable, and calculations depending on
+it produce 0 finite results. This pattern bit Nuuk v20
+(`required_members_for_payroll`), Heatwave v15
+(`registered_vulnerable_population_denominator`), and most recently
+Nuuk v23 (`rental_revenue_shortfall_dkk` — both `combined_*_surplus`
+outputs were null in 100% of MC runs).
+
+### 5. generate-calculations — solid
+
+Always produces an AST-parsable Python module. Function names use the
+`formula_hint` LHS; arguments match `depends_on` exactly in declared
+order; division guards are placed correctly; `P(...)` notation
+becomes a `NotImplementedError` stub. Argument-name shadowing of
+sibling function names is handled correctly per the explicit rule.
+
+LHS collisions between `recommended_first_calculations` and
+`derived_questions` (when two entries name the same output) produce a
+fallback to the entry id, which can leave duplicate functions in the
+module computing identical values (e.g. v23's `combined_shock_surplus_dkk`
+and `combined_viability_surplus_dkk` are identical bodies under
+different names). Cosmetic but worth dedup'ing upstream.
+
+### 6. run-scenarios — solid
+
+Deterministic low/base/high evaluation produces clean tables.
+`spread_ratio = high/low` correctly inverts (`<1`) for outputs where
+higher inputs make the result worse (runway, contingency-after-shock).
+Skips and warnings are scenario-agnostic when the cause is structural
+(null `formula_hint`).
+
+### 7. monte-carlo — solid after one wiring fix
+
+Function-name discovery from `formula_hint` LHS (rather than from the
+`q_*`-prefixed entry id) was a real bug that shipped at v19 and was
+fixed at the prompt level — a re-run on the same artifacts then
+discovered all generated functions. The Bernoulli-on-binary-gate rule
+correctly bimodalises `total_available_funding_eur`. Sensitivity
+rankings via Pearson correlation produce the right top driver in every
+case I've inspected (e.g. Nuuk's `labor_law_cost_uplift_fraction` at
+r=−0.94 against contingency-after-shock).
+
+Threshold pass-rate computation against explicit `settings.thresholds`
+is the most operationally useful output the pipeline produces.
+Faraday: `P(gate_surplus_eur ≥ 0) = 0.0%` across 10k runs is a
+concrete answer to a concrete question.
+
+## How well does the pipeline model the most important parameters?
+
+### Leipzig Heat Response (public health) — well
+
+By v16: the model computes a coverage cascade (vulnerable population
+estimate → contacted → cooling-centre served → protected → avoided
+deaths) and a unit-economics line (`cost_per_protected_person`).
+Monte Carlo produces median 25 avoided deaths with p05–p95 of 7–64.
+Sensitivity correctly identifies `baseline_heat_mortality_rate_per_person`
+as the dominant unknown, then `intervention_effectiveness`, then
+`registered_vulnerable_population`. Zero dead-end inputs in v16.
+Genuinely useful for tuning the plan's data-gathering priorities.
+
+### Faraday Enclosure (commercial) — very well, with a clear "no" answer
+
+By v19: the model goes all the way through Year-1 P&L
+(revenue → gross profit → operations net cash → gate surplus →
+runway → MIL-STD funding gap → required market penetration). With
+explicit thresholds in v19c/d, the pipeline returns
+`P(gate_surplus_eur ≥ 0) = 0/10000 = 0%` and
+`P(required_market_penetration ≤ 1) = 28.8%`. The plan needs
+146% of the addressable market to break even at base case. This is the
+clearest single answer the pipeline has produced — the model says
+unambiguously "this product cannot pass its own gate at any plausible
+parameter combination." That answer would be hard to derive from the
+prose plan alone.
+
+### Nuuk Clay Workshop (community business) — partially
+
+By v22: the model decomposes the labor-law shock into
+`baseline_fixed_labor_cost × labor_law_cost_uplift_fraction`,
+mechanistically grounded in the report's "20–35%" uplift quote.
+Sensitivity correctly identifies the labor-uplift fraction as the
+dominant driver (r=−0.94 against contingency surplus).
+
+What the model doesn't capture across v20–v23: the **off-peak
+hourly-rental coverage gate** that the report names as the actual
+funding-gate KPI. The hourly rental rate, off-peak hours, and utility
+overhead are extracted and bounded but no calculation tests "does
+off-peak revenue cover utility overhead?". Three iterations in, that
+gate is structurally absent. This is a real model-quality gap.
+
+By v23: the model attempts to combine the survival metric
+(`combined_viability_surplus_dkk`) but trips on the dependency black
+hole described above — every Monte Carlo run produces null. So the
+intent has caught up to the plan's actual structure but the wiring
+between bounds and calculations hasn't.
+
+## Recurring failure modes
+
+In rough order of impact:
+
+| # | Issue | Domains hit | Severity |
+|---|---|---|---|
+| 1 | Bounds-skip-but-no-calc dependency black hole | Heatwave v15, Nuuk v20, Nuuk v23 | high — produces null outputs in 100% of MC runs for affected calcs |
+| 2 | Dead-end bounded inputs persist across iterations | All three domains | medium — wastes sampling budget, distorts no answer |
+| 3 | Unmodelled stated funding gates (Nuuk off-peak coverage) | Nuuk v20–v23 | medium — pipeline answers a different question than the plan asks |
+| 4 | Unit-inference substring matching false positives (`operations` matches `ratio`) | Faraday v18 | low — fixed at prompt level by v19 with whole-token matching |
+| 5 | Function-name discovery via entry id rather than formula LHS | Faraday v19 | low — fixed at prompt level after one missed run |
+| 6 | LHS collisions producing semantically duplicate functions/outputs | Nuuk v21, v23 | low — cosmetic, no incorrect numbers |
+| 7 | Currency support beyond EUR done ad-hoc by agents | Nuuk v20–v23 (DKK) | low — agents extended `_eur` symmetrically and it worked, but not codified |
+
+## What the pipeline answers well today
+
+- **"Can this plan pass its own funding gate?"** Faraday makes this a
+  hard zero. Threshold settings are the right interface.
+- **"Which single input most drives output uncertainty?"** Sensitivity
+  rankings are reliable across all three domains.
+- **"What does the downside / base / upside case look like?"**
+  `run-scenarios` is fast, deterministic, and easy to read.
+- **"Where does the model collapse?"** Heavy-tail / `inf` warnings on
+  outputs whose denominator can go negative (Faraday's contribution
+  margin in p05) surface real model fragility.
+
+## What the pipeline doesn't yet answer well
+
+- **"Does the off-peak coverage gate pass?"** Stated KPI, structurally
+  unmodelled in Nuuk v20–v23.
+- **"What if all key levers move adversely together?"** Correlation
+  groups exist in the monte-carlo settings spec but I haven't seen them
+  actually used. Default is full independence.
+- **"Why is `breakeven_units` `inf` in 26% of runs?"** The model reports
+  the collapse rate but doesn't explain which input combination
+  triggered it.
+- **"What's the smallest set of input revisions that flips
+  `P(gate_pass)` above 50%?"** The pipeline can answer the gate-pass
+  question but not the inverse design question.
+
+## Closing thought
+
+The pipeline is genuinely useful at this point — it produces the kind
+of single-paragraph "this plan can/can't pass its own gate" answer
+that a careful human reading the prose plan would take much longer to
+arrive at. The biggest concrete improvement available is closing the
+bounds-vs-calculations dependency black hole, because every
+recurrence of it removes a calculated output from the model's payoff
+column. Beyond that, the model-quality gap to close domain-by-domain
+is making sure every funding-gate KPI named in the prose plan ends up
+as a calculated output the pipeline can test against.

--- a/experiments/napkin_math/docs/20260512_codex.md
+++ b/experiments/napkin_math/docs/20260512_codex.md
@@ -1,0 +1,386 @@
+# Monte Carlo Pipeline Status Assessment
+
+## Scope
+
+This document summarizes the current state of the plan-to-Monte-Carlo simulation pipeline, based primarily on the Nuuk Clay Workshop test case across versions v20, v21, v22, and v23.
+
+The focus is not whether the clay workshop plan itself is viable. The focus is whether the pipeline is successfully extracting the most important modelling parameters from plans, turning them into executable calculations, assigning bounds, running scenarios, and producing Monte Carlo outputs that answer the plan's core viability questions.
+
+## Executive Summary
+
+The Monte Carlo simulation code appears directionally solid once it receives a coherent model. It can run deterministic scenarios, sample bounded inputs, produce distributions, report percentiles, and calculate sensitivity correlations. The main problems are upstream: parameter extraction, schema semantics, bounds generation, calculation generation, and validation contracts.
+
+The pipeline is improving. v20 failed because critical derived questions had null formulas. v21 fixed executable formulas and produced a meaningful combined viability gate. v22 improved mechanistic modelling of labor-law shock, but lost the composite gate. v23 restored the combined survival-gate intent, but exposed a deeper wiring bug: a derived intermediate was placed in `missing_values_to_estimate`, skipped by bounds, and not generated as a calculation, causing the most important Monte Carlo output to be missing in every run.
+
+The current state is best described as:
+
+> The Monte Carlo engine is probably usable, but the model-building pipeline is not yet reliable enough to trust unattended.
+
+The pipeline can now often identify the right risks, but it does not consistently preserve them as executable, bounded, end-to-end calculations.
+
+## Current Assessment
+
+| Area | Status | Assessment |
+|---|---:|---|
+| Monte Carlo runner | Good | Works when given bounded inputs and executable calculations. |
+| Scenario runner | Mostly good | Correctly exposes skipped/unresolvable calculations. |
+| Sensitivity analysis | Good enough | Correlations are useful for identifying dominant drivers. |
+| Parameter extraction | Improving | Now better at extracting executable formulas, but still misclassifies derived intermediates. |
+| Bounds generation | Fragile | Skips some `missing_values_to_estimate` entries when their names look derivable. |
+| Calculation generation | Narrow contract | Only emits functions from recommended calculations and derived questions. This is fine, but other stages must respect it. |
+| Validation | Too permissive | Allows unresolved dependencies, duplicate formula logic, dead-end important variables, and missing explicit values. |
+| End-to-end reliability | Not yet good | The most important output can disappear while validation still reports valid. |
+
+## What the Monte Carlo Code Seems to Do Well
+
+The Monte Carlo code itself is not where I see the earliest or most serious problem.
+
+It appears to do these things correctly:
+
+- Runs 10,000 sampled simulations.
+- Produces finite-output summaries when dependencies resolve.
+- Reports mean, standard deviation, min, percentiles, and max.
+- Tracks missing outputs when calculations cannot resolve.
+- Produces sensitivity correlations between outputs and input drivers.
+- Surfaces warnings when calculations are skipped or unresolvable.
+
+The Monte Carlo output is useful when the model is wired correctly. For example, in earlier versions it clearly showed that the plan's contingency logic was fragile under labor-law shock and speculative revenue shortfall. That is exactly the kind of insight the simulation should produce.
+
+The main issue is that Monte Carlo can only evaluate the model it is handed. When upstream stages produce a structurally incomplete model, Monte Carlo accurately reports missing outputs, but it cannot repair the model.
+
+## Main Pipeline Pattern Across Versions
+
+### v20
+
+v20 had the earliest obvious failure:
+
+- Important `derived_questions` existed.
+- Their `formula_hint` values were null.
+- The scenario and Monte Carlo stages skipped those questions.
+- The pipeline did not answer the core plan-viability gates.
+
+The key problem was that parameter extraction identified the right questions but did not turn them into executable formulas.
+
+### v21
+
+v21 was a major improvement:
+
+- Derived questions received formulas.
+- Skipped calculations dropped to zero.
+- Scenario warnings disappeared.
+- A meaningful combined gate appeared: whether the contingency cushion covered the speculative revenue gap.
+
+This was the first version that felt like the pipeline was modelling the plan's core risk structure rather than just extracting decorative numbers.
+
+Remaining issues in v21:
+
+- Some inputs were still dead-ended.
+- Duplicate output/collision behavior appeared.
+- The off-peak utility coverage gate was still missing.
+- Instructor capacity was computed but not connected to revenue capacity or staffing cost.
+
+### v22
+
+v22 improved the mechanism of the labor shock model:
+
+- Labor shock became a function of baseline fixed labor cost multiplied by a cost uplift fraction.
+- This is better than sampling a free-floating scalar shock.
+
+However, v22 regressed on decision-gate quality:
+
+- The combined viability gate disappeared.
+- The user had to mentally combine labor-shock survival with revenue-gap risk.
+- One derived question regressed to a null formula.
+- Dead-end inputs remained.
+
+The lesson from v22:
+
+> Better mechanistic decomposition is not enough. The pipeline must preserve the highest-level viability question after decomposition.
+
+### v23
+
+v23 restored the combined-survival-gate intent:
+
+- `combined_viability_surplus_dkk` appeared.
+- `combined_shock_surplus_dkk` appeared.
+- Null derived questions were eliminated.
+- The pipeline attempted to model the actual Builder's Balance survival test.
+
+But v23 exposed a deeper schema-contract bug:
+
+- `rental_revenue_shortfall_dkk` was referenced by the combined-surplus calculations.
+- It was placed in `missing_values_to_estimate`.
+- Bounds generation skipped it, apparently because the name looked like a derivable output.
+- Calculation generation did not generate it, because it only emits functions from recommended calculations and derived questions.
+- Result: the most important combined-surplus outputs had zero finite Monte Carlo results.
+
+This is the most important current diagnosis:
+
+> The pipeline lacks a strict contract for whether a quantity is a primitive unknown, a bounded assumption, or a derived calculated output.
+
+## The Most Important Current Failure Mode
+
+The recurring failure is not just one bad prompt. It is a schema-contract problem.
+
+Currently, an identifier can fall into a gap between pipeline stages:
+
+1. Parameter extraction references an id in a formula.
+2. The id is declared as `missing_values_to_estimate`.
+3. Bounds generation decides not to bound it because it looks derived.
+4. Calculation generation does not create a function for it because it is not in `recommended_first_calculations` or `derived_questions`.
+5. Scenario and Monte Carlo cannot resolve it.
+6. Validation still passes or only weakly warns.
+
+This creates a black hole for ids such as:
+
+- `*_gap`
+- `*_shortfall`
+- `*_surplus`
+- `*_deficit`
+- `*_ratio`
+- `required_*`
+- `expected_*`
+- `remaining_*`
+- `*_after_*`
+
+Many of these names are usually derived outputs, not primitive missing assumptions. They should usually be calculations, not bounded inputs.
+
+## How Well the Pipeline Models Important Plan Parameters
+
+The pipeline is getting better at identifying important plan parameters. It repeatedly surfaced the correct high-leverage dimensions in the Nuuk case:
+
+- Contingency reserve.
+- Labor-law reclassification or labor-cost uplift risk.
+- Speculative/off-peak revenue realization.
+- Taster-session conversion.
+- Hourly rental revenue assumptions.
+- Material buffer / working capital.
+- Staffing capacity.
+- Operational readiness deadline.
+
+That is good. The extractor is not merely pulling random numbers.
+
+The problem is that the pipeline is inconsistent at turning those important parameters into complete causal calculations.
+
+Examples:
+
+- It identifies rental rate, hours, and utilization-like quantities, but does not always turn them into bottom-up revenue or coverage calculations.
+- It identifies instructor capacity, but does not reliably connect it to revenue capacity, service reliability, staffing cost, or session coverage.
+- It identifies material buffer costs, but may leave them detached from liquidity or runway calculations.
+- It identifies plan deadlines, but may leave them as decorative dates rather than schedule-risk gates.
+- It identifies combined viability pressure, but may wire it through an unbounded missing intermediate.
+
+So the current quality is:
+
+> Good at finding important concepts. Still unreliable at preserving them as executable model structure.
+
+## Specific Evaluation of the Clay Workshop Test Case
+
+The clay workshop is a good test case because it exposes several classes of modelling difficulty:
+
+1. Narrative confidence vs numerical fragility.
+   The plan sounds robust, but the simulation can reveal whether the contingency actually survives shocks.
+
+2. Multiple interacting gates.
+   Labor-law risk, speculative revenue, utility overhead, membership conversion, and staffing reliability interact.
+
+3. Mixed explicit and implied quantities.
+   Some values are stated directly, while others must be inferred from relationships such as rate × hours × utilization.
+
+4. Physical operations.
+   The plan involves inventory, utilities, staffing, equipment downtime, local demand, and seasonality.
+
+5. Real schema stress.
+   It repeatedly surfaces boundary bugs between extraction, bounds, calculations, validation, scenarios, and Monte Carlo.
+
+The case is not ideal as the only benchmark because it may overfit the prompt toward small-business/community-workshop patterns. But it is a strong regression test because it keeps revealing whether the pipeline can preserve real viability logic.
+
+## What Is Working
+
+### 1. The pipeline can now improve iteratively
+
+The v20 to v23 progression shows meaningful learning:
+
+- Null formulas were reduced.
+- Derived questions became executable.
+- Mechanistic decomposition improved.
+- Combined gate logic was introduced.
+- Warning surfaces became more informative.
+
+This suggests the architecture is amenable to improvement.
+
+### 2. Monte Carlo output is interpretable
+
+When outputs are finite, the simulation summaries are useful. The mean/p05/p50/p95 summaries and sensitivity drivers clearly identify which assumptions dominate model behavior.
+
+### 3. The pipeline exposes model incompleteness
+
+Even when it fails, the later stages expose useful symptoms:
+
+- skipped functions
+- missing outputs
+- finite vs missing counts
+- dead-end inputs
+- sensitivity gaps
+
+These are valuable diagnostics.
+
+## What Is Not Working Yet
+
+### 1. Validation is too weak
+
+Validation should not report clean or near-clean status when:
+
+- A formula RHS dependency is neither bounded, explicit, nor calculated.
+- A critical output has zero finite Monte Carlo runs.
+- A high-priority uncertain key value feeds no calculation.
+- A derived question duplicates a recommended calculation.
+- An explicit value has `value: null` while the value appears in comment/source text.
+- A missing value looks like a derived output and is referenced by calculations.
+
+The validator should become the main guardrail. Prompt text alone is not enough.
+
+### 2. `missing_values_to_estimate` is semantically overloaded
+
+It currently mixes two categories:
+
+- primitive external assumptions, which should receive bounds
+- derived-but-missing intermediates, which should become calculations
+
+These need to be separated by schema or enforced by validation.
+
+Suggested distinction:
+
+- `missing_inputs_to_bound`: primitive uncertain inputs
+- `derived_calculations_needed`: calculated quantities that require formulas
+
+If the schema cannot change, then validation must enforce the distinction using naming and dependency rules.
+
+### 3. Highest-level viability gates are not reliably preserved
+
+The pipeline may decompose a model into parts but lose the top-level question.
+
+For planning evaluation, the top-level question is often the most important output:
+
+- Does the reserve survive combined shocks?
+- Does capacity cover demand?
+- Does revenue cover fixed and variable costs?
+- Does staffing cover required service levels?
+- Does the deadline survive realistic task duration uncertainty?
+
+The pipeline must preserve these as final aggregate surplus, deficit, ratio, or boolean gates.
+
+### 4. Rate × volume × utilization is still not automatic enough
+
+When a plan contains a rate-like value and a volume/capacity-like value, the pipeline should strongly prefer bottom-up formulas:
+
+- revenue = rate × volume × utilization
+- cost = unit_cost × units
+- capacity = hours × throughput × utilization
+- staffing cost = FTE × hours × wage rate
+
+Leaving rate-like values dead-ended is a sign that the model is not really testing the plan's economics or capacity.
+
+### 5. Duplicate calculations are still possible
+
+v23 had both `combined_viability_surplus_dkk` and `combined_shock_surplus_dkk`, which appear to be overlapping or duplicative.
+
+Duplicate calculations are not fatal, but they confuse interpretation and may hide the fact that the model has fewer real outputs than it appears.
+
+## Recommended Fixes
+
+### Highest priority: validation contract
+
+Add a validation rule:
+
+```text
+For every RHS variable in every formula:
+  it must resolve to one of:
+    - explicit numeric key_value
+    - bounded missing primitive
+    - output of a recommended_first_calculation
+    - output of a derived_question
+
+If not, validation must fail or warn loudly.
+```
+
+This single rule would catch the v23 `rental_revenue_shortfall_dkk` failure before scenarios and Monte Carlo.
+
+### Add primitive-vs-derived missing-value rule
+
+```text
+missing_values_to_estimate must contain primitive external assumptions, not calculated outputs.
+
+Ids containing gap, shortfall, surplus, deficit, ratio, required, expected, total, remaining, or after should trigger a warning unless explicitly justified as primitive external assumptions.
+```
+
+### Add zero-finite-output validation
+
+```text
+If a calculated output has zero finite values in scenarios or Monte Carlo, treat it as an error for critical outputs and a warning otherwise.
+```
+
+### Add composite-gate preservation rule
+
+```text
+If multiple pressures draw on the same reserve, budget, capacity, runway, or margin, compute a combined surplus or coverage ratio unless the plan treats them as independent.
+```
+
+### Add dead-end high-priority input rule
+
+```text
+Any critical or high-priority uncertain input should feed at least one calculation. If it does not, warn.
+```
+
+### Add duplicate formula detection
+
+```text
+If two calculations have equivalent RHS formulas and equivalent dependencies but different LHS ids, warn or deduplicate.
+```
+
+### Add explicit-value parsing warning
+
+```text
+If value_type is explicit and value is null, but source_text or comment contains a parseable number/date, warn.
+```
+
+## Recommended v24 Goal
+
+The next target should not be a broad prompt rewrite. It should be a contract tightening pass.
+
+v24 should aim for:
+
+1. Keep v23's combined-survival gate.
+2. Ensure every dependency in that gate is explicit, bounded, or calculated.
+3. Prevent derived intermediates from entering `missing_values_to_estimate` without bounds or formulas.
+4. Preserve rate × volume × utilization calculations.
+5. Deduplicate equivalent outputs.
+6. Make validation fail or warn before scenario/Monte Carlo if the payoff variable cannot resolve.
+
+A successful v24 Nuuk run should have:
+
+- zero skipped calculations
+- zero unresolvable scenario outputs
+- zero zero-finite Monte Carlo outputs for critical gates
+- no duplicate combined gates
+- no high-priority dead-end rental/staffing/capacity values
+- a finite distribution for the final combined viability surplus
+
+## Overall Verdict
+
+The Monte Carlo simulation code is probably not the bottleneck. The bottleneck is the model construction pipeline around it.
+
+The pipeline has made real progress:
+
+- It now often identifies the right risks.
+- It can produce executable formulas.
+- It can build mechanistic relationships.
+- It can attempt combined viability gates.
+
+But it is not yet reliable because the schema contract is loose. Important quantities can become stranded between extraction, bounds, and calculation generation. Validation is currently too permissive to catch this early.
+
+The right next move is not another large prompt rewrite. The right next move is stricter validation and clearer semantics:
+
+> Every important model variable must be either explicit, bounded, or calculated. No fourth state should exist.
+
+Once that invariant holds, the Monte Carlo outputs will become much more trustworthy.

--- a/experiments/napkin_math/docs/20260512_status.md
+++ b/experiments/napkin_math/docs/20260512_status.md
@@ -1,0 +1,336 @@
+# Pipeline status & ways forward — 2026-05-12
+
+This document consolidates the two independent assessments produced
+today (`20260512_codex.md` and `20260512_claude.md`), then proposes
+concrete ways forward — including an honest evaluation of splitting
+`extract-parameters` into a candidate-identification step and a
+structuring step.
+
+## TL;DR
+
+- The two AI assessments **agree on the dominant failure mode**:
+  ids can fall into a gap between extraction, bounds, and
+  calculations, producing zero finite results for the pipeline's
+  payoff outputs. Codex frames this as a *schema contract* problem;
+  Claude frames it as the *bounds-skip-but-no-calc black hole*. Same
+  bug, different framing levels.
+- Both agree the pipeline is genuinely useful when it works, and
+  that the Monte Carlo runner is not the bottleneck — model
+  construction is.
+- **Highest-leverage next move: tighten the validation contract**
+  along the lines Codex proposes. Add the rule "every important
+  model variable must be explicit, bounded, or calculated — no
+  fourth state."
+- **Splitting `extract-parameters` into a 2-step
+  candidate-then-structure flow is worth trying**, but it does not
+  directly fix the dominant failure mode. Best framed as a
+  provenance/debuggability win, not a model-correctness fix. Do it
+  *after* the validation contract is tightened, not before.
+
+## Comparison: codex vs claude assessments
+
+### Headline: same diagnosis, different framing levels
+
+Two independent AI reviews of the same pipeline reaching the same
+diagnosis is reasonably strong evidence the diagnosis is right.
+
+### Where they agree
+
+| Claim | Both agree |
+|---|---|
+| Monte Carlo runner is fundamentally solid | yes |
+| Pipeline is genuinely improving v20 → v23 | yes |
+| The dependency black hole is the #1 issue | yes |
+| Dead-end inputs persist across versions | yes |
+| Duplicate calcs in v23 (`combined_viability_surplus_dkk` vs `combined_shock_surplus_dkk`) | yes |
+| Off-peak coverage gate (Nuuk's stated KPI) is structurally absent | yes |
+| Validation is too permissive | yes |
+
+### Where they differ
+
+| Dimension | Codex | Claude |
+|---|---|---|
+| **Evidence base** | Nuuk only (v20–v23) | All 3 domains (v11–v23) |
+| **Diagnosis level** | Schema contract — "no fourth state should exist" | Symptom-level — "bounds-skip-but-no-calc" |
+| **Prescriptiveness** | High — 7 concrete validation rules + v24 goal | Low — describes failure modes, no rule text |
+| **Numbers cited** | Few specific | Many: `P(gate_pass)=0/10000`, `r=−1.00`, etc. |
+| **Coverage of operational wins** | Doesn't mention them | Faraday's P=0, threshold pass-rate as most useful output |
+| **Schema redesign suggestion** | `missing_inputs_to_bound` vs `derived_calculations_needed` split | Not proposed |
+| **Pipeline-as-product framing** | "Not yet reliable enough to trust unattended" | "Genuinely useful at this point" |
+
+### Where Codex is sharper
+
+- **Schema-contract framing** is more useful than symptom framing — it exposes that the fix belongs at the schema level, not as a per-stage patch.
+- **The `missing_inputs_to_bound` vs `derived_calculations_needed` split** directly maps to the bug. Claude noticed the bug 3 times but didn't propose a structural fix.
+- **The 7 proposed validation rules** are drop-in actionable.
+- **Closing invariant** is the cleanest single sentence either produced: *"Every important model variable must be either explicit, bounded, or calculated. No fourth state should exist."*
+
+### Where Claude is sharper
+
+- **Three-domain coverage** prevents overfitting to small-business plans. Codex's Nuuk-only evidence might miss patterns visible in Faraday and Heatwave.
+- **Concrete operational wins** (Faraday's hard zero, Nuuk's single-shock dominance, Heatwave's 25 median deaths avoided) — context for "is the pipeline already useful?".
+- **Function-name discovery bug at v19a** — evidence Monte Carlo had at least one real wiring bug. Codex grades MC unconditionally "good".
+- **Threshold pass-rate framing** — Codex doesn't mention this is the operationally most useful output.
+
+### Bottom line of the comparison
+
+If acting on one document, **act on Codex** — its prescriptions are at the right level. The schema-contract framing and the 7 validation rules are directly implementable. Use Claude for context on what to keep working while fixing.
+
+## Highest-leverage ways forward
+
+### 1. Tighten the validation contract (highest priority)
+
+Add Codex's invariant as a hard validator rule:
+
+```text
+For every RHS variable in every formula:
+  it must resolve to one of:
+    - explicit numeric key_value
+    - bounded missing primitive (in missing_values_to_estimate AND in bounds.json)
+    - output of a recommended_first_calculation
+    - output of a derived_question
+
+If not, validate-parameters must ERROR (not WARN).
+```
+
+This single rule catches the `rental_revenue_shortfall_dkk` failure
+in v23 *before* scenarios and Monte Carlo waste 10,000 runs producing
+null. It also catches `required_members_for_payroll` in v20 and
+`registered_vulnerable_population_denominator` in v15.
+
+### 2. Add primitive-vs-derived discipline to `missing_values_to_estimate`
+
+Either change the schema (Codex's preferred fix) — split into
+`missing_inputs_to_bound` for primitives and
+`derived_calculations_needed` for missing derivations — or enforce
+the distinction in the validator. The naming heuristic (Codex
+suggests warning on ids containing `gap`, `shortfall`, `surplus`,
+`deficit`, `ratio`, `required`, `expected`, `remaining`, `_after_`)
+is a reasonable first cut.
+
+### 3. Mandate combined-gate preservation
+
+When multiple shocks draw on the same reserve / runway / margin, the
+pipeline must produce the combined-surplus output. Nuuk has shown
+twice (v22 lost it after v21 added it; v23 attempted it but black-holed).
+
+### 4. Validate end-to-end coverage of stated funding gates
+
+Every plan KPI named as a "gate" or "pass/fail criterion" in the
+extracted `comment` or `source_text` should appear as either a
+calculated output OR an explicit `monte-carlo` threshold target.
+Nuuk's off-peak coverage gate has been absent across v20–v23 despite
+being the plan's named funding gate.
+
+### 5. Add explicit-value parsing rule
+
+If `value_type: "explicit"` and `value: null` but the literal value
+appears in `source_text` or `comment` (parseable number or date),
+WARN. This catches v23's `operational_readiness_date` issue
+("2026-09-15" lived in the comment but `value` was null).
+
+### 6. Detect and dedupe equivalent calculations
+
+When two functions have the same RHS and same `depends_on` but
+different LHS ids (v23 had `combined_viability_surplus_dkk` and
+`combined_shock_surplus_dkk` doing the same arithmetic), warn or
+auto-dedup. Cosmetic but it confuses interpretation.
+
+## On splitting `extract-parameters` into two steps
+
+### The proposal
+
+Currently `extract-parameters` does everything in one shot: read the
+report → identify what matters → triage to ≤8 → categorise → assign
+units → write formulas → produce JSON. The proposal is to split into:
+
+- **Step A — candidate identification**: scan the report, return a
+  list of `{line_number, snippet, why_relevant}` items pointing at
+  every potentially-important parameter
+- **Step B — structuring**: read the much smaller candidate list and
+  produce the schema-conformant JSON (key_values,
+  missing_values_to_estimate, derived_questions,
+  recommended_first_calculations)
+
+### What this would buy
+
+| Benefit | Strength |
+|---|---|
+| **Provenance** — every key_value traceable to a specific line, not paraphrased into `source_text` | high |
+| **Debuggability** — when the pipeline misses an important parameter (Nuuk off-peak gate), you can inspect Step A's output to see whether it was identified at all | high |
+| **Cheaper iteration on structuring rules** — changing the schema/categorisation prompt only re-runs Step B on the candidate list, not the whole 350 KB markdown | medium [†] |
+| **Independent test surfaces** — Step A measures recall (did we find the candidate?), Step B measures precision (did we structure it correctly?). Today they're entangled | medium |
+| **Smaller second-pass context** — Step B operates on a candidate list that's maybe 5–10 KB, not the full report | medium [†] |
+
+[†] These two benefits assume Step A returns extracted snippets. They
+weaken substantially if Step A uses **in-place XML tagging** (preferred
+— see "Step A output format" below). With in-place tagging, Step B
+still receives the full report, just marked up.
+
+### What this would NOT buy
+
+- **It does not fix the dominant failure mode.** The black hole sits
+  between extraction (any version), bounds, and calculations. Splitting
+  extraction in two doesn't change the fact that a derived id can land
+  in `missing_values_to_estimate` and get stranded.
+- **It does not improve modelling quality of the off-peak coverage
+  gate** unless Step A is *better* at noticing the gate than the
+  current single-shot extractor. There's no obvious reason it would be
+  — both have the same input.
+- **Triage to ≤8 gets harder when split**, not easier. Step B
+  re-evaluating "is this candidate more important than that one?"
+  needs the full prose context, which Step A's
+  `{line_number, snippet}` may not preserve enough of.
+
+### Risks
+
+| Risk | Severity |
+|---|---|
+| **Step A recall failures poison everything downstream** — if Step A misses an important parameter, Step B has no way to recover it. Today the single-shot at least sees the whole report at structuring time. | high |
+| **Calibrating "candidate" is hard** — too narrow and you re-introduce today's blind spots; too wide and Step B is overwhelmed | medium |
+| **More moving parts** — two skills, two prompts, two sets of iteration overhead | medium |
+| **Loss of holistic context** — sometimes the right key_value isn't directly stated; it's inferred from a constellation of mentions. Step A focused on explicit hits may miss the constellation. | medium |
+
+### Step A output format: in-place XML tagging
+
+The natural output for Step A is **the report verbatim, with
+`<planexe-candidate>` tags wrapped around the relevant lines**.
+Concretely:
+
+```markdown
+The Year 1 budget is fixed at <planexe-candidate reason="budget">2,000,000 DKK</planexe-candidate>
+under the Builder's Balance strategy.
+
+The contingency is <planexe-candidate reason="risk-buffer">15% of budget (300,000 DKK)</planexe-candidate>,
+ring-fenced for unexpected shocks.
+```
+
+Step B then receives this marked-up document instead of the original.
+
+#### Why in-place XML tagging beats a JSON `{line, snippet}` list
+
+| Property | Verbatim XML tagging | JSON snippet list |
+|---|---|---|
+| Preserves surrounding context for Step B | yes — natural | no — lost |
+| Verbatim integrity checkable by diffing | yes | no — Step A may rephrase the snippet |
+| Step B sees structural cues (section headers, tables) | yes — for free | no — must encode separately |
+| Provenance | yes — verbatim source text via tag position | depends on snippet quality |
+| Second-pass token cost | same as today (full report) | smaller |
+
+The verbatim form trades token cost for context — and at ~350 KB for
+the Nuuk markdown, context matters more than tokens.
+
+#### Specific design choices
+
+| Decision | Recommendation | Why |
+|---|---|---|
+| Tag name | `<planexe-candidate>` (or another project-namespaced tag) | Avoids collisions with markdown that may already contain HTML/XML |
+| Granularity | Semantic unit (sentence, list item, table row) — not literal "line" | Markdown lines are inconsistent: `# header` is one line, a wrapped paragraph is one line, a budget table row is one line. Sentences match the unit of meaning |
+| Attributes | One short `reason="..."` attribute | Lets Step B triage when overwhelmed; keeps prompt complexity low |
+| Step A output | Entire report with tags inserted, nothing else | Preserves global structure; no sidecar to keep in sync |
+| JSON sidecar | Defer — re-derive line numbers later from tag positions if needed | Reduces moving parts in v1 |
+| Tag-density budget | Cap at ~50 tags per report; treat overflow as a prompt-quality signal | Without a budget Step A will tag too liberally and Step B has no signal |
+
+#### What this changes about the tradeoff
+
+In-place XML tagging means **Step B still receives the full ~350 KB
+report** with tags. The "smaller second-pass context" benefit listed
+in the table earlier mostly evaporates, and "cheaper iteration on
+structuring rules" weakens too. The case for the split now rests on
+**provenance, debuggability, and independent test surfaces** — not on
+token cost.
+
+If small-context is also wanted, Step A would need to **prune** —
+return only the sections containing tags, plus a context window (e.g.
+±10 lines). That's an additional design choice, and pruning loses
+cross-section relationships (a budget figure in section 2 referenced
+by a risk in section 8 needs both visible to Step B). I'd defer the
+pruning question — start with full-document in-place tagging, since
+context matters more for correctness, and add pruning later if Step
+B's input actually becomes a problem.
+
+### My recommendation
+
+**Worth trying, but it is the second-priority fix, not the first.**
+The contract-tightening work above closes the failure mode both
+documents identified. The split is a provenance/debuggability win that
+would *help diagnose* why the off-peak coverage gate keeps getting
+missed, but doesn't directly fix it.
+
+Concrete sequencing:
+
+1. **First**, do the contract-tightening pass (validation rules above
+   + the missing-values discipline). This is roughly v24 in Codex's
+   numbering. Re-run all three domains (Heatwave v17, Faraday v20,
+   Nuuk v24) and confirm the black hole is closed.
+2. **Then** evaluate whether the persistent extraction misses (Nuuk
+   off-peak gate; instructor capacity dead-end across v20–v23) are
+   recall problems — i.e. the extractor never noticed — or
+   structuring problems — it noticed but discarded. Today we can't
+   tell the difference.
+3. **If it's a recall problem**, build the 2-step split as a
+   diagnostic experiment: run Step A on Nuuk and inspect whether the
+   off-peak gate appears in the candidate list. If it does, then the
+   structuring step is the issue (and the split helps). If it
+   doesn't, then a different recall-improvement intervention is
+   needed (chunking, different scanning prompt, or
+   domain-specific extractor variants).
+4. **If the contract tightening alone fixes the per-run failures**,
+   the split becomes lower priority — provenance is nice but not
+   load-bearing.
+
+### Alternative: keep the 1-step extract but add a `candidates_inspected`
+side-channel
+
+A lighter-weight version of the proposal: keep `extract-parameters`
+as one step, but require it to also emit a `candidates_inspected`
+list — every candidate it considered, with a brief
+`accepted | rejected: <reason>` annotation. This gets most of the
+debuggability benefit (you can see what was rejected and why) without
+splitting the skill in two. Worth weighing against the full split.
+
+## Recommended v24 goal
+
+Tightly scoped:
+
+1. Add validator rule: every formula RHS variable must resolve to
+   one of {explicit key_value, bounded missing primitive, recommended
+   calc output, derived question output}. ERROR severity.
+2. Add validator rule: ids in `missing_values_to_estimate` whose name
+   matches `gap | shortfall | surplus | deficit | ratio | required_ |
+   expected_ | remaining_ | _after_` produce a WARN unless explicitly
+   justified.
+3. Add validator rule: explicit value_type with null value triggers a
+   WARN if `source_text` or `comment` contains a parseable number or
+   date.
+4. Add validator rule: high or critical priority key_value that feeds
+   no calculation triggers a WARN.
+5. Add validator rule: two calculations with equivalent RHS and
+   equivalent dependencies trigger a WARN.
+6. Re-run Nuuk v24. Success criterion: the combined-survival output
+   has finite values in 100% of Monte Carlo runs.
+
+## Recommended v25 (or v24.5) goal
+
+Decide whether to do the extract-parameters split based on what v24
+shows:
+
+- If v24 fixes the dominant failures and the model now produces the
+  off-peak coverage gate correctly: defer the split indefinitely.
+- If v24 fixes the contract bug but recall problems persist (the
+  off-peak gate still doesn't show up; instructor capacity still
+  unconnected): build the split as a diagnostic. Start with the
+  candidate list as a side-channel (Alternative above) before
+  committing to a full skill split.
+
+## Closing thought
+
+The pipeline is at the stage where the single-paragraph answers it
+produces (Faraday: `P(gate_pass) = 0`; Nuuk: labor-shock dominance at
+`r = −1.00`) are genuinely useful — useful enough that the marginal
+return on more domain-coverage testing is now small. The marginal
+return on **closing the structural bug both documents identified** is
+much higher. Once the black hole is closed, the cycle of "v22 added
+the gate, v23 lost it to a dependency, v24 re-adds it" stops, and
+each subsequent iteration moves the model forward instead of
+sideways.


### PR DESCRIPTION
## Summary

Adds `experiments/napkin_math/` — a 7-stage skill-driven pipeline that turns a PlanExe report into a validated modelling spec and runs Monte Carlo over it:

```
extract-parameters → validate-parameters → repair-parameters (optional)
  → generate-bounds → generate-calculations → run-scenarios → monte-carlo
```

- 6 Claude Code skills under `experiments/napkin_math/.claude/skills/` (SKILL.md + system-prompt.txt each)
- `README.md` documenting each stage's purpose, input/output schema, and rules
- 3 docs from the 2026-05-12 cross-assessment round (`codex`, `claude`, consolidated `status`) capturing the current failure-mode analysis and proposed next moves

## .gitignore change

Removes the blanket `.claude/` entry so per-experiment skill bundles can be tracked. The repo-root `.claude/` (user-local `settings.local.json`, `scheduled_tasks.lock`) was never added to git and remains untracked — no leakage.

## Test plan
- [ ] Verify CI passes (lint / typecheck / tests)
- [ ] Confirm repo-root `.claude/` does not appear as a tracked file
- [ ] Spot-check that the 6 skills are discoverable from `experiments/napkin_math/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)