### PR TITLE
feat(napkin-math): teach extractors threshold-friendly output naming

### DIFF
--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -246,6 +246,23 @@ rental_revenue_shortfall_dkk = max(0, -drop_in_capacity_surplus_dkk)      (the s
 
 Then any aggregate test that consumes the stressor reads from this derived value, and the simulation respects the causal link.
 
+No dead-end variables:
+
+Every entry in key_values and missing_values_to_estimate must feed at least one calculation — either directly (it appears in another entry's depends_on or formula_hint RHS) or transitively (it feeds a calculation whose output is used by another calculation). Before emitting the JSON, walk every variable and confirm it reaches a recommended_first_calculation or derived_question output.
+
+A variable extracted "for context" but never used by a calculation is dead weight. It pollutes the bounds (forcing generate-bounds to assign a range you never sample meaningfully), shows up as a non-driver in sensitivity reports, and clutters the insights without adding signal.
+
+Common dead-end patterns to watch for:
+- a threshold or trigger value (e.g., "surcharge activates when X exceeds 30%") extracted without also extracting X and the margin calculation that tests it;
+- a capacity, FTE, or staffing constant extracted as background detail but never multiplied into a throughput, cost, or revenue formula;
+- a percentage target or "operational goal" the plan mentions but the model has no way to evaluate.
+
+Fix in priority order:
+1. If you can model the variable cheaply, add a calculation that uses it. For triggers, the natural form is "<x>_margin = actual_share - threshold_share" — and you must also add `actual_share` to missing_values_to_estimate if absent from the source. Both the trigger and the actual share must connect to the margin calculation.
+2. If you cannot model it, drop the variable. Do not extract it and leave it stranded.
+
+It is better to return six well-connected key_values than eight where two are dead-ends. The caps are a ceiling, not a target.
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -263,6 +263,12 @@ Fix in priority order:
 
 It is better to return six well-connected key_values than eight where two are dead-ends. The caps are a ceiling, not a target.
 
+Keep plan_summary.modelling_frame consistent with the executable model:
+
+modelling_frame describes the scope of what the calculations actually evaluate, not the full plan as written. If you drop a risk concept (utility shock, supplier shock, regulatory shock, etc.) under the No-dead-end rule because no calculation tests it, also drop that concept from the modelling_frame text. A frame that names risks the model has no way to evaluate reads as overstating what the simulation covers and misleads downstream readers of the insights report.
+
+Concrete pattern: if the frame says "buffers against A, B, and C shocks" and you only retained calculations that test A and B, the frame must say "buffers against A and B shocks". Do not paper over the gap by keeping the dropped concept in the prose.
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -197,10 +197,29 @@ Preferred patterns:
 - gate_surplus = available_amount - required_amount
 - coverage_ratio = available_capacity / required_capacity
 - contingency_after_shock = contingency_reserve - shock_cost
-- revenue_gap = required_revenue - expected_revenue
+- revenue_capacity_surplus = expected_revenue - required_revenue
 - breakeven_surplus = expected_units - breakeven_units
 - runway_days = available_cash / daily_burn_rate
 - required_share = required_count / denominator_count
+
+Threshold-friendly output naming (apply to every output that will be tested against a pass/fail threshold):
+
+When the calculation produces a number meant to be compared against a threshold, name it so that "positive = pass" is the obvious read. Set up the formula so the threshold direction is ">= 0" rather than "<= 0". This removes the need for a reader to re-derive "which sign is good" every time they look at the report.
+
+Preferred suffixes for threshold-tested calculations:
+- _surplus      — available minus required; positive = healthy
+- _buffer       — reserve minus draw; positive = room remaining
+- _margin       — achieved minus required; positive = clears the bar
+- _coverage     — available divided by required, or the surplus form
+
+Avoid for threshold-tested calculations:
+- _gap          — the direction is ambiguous; the reader has to guess which sign is the good one
+- _deficit      — implies "always bad", but invites the same threshold confusion
+- _shortfall    — only use when the formula matches the name (required minus achieved); even then prefer the surplus framing
+
+If you would naturally write "x_gap = expected - capacity" with threshold "<= 0", instead write "x_capacity_surplus = capacity - expected" with threshold ">= 0". The sign flips; the name explains itself.
+
+Apply this rule even when the underlying source phrasing is "the gap is X". The source text is allowed to use "gap"; the calculation output id is not.
 
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
@@ -282,7 +301,7 @@ gross_profit = revenue * gross_margin
 
 5. Gate, runway, or funding:
 total_available_funding = initial_budget + conditional_funding_gate
-funding_gap = required_cost - available_profit
+funding_surplus = available_profit - required_cost
 
 6. Break-even:
 contribution_margin_per_unit = arpu * gross_margin - cac_per_unit - warranty_reserve_per_unit
@@ -324,7 +343,7 @@ Examples:
 net_cash_from_operations = gross_profit - fixed_cost
 gate_surplus = net_cash_from_operations - gate_threshold
 units_surplus = units_sold - required_units
-funding_gap = required_funding - available_cash
+funding_surplus = available_cash - required_funding
 
 Do not extract a conditional funding amount unless either:
 - it feeds total_available_funding, or

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -221,6 +221,31 @@ If you would naturally write "x_gap = expected - capacity" with threshold "<= 0"
 
 Apply this rule even when the underlying source phrasing is "the gap is X". The source text is allowed to use "gap"; the calculation output id is not.
 
+Derive coupled stressors instead of sampling them independently:
+
+If a stressor variable (a shortfall, deficit, overrun, drain, leakage) is mechanically derivable from quantities the model already covers, declare it as a calculation. Do not put it in missing_values_to_estimate as if it were an independent input. Sampling a derived stressor independently:
+- double-counts the same underlying risk in the simulation;
+- lets the simulation produce physically incoherent combinations (e.g., a large rental shortfall in a scenario where the capacity surplus is positive — there should not be a shortfall there at all);
+- weakens the sensitivity analysis, because two outputs that share a cause look like they have independent drivers.
+
+Concrete signs of this anti-pattern in your draft:
+- a missing_values_to_estimate entry whose why_needed text references another modelled variable by name ("when X underperforms");
+- a suggested_estimation_method that is effectively a formula ("expected_X * (1 - realized_share)", "expected_X - achievable_X");
+- an aggregate test (combined_viability_surplus, runway, etc.) that subtracts both an independent stressor AND the inputs the stressor logically depends on.
+
+Fix: convert the entry into a recommended_first_calculation or derived_question. Use a non-negative guard when the stressor can only be a one-sided shortfall:
+
+rental_revenue_shortfall = max(0, expected_revenue - achievable_revenue)
+labor_law_cost_overrun   = max(0, salaried_cost - contractor_cost)
+runway_burn_overrun      = max(0, actual_burn_rate - planned_burn_rate)
+
+When the underlying surplus calculation already exists, derive the stressor from its negative side rather than recomputing the difference. Example:
+
+drop_in_capacity_surplus_dkk = (rate * hours) - expected_revenue          (already declared)
+rental_revenue_shortfall_dkk = max(0, -drop_in_capacity_surplus_dkk)      (the stressor)
+
+Then any aggregate test that consumes the stressor reads from this derived value, and the simulation respects the causal link.
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
@@ -209,6 +209,23 @@ rental_revenue_shortfall_dkk = max(0, -drop_in_capacity_surplus_dkk)      (the s
 
 Then any aggregate test that consumes the stressor reads from this derived value, and the simulation respects the causal link.
 
+No dead-end variables:
+
+Every entry in key_values and missing_values_to_estimate must feed at least one calculation — either directly (it appears in another entry's depends_on or formula_hint RHS) or transitively (it feeds a calculation whose output is used by another calculation). Before emitting the JSON, walk every variable and confirm it reaches a recommended_first_calculation or derived_question output.
+
+A variable extracted "for context" but never used by a calculation is dead weight. It pollutes the bounds (forcing generate-bounds to assign a range you never sample meaningfully), shows up as a non-driver in sensitivity reports, and clutters the insights without adding signal.
+
+Common dead-end patterns to watch for:
+- a threshold or trigger value (e.g., "surcharge activates when X exceeds 30%") extracted without also extracting X and the margin calculation that tests it;
+- a capacity, FTE, or staffing constant extracted as background detail but never multiplied into a throughput, cost, or revenue formula;
+- a percentage target or "operational goal" the plan mentions but the model has no way to evaluate.
+
+Fix in priority order:
+1. If you can model the variable cheaply, add a calculation that uses it. For triggers, the natural form is "<x>_margin = actual_share - threshold_share" — and you must also add `actual_share` to missing_values_to_estimate if absent from the report. Both the trigger and the actual share must connect to the margin calculation.
+2. If you cannot model it, drop the variable. Do not extract it and leave it stranded.
+
+It is better to return six well-connected key_values than eight where two are dead-ends. The caps are a ceiling, not a target.
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
@@ -226,6 +226,12 @@ Fix in priority order:
 
 It is better to return six well-connected key_values than eight where two are dead-ends. The caps are a ceiling, not a target.
 
+Keep plan_summary.modelling_frame consistent with the executable model:
+
+modelling_frame describes the scope of what the calculations actually evaluate, not the full plan as written. If you drop a risk concept (utility shock, supplier shock, regulatory shock, etc.) under the No-dead-end rule because no calculation tests it, also drop that concept from the modelling_frame text. A frame that names risks the model has no way to evaluate reads as overstating what the simulation covers and misleads downstream readers of the insights report.
+
+Concrete pattern: if the frame says "buffers against A, B, and C shocks" and you only retained calculations that test A and B, the frame must say "buffers against A and B shocks". Do not paper over the gap by keeping the dropped concept in the prose.
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
@@ -160,10 +160,29 @@ Preferred patterns:
 - gate_surplus = available_amount - required_amount
 - coverage_ratio = available_capacity / required_capacity
 - contingency_after_shock = contingency_reserve - shock_cost
-- revenue_gap = required_revenue - expected_revenue
+- revenue_capacity_surplus = expected_revenue - required_revenue
 - breakeven_surplus = expected_units - breakeven_units
 - runway_days = available_cash / daily_burn_rate
 - required_share = required_count / denominator_count
+
+Threshold-friendly output naming (apply to every output that will be tested against a pass/fail threshold):
+
+When the calculation produces a number meant to be compared against a threshold, name it so that "positive = pass" is the obvious read. Set up the formula so the threshold direction is ">= 0" rather than "<= 0". This removes the need for a reader to re-derive "which sign is good" every time they look at the report.
+
+Preferred suffixes for threshold-tested calculations:
+- _surplus      — available minus required; positive = healthy
+- _buffer       — reserve minus draw; positive = room remaining
+- _margin       — achieved minus required; positive = clears the bar
+- _coverage     — available divided by required, or the surplus form
+
+Avoid for threshold-tested calculations:
+- _gap          — the direction is ambiguous; the reader has to guess which sign is the good one
+- _deficit      — implies "always bad", but invites the same threshold confusion
+- _shortfall    — only use when the formula matches the name (required minus achieved); even then prefer the surplus framing
+
+If you would naturally write "x_gap = expected - capacity" with threshold "<= 0", instead write "x_capacity_surplus = capacity - expected" with threshold ">= 0". The sign flips; the name explains itself.
+
+Apply this rule even when the underlying source phrasing is "the gap is X". The source text is allowed to use "gap"; the calculation output id is not.
 
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
@@ -245,7 +264,7 @@ gross_profit = revenue * gross_margin
 
 5. Gate, runway, or funding:
 total_available_funding = initial_budget + conditional_funding_gate
-funding_gap = required_cost - available_profit
+funding_surplus = available_profit - required_cost
 
 6. Break-even:
 contribution_margin_per_unit = arpu * gross_margin - cac_per_unit - warranty_reserve_per_unit
@@ -287,7 +306,7 @@ Examples:
 net_cash_from_operations = gross_profit - fixed_cost
 gate_surplus = net_cash_from_operations - gate_threshold
 units_surplus = units_sold - required_units
-funding_gap = required_funding - available_cash
+funding_surplus = available_cash - required_funding
 
 Do not extract a conditional funding amount unless either:
 - it feeds total_available_funding, or

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
@@ -184,6 +184,31 @@ If you would naturally write "x_gap = expected - capacity" with threshold "<= 0"
 
 Apply this rule even when the underlying source phrasing is "the gap is X". The source text is allowed to use "gap"; the calculation output id is not.
 
+Derive coupled stressors instead of sampling them independently:
+
+If a stressor variable (a shortfall, deficit, overrun, drain, leakage) is mechanically derivable from quantities the model already covers, declare it as a calculation. Do not put it in missing_values_to_estimate as if it were an independent input. Sampling a derived stressor independently:
+- double-counts the same underlying risk in the simulation;
+- lets the simulation produce physically incoherent combinations (e.g., a large rental shortfall in a scenario where the capacity surplus is positive — there should not be a shortfall there at all);
+- weakens the sensitivity analysis, because two outputs that share a cause look like they have independent drivers.
+
+Concrete signs of this anti-pattern in your draft:
+- a missing_values_to_estimate entry whose why_needed text references another modelled variable by name ("when X underperforms");
+- a suggested_estimation_method that is effectively a formula ("expected_X * (1 - realized_share)", "expected_X - achievable_X");
+- an aggregate test (combined_viability_surplus, runway, etc.) that subtracts both an independent stressor AND the inputs the stressor logically depends on.
+
+Fix: convert the entry into a recommended_first_calculation or derived_question. Use a non-negative guard when the stressor can only be a one-sided shortfall:
+
+rental_revenue_shortfall = max(0, expected_revenue - achievable_revenue)
+labor_law_cost_overrun   = max(0, salaried_cost - contractor_cost)
+runway_burn_overrun      = max(0, actual_burn_rate - planned_burn_rate)
+
+When the underlying surplus calculation already exists, derive the stressor from its negative side rather than recomputing the difference. Example:
+
+drop_in_capacity_surplus_dkk = (rate * hours) - expected_revenue          (already declared)
+rental_revenue_shortfall_dkk = max(0, -drop_in_capacity_surplus_dkk)      (the stressor)
+
+Then any aggregate test that consumes the stressor reads from this derived value, and the simulation respects the causal link.
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/docs/20260516_claude.md
+++ b/experiments/napkin_math/docs/20260516_claude.md
@@ -1,287 +1,436 @@
 # Pipeline status — Claude's view, 2026-05-16
 
-This document captures my (Claude's) perception of the PlanExe parameter
-modelling pipeline after a session focused exclusively on the **compression
-stage** and the **parameter-extraction stage**. The remaining four skills
-(`validate-parameters`, `generate-bounds`, `generate-calculations`,
-`run-scenarios`, `monte-carlo`) were not exercised today, so the
-2026-05-12 assessment remains the authoritative description of those.
+End-of-day snapshot. This is the second of two same-day updates: an
+earlier version of this doc captured the morning's compression-stage and
+parameter-extraction work; this version expands it with two follow-on
+sessions that lifted the Monte Carlo stage out of the LLM, locked the
+pipeline schema across stages, and ran four iterations of a ChatGPT
+review loop on the Nuuk plan.
 
-The honest framing of today's work: the input that the expensive
-extraction skill sees got materially better, but I did not retest
-whether that improvement actually moves the downstream Monte Carlo
-quality bar. That validation is the next step, not done yet.
+The headline state at end-of-day: the pipeline is **closed end-to-end**
+on the Nuuk Clay Workshop sample using the digest variant, with
+deterministic Python at the simulation stage, strict schema validation
+between LLM stages, automated tests in CI, a project-manager-facing
+insights report, and four prompt rules added in response to four rounds
+of external review. The Monte Carlo runs with zero warnings, validation
+is clean, and the verdicts read coherently:
 
-## TL;DR
+```
+P(combined_viability_surplus_dkk >= 0) = 1.09%     DOOM
+P(single_shock_buffer_dkk        >= 0) = 81.97%    ROBUST
+P(drop_in_capacity_surplus_dkk   >= 0) = 0.14%     DOOM
+P(taster_conversion_margin       >= 0) = 74.92%    MARGINAL
+```
 
-Today's deliverables, all on the `feat/napkin-math-prepare-extract-input`
-branch:
+The biggest remaining structural question — *does the pipeline
+generalise beyond the Nuuk case?* — is still open. Every prompt rule was
+validated against one plan in one currency in one domain.
 
-- A new driver script `prepare_extract_input.py` that assembles the
-  137-recommended 8-section extraction bundle (four sections compressed
-  via `compress_report_section`, four sections passed through raw), in
-  137's order, with the Strategic Decisions slot replaced by Selected
-  Scenario per proposal 139.
-- A new sibling skill `extract-parameters-from-digest` that reads that
-  assembled file and emits a parameter JSON with the same schema as the
-  existing `extract-parameters-from-full` skill. The two skills are head-to-head
-  comparable on the same plan.
-- Three substantive compression-side improvements: a language-neutral
-  numeric-density scoring bonus, an LLM-side number-word
-  digit-annotation rule (so "four part-time instructors" becomes
-  "four (4) part-time instructors" in `line_english`), and a
-  denominator-pairing rule in the `missing_data_to_estimate` bucket
-  so every rate/share/per-unit value in earlier buckets surfaces its
-  matching denominator.
-- One cross-section canonicalisation rule and one budget-vs-revenue
-  denominator rule added to the extraction skill's system prompt, with
-  the explicit understanding that canonicalisation belongs in the
-  consumer, not the compressor.
-- Proposals 137 and 139 updated with the lessons.
+## TL;DR — what shipped today
 
-The biggest open question I cannot answer today: **does the compressed
-pipeline produce a better parameters.json than the full-HTML pipeline,
-or merely a cheaper one?** Six external review cycles on the compressed
-digests landed at "v26 is the best version so far" and "I would accept
-this output", but the comparison was conducted on digest quality and the
-extracted parameters in isolation, not against a fresh full-HTML run on
-the same plan with the existing skill.
+Three branches, three coherent slabs of work.
+
+**1. `feat/napkin-math-prepare-extract-input` (merged as PR #704, morning):**
+- `prepare_extract_input.py` driver and the `extract-parameters-from-digest` sibling skill.
+- Three compression-side improvements: numeric-density scoring bonus,
+  number-word digit-annotation rule, denominator-pairing in the
+  `missing_data_to_estimate` bucket.
+- Cross-section canonicalisation and budget-vs-revenue denominator rules
+  added to the extractor prompt.
+- Proposals 137 and 139 updated.
+
+**2. `feat/napkin-math-monte-carlo-runner` (merged as PR #705, afternoon):**
+- **Stage 7 lifted out of the LLM**. `run_monte_carlo.py` is a deterministic
+  Python script with a seeded NumPy RNG. The `monte-carlo` skill is now
+  a thin wrapper that locates inputs, builds optional settings, and
+  invokes the runner. The previous LLM-driven simulation couldn't
+  actually sample 10 000 draws in-prompt and produced plausible-looking
+  but non-deterministic numbers.
+- **Strict schema across the four LLM stages**. Bounds entries gain
+  required `sampling_discipline`, `non_negative`, and
+  `default_pass_probability`; entries with non-null `formula_hint` gain
+  `output_name` and `output_unit`. The runner exits with `SCHEMA ERROR`
+  exit code 2 when anything is missing — no fallback path that re-guesses
+  the classification.
+- **`summarize-insights` skill** with `summarize_insights.py`. Reads any
+  subset of the four pipeline artifacts and emits `insights.md` with
+  `Bad news first` at the top, DOOM/FRAGILE/MARGINAL/ROBUST verdict
+  bands driven entirely by user-declared thresholds, and project-
+  manager-friendly language throughout. Writing rules codified in the
+  skill itself: bad news first, no sugar-coating, no sycophancy, no
+  hedging phrases.
+- **`test-napkin-math` skill** with `tests/run_smoke.py`. Eight end-to-end
+  smoke checks that cover the runner, schema validation paths, the
+  summarizer, and the `compress_report_section` pytest suite. Plus a
+  synthetic fixture under `tests/fixtures/smoke/` exercising every
+  sampling discipline.
+- **44 unittest cases** under `tests/test_run_monte_carlo.py`, picked up
+  by the repo's `python test.py` via new `__init__.py` files. Three real
+  bugs surfaced and got fixed: `np.triangular` crash when `low == high`
+  in continuous discipline, `np.std == 0` floating-point false-negative
+  on constant arrays (used `np.ptp` instead), and a 10-currency
+  allowlist replaced by data-driven discovery from declared input units.
+- **`extract-parameters` renamed to `extract-parameters-from-full`** to
+  pair cleanly with `extract-parameters-from-digest`. 61 textual
+  references swept across 20 files with a negative lookahead to avoid
+  touching the digest variant.
+- **README updated** to document the digest variant, the new required
+  schema fields, and the Python runner stage.
+- **v27 reference run** of the full pipeline on the Nuuk digest, all
+  files clean end-to-end, gitignored output tree.
+
+**3. `feat/napkin-math-metric-naming` (PR #706, current, four commits, not merged):**
+Four prompt-rule additions, each driven by a single round of ChatGPT
+feedback against the previous version. Each round generated a numbered
+output dir under `output/v{27..31}/` (all gitignored).
+
+| Round | Prompt rule added | Demonstrated in |
+|---|---|---|
+| v27 → v28 | **Threshold-friendly output naming.** Positive = pass. Prefer `_surplus / _buffer / _margin / _coverage`; avoid `_gap / _deficit / _shortfall`. Flip the formula sign rather than emit a confusingly-named output. | `rental_revenue_gap_dkk` (threshold `<= 0`) → `drop_in_capacity_surplus_dkk` (threshold `>= 0`) |
+| v28 → v29 | **Derive coupled stressors instead of sampling them independently.** When a stressor is mechanically derivable from already-modelled inputs, declare it as a calculation with `max(0, expected − achievable)`. Independent sampling double-counts the underlying risk and allows physically incoherent simulation runs. | `rental_revenue_shortfall_dkk` moves from `missing_values_to_estimate` to `recommended_first_calculations`; bounds entry deleted; sensitivity drivers of `combined_viability_surplus` shift from the tautological shortfall (r=−0.87) to the true upstream drivers (revenue mix, revenue target, billable hours). P(combined ≥ 0) drops 5.27% → 1.09% because the previously-assumed bounds (0/158k/350k) under-estimated the actual derived shortfall (84k/326k/506k). |
+| v29 → v30 | **No dead-end variables.** Every `key_value` and `missing_values` entry must reach a calculation directly or transitively. Six well-connected key_values beat eight with two strays. The caps are a ceiling, not a target. | `utility_surcharge_cost_share_trigger` and `instructor_fte_equivalent` dropped from key_values; all six remaining variables feed at least one calculation; threshold probabilities unchanged because the dropped variables were genuinely unused. |
+| v30 → v31 | **Keep `modelling_frame` consistent with the executable model.** When a concept is dropped from the variable set, drop it from the frame too. The frame should describe what the simulation actually evaluates, not the full plan as written. | v30's frame mentioned "fixed Arctic operating costs" (overpromised — model only handles labor) and omitted the Taster KPI dimension. v31's frame names all four executable threshold tests by their semantics. |
+
+ChatGPT's v31 verdict: *"Keep this as the current best version. Further
+tuning on the Nuuk case probably gives diminishing returns."*
 
 ## What changed today, skill by skill
 
-### compress_report_section — three structural improvements
+### compress_report_section — three structural improvements (morning, PR #704)
 
-The composite ranking score for the four list buckets (numeric_values,
-load_bearing_assumptions, gates_and_thresholds, risks_and_shocks,
-missing_data_to_estimate) now combines:
+Composite ranking score now combines:
 
 - `source_evidence * modelling_relevance` (1..25), unchanged
-- a code-verified quote bonus (+10), unchanged
-- a **numeric-density bonus** (0..3) based on the count of numeric
-  tokens in `line_english + source_quote`
+- code-verified quote bonus (+10), unchanged
+- numeric-density bonus (0..3) based on the count of numeric tokens
+  in `line_english + source_quote`
 
 The numeric-density bonus is the only content-shape signal that
-survived design review: an earlier iteration of the bonus included a
+survived design review. An earlier iteration included a
 `PROTECTED_MODELLING_TERMS` list (budget, contingency, revenue, labor,
-rate, break-even, …) which I added on the strength of a ChatGPT
-recommendation. That list was English-only and commercial-finance-biased,
-so it would silently downrank Danish content and non-commercial plans
-(renovations, hobby projects, public-health interventions) without
-any signal in the output that the bias existed. The user caught it
-before it merged; I removed both the protected-term and the
-formula-cue lists (also English-biased) and saved a memory note so
-the next session does not repeat the mistake. The remaining
-numeric-density rule is genuinely language- and domain-neutral —
-digits are digits in any language.
+rate, break-even, …) that was English-only and commercial-finance-biased.
+The user caught it before it merged; the remaining numeric-density rule
+is language- and domain-neutral because digits are digits in any script.
 
-The shared `line_english` prompt now carries a **number-word
-annotation rule**: when the source states a quantity as a word (in any
-language: "two", "twelve", "a dozen", "to", "deux", "zwei", …) the
-LLM must annotate the digit form inline, e.g.
-"four (4) part-time instructors". The native phrasing stays in
-`line_original`. This delegates the multilingual recognition to the LLM
-where it has the training, rather than encoding number-word tables
-in code. Vague quantifiers ("several", "a handful", "some") are
-explicitly excluded so the LLM does not invent digits for them.
+The shared `line_english` prompt now carries a number-word annotation
+rule and the `missing_data_to_estimate` bucket prompt carries a
+denominator-pairing rule with concrete patterns. After this change, the
+v26 Nuuk digest exposed the right denominators across all four
+compressed sections.
 
-The `missing_data_to_estimate` bucket prompt now carries a
-**denominator-pairing rule** with concrete patterns: a share-of-revenue
-percentage needs the absolute period-revenue target; a per-hour price
-needs billable hours; a conversion rate needs an attendee count; an
-FTE count needs a per-head cost; a failure-duration needs per-period
-revenue exposure. After this change, the v26 Nuuk digest exposed the
-right denominators across all four compressed sections — exactly the
-items the downstream extractor was previously having to invent.
+### prepare_extract_input.py — new bundle driver (morning, PR #704)
 
-### prepare_extract_input.py — new bundle driver
+Assembles `extract_parameters_input.md` from the 137-recommended bundle
+in 137's order. Four compressed sections via `run_compress_full`, four
+raw sections passed through from the sample dir. Mixed-format keeps the
+inline epistemic tags where they matter and avoids doubling the LLM cost
+on sections that don't benefit from compression. The full 8-section
+bundle is ~56 KB on the Nuuk sample, well under any sensible LLM
+context.
 
-The script takes a PlanExe sample directory and assembles
-`extract_parameters_input.md` from the 137-recommended bundle in 137's
-order: Executive Summary, Project Plan, Selected Scenario, Assumptions,
-Review Plan, Premortem, Expert Criticism, Data Collection. The four
-"Keep or compress" sections of 137 use the compressed digests produced
-by `run_compress_full`; the four plain "Keep" sections are passed
-through raw from the sample dir.
+### extract-parameters-from-digest — new sibling skill (morning, PR #704)
 
-Mixed-format was the right choice: forcing all eight through compression
-would have doubled LLM cost and runtime without obviously improving the
-digest, while keeping all eight raw would have lost the inline epistemic
-tags that the downstream skill relies on. The compressed digest alone
-is ~21 KB on the Nuuk sample; the full 8-section bundle is ~56 KB —
-still well under any sensible LLM context.
+A minimal-diff fork of the renamed `extract-parameters-from-full` skill.
+Output schema is byte-identical so the two skills produce comparable
+JSON. Input-framing intro describes the 8-section bundle and its
+mixed-format nature; a "How to read the digest" block teaches the LLM
+to use the inline `[source_status | e=N r=N | quote: verified|unverified]`
+tags on compressed sections; a cross-section canonicalisation rule
+addresses the compressor's intentional over-production.
 
-### extract-parameters-from-digest — new sibling skill
+### monte-carlo — Stage 7 lifted to deterministic Python (afternoon, PR #705)
 
-A minimal-diff fork of the existing `extract-parameters-from-full` skill. The
-system prompt is byte-identical from the formula/dependency/uniqueness
-rules onward; the only changes are:
+The old skill asked the LLM to "run 10 000 simulations" and emit summary
+stats. The LLM cannot actually sample 10 000 draws in-prompt — it
+produced plausible-looking but non-deterministic numbers that didn't
+respect the seed setting. Replaced with `run_monte_carlo.py`: seeded
+NumPy RNG, triangular/uniform/Bernoulli sampling per the user-declared
+`sampling_discipline`, dependency-ordered calculation execution via
+`inspect.signature`, threshold operators, Pearson sensitivity (top 5,
+dependency-filtered, ≥20-sample minimum), aggregated warnings. Same
+seed produces a byte-identical output file. The `monte-carlo` skill
+becomes a thin wrapper around the script.
 
-- The input-framing intro describes the 8-section bundle and its
-  mixed-format nature.
-- A "How to read the digest" block teaches the LLM to use the inline
-  `[source_status | e=N r=N | quote: verified|unverified]` tags on
-  compressed sections, and general triage on raw sections.
-- A **cross-section canonicalisation rule** with concrete merge
-  patterns ("collapse all hourly-rate phrasings to one
-  `*_hourly_rate_dkk` id; drop the rest"). Reasoning: the compressor
-  intentionally over-produces because each section is fed a different
-  multi-file Luigi blob, so the same primitive surfaces under multiple
-  phrasings. Pushing canonicalisation upstream into the compressor
-  would couple it to extractor-schema decisions and lose per-section
-  provenance.
-- A **budget-vs-revenue denominator rule** in the Additional modelling
-  rules block. This one was added after a v26 review caught the
-  extractor computing `rental_revenue = budget * rental_share`, which
-  conflates spend capacity with sales target. The rule generalises to
-  cost-share, margin-share, contribution-share, and channel-share
-  percentages.
+### Strict upstream schema (afternoon, PR #705)
 
-The schema is byte-identical to the original `extract-parameters-from-full` so
-the two skills produce comparable JSON.
+Bounds entries gain `sampling_discipline` (one of `fixed |
+bernoulli_gate | integer | fraction | continuous`), `non_negative`
+(bool), and `default_pass_probability` (number in `[0, 1]` when
+`bernoulli_gate`, null otherwise). Entries with non-null `formula_hint`
+gain `output_name` and `output_unit`. The Monte Carlo runner reads
+these fields verbatim; missing or invalid values cause a `SCHEMA ERROR`
+exit code 2 with a message naming the upstream stage to re-run. There is
+no fallback path that re-guesses any classification.
 
-### validate, repair, bounds, calculations, scenarios, monte-carlo — untouched
+Three upstream skill prompts (`generate-bounds`, `extract-parameters-from-full`,
+`extract-parameters-from-digest`) and one downstream skill prompt
+(`run-scenarios`) updated to emit or consume the new fields. The
+`run-scenarios` prompt lost its 86-line unit-inference rule table —
+units are now copied verbatim from the entry's `output_unit`.
 
-Not exercised today. The 2026-05-12 assessment of these skills stands
-unchanged: validate-parameters and run-scenarios are solid, repair is
-unbuilt-and-not-blocking, generate-bounds and generate-calculations have
-the bounds-skip-but-no-calc dependency black hole that bit at v15, v20,
-and v23, and monte-carlo is solid after the v19 function-name-discovery
-fix.
+### summarize-insights — new skill + script (afternoon, PR #705)
 
-## How well does today's work address what was broken on 2026-05-12?
+`summarize_insights.py` reads any subset of the four pipeline artifacts
+and emits `insights.md` next to them. The output is written for project
+managers and non-developers; the body avoids statistics jargon (no
+"NaN", "Infinity", "Pearson", "non-finite", "model collapse",
+"p05/p50/p95"). Section order is deliberate: **Bad news first** leads
+with consolidated DOOM/FRAGILE callouts, scenario warnings, and
+blank-run alerts. If nothing qualifies, the section is omitted entirely
+— silence is the only acceptable form of good news.
+
+Verdict bands are driven entirely by user-declared thresholds: at least
+80% **ROBUST**, 50–80% **MARGINAL**, 20–50% **FRAGILE**, under 20%
+**DOOM**. No identifier-string or unit-string interpretation. The script
+does not invent thresholds for outputs the user did not declare.
+
+Writing rules codified in `SKILL.md` so they survive future edits: bad
+news first, no sugar-coating, no sycophancy, no hedging phrases (`the
+honest read is`, `frankly`, `to be fair`, `in fairness`, `candidly`,
+…). The user explicitly called out the hedging-phrase rule: *"the word
+honest signals to me that the default mode is not-honest."*
+
+### test-napkin-math — new skill + smoke runner (afternoon, PR #705)
+
+`tests/run_smoke.py` runs eight end-to-end checks: runner output,
+determinism, Bernoulli arithmetic spot-check, sensitivity ranking,
+schema-error fail-fast paths for each required field, summarize-insights
+end-to-end, `prepare_extract_input.py` import sanity, and the
+`compress_report_section` pytest suite. Designed to be invoked after
+any change to napkin_math or to the upstream skill prompts.
+
+### CI unittest suite — discovered by `python test.py` (afternoon, PR #705)
+
+44 cases under `tests/test_run_monte_carlo.py`. Covers settings merging
+(n_runs clamping, seed/distribution validation), each of the five
+sampling disciplines including Bernoulli p=0 / p=1 / override edge
+cases, schema validation for every required field, calculation
+execution failure modes (missing fn, exception, NaN return, multi-stage
+dependency), sensitivity ranking invariants, threshold operators
+(each of `> >= < <= == !=`, unsupported, unknown output), determinism
+(same seed byte-identical, different seeds diverge), unit propagation
+(`output_unit` copied verbatim), degenerate inputs (empty plan, low ==
+base == high continuous), and `distribution_default` uniform-vs-
+triangular variance ordering.
+
+Required new `__init__.py` at `experiments/`, `experiments/napkin_math/`,
+and `experiments/napkin_math/tests/` so the repo's `unittest.discover`
+walks into the experiment tree. Tests now show up alongside the
+existing 323 from `worker_plan` / `mcp_cloud` / `worker_plan_database`.
+
+### extract-parameters-from-full — renamed from extract-parameters (afternoon, PR #705)
+
+The bare name was ambiguous once the digest variant existed. Both
+skills produce the same output schema and differ only in input format.
+Mechanical rename with negative-lookahead sweep so the digest variant
+was not touched.
+
+### Four extractor prompt rules — current PR #706
+
+Each rule sits in both `extract-parameters-from-full` and
+`extract-parameters-from-digest` system prompts. The rules generalise
+specific Nuuk-case observations from ChatGPT into prompt rules that
+should apply on any plan:
+
+1. **Threshold-friendly output naming.** When a calculation will be
+   compared to a threshold, name it so that positive = pass. Prefer
+   `_surplus / _buffer / _margin / _coverage`; avoid `_gap / _deficit`.
+   Flip the formula sign rather than emit a confusingly-named output.
+   Also fixed two pre-existing conflicting examples in the same prompts
+   (`revenue_gap = required - expected`, `funding_gap = required -
+   available`) to the surplus framing.
+
+2. **Derive coupled stressors instead of sampling them independently.**
+   If a stressor variable (shortfall, deficit, overrun, drain, leakage)
+   is mechanically derivable from already-modelled inputs, declare it as
+   a calculation with `max(0, expected - achievable)`. Independent
+   sampling double-counts the underlying risk, allows physically
+   incoherent simulation runs, and weakens the sensitivity analysis.
+   Concrete signs of the anti-pattern in a draft: a `missing_values`
+   entry whose `why_needed` references another modelled variable by
+   name; a `suggested_estimation_method` that is effectively a formula;
+   an aggregate test that subtracts both an independent stressor AND the
+   inputs the stressor logically depends on.
+
+3. **No dead-end variables.** Every `key_value` and `missing_values`
+   entry must feed at least one calculation directly or transitively.
+   Before emitting JSON, walk the dependency graph and confirm each
+   variable reaches a calculation output. Common dead-end patterns
+   called out: a threshold/trigger value extracted without the variable
+   being tested against it AND a margin calculation; a capacity/FTE
+   constant extracted as background detail; a target the plan mentions
+   but the model has no way to evaluate. *"It is better to return six
+   well-connected key_values than eight where two are dead-ends. The
+   caps are a ceiling, not a target."*
+
+4. **Keep `plan_summary.modelling_frame` consistent with the executable
+   model.** When a risk concept is dropped under the No-dead-end rule,
+   drop it from the frame text. The frame describes what the
+   calculations actually evaluate, not the full plan as written.
+
+## What today's work addresses from the 2026-05-12 assessment
 
 The 0512 assessment named three structural recurring failures:
 
-1. **Bounds-skip-but-no-calc dependency black hole** —
-   `missing_values_to_estimate` entries whose ids look derivable
-   (`*_shortfall`, `*_gap`) get skipped by bounds and ignored by
-   calculations. **Not addressed today.** This bug lives downstream of
-   anything I changed.
-2. **Dead-end bounded inputs persist across iterations** — bounded
-   variables that no calculation consumes. **Partially addressed
-   indirectly.** The new cross-section canonicalisation rule in the
-   extraction skill explicitly forbids preserving two ids for the same
-   real-world quantity, which should reduce one cause of dead-ends.
-   The new denominator-pairing rule in the compressor surfaces
-   denominators that *should* feed calculations the extractor was
-   already producing — which should reduce another cause. But neither
-   change has been validated against the bounds/calculations stage.
-3. **Unmodelled stated funding gates** — Nuuk v20–v23 never modelled the
-   off-peak hourly rental coverage gate the report names as the funding
-   KPI. **Possibly addressed today.** The v26 extracted parameters
-   include `required_rental_utilization_fraction = rental_revenue_target_dkk
-   / (minimum_viable_hourly_rate_dkk * off_peak_rental_hours_year)`,
-   which is the formula for that gate. Whether it survives bounds and
-   produces non-null Monte Carlo runs is untested.
+1. **Bounds-skip-but-no-calc dependency black hole.** `missing_values_to_estimate`
+   entries whose ids looked derivable (`*_shortfall`, `*_gap`) got
+   skipped by bounds and ignored by calculations.
+   **Addressed.** The strict-schema work in PR #705 makes the runner
+   exit with `SCHEMA ERROR` exit code 2 if any required field is
+   missing, which surfaces this class of failure immediately instead of
+   producing silent NaN cascades. And the *Derive coupled stressors*
+   rule in PR #706 actively converts the `*_shortfall` entries from
+   independent missing inputs into derived calculations, so they no
+   longer fall into the bounds-skip path.
 
-So today's work plausibly closes (3) and softly chips at (2), but the
-load-bearing failure (1) is untouched and lives downstream of where I
-was operating.
+2. **Dead-end bounded inputs persist across iterations.** Bounded
+   variables that no calculation consumes.
+   **Addressed.** The *No dead-end variables* rule in PR #706 forbids
+   exactly this. The dependency-walk check is described in the prompt
+   and implemented as a manual walk during regeneration; not yet a
+   programmatic validator step, but the rule is explicit enough that
+   the LLM can enforce it.
+
+3. **Unmodelled stated funding gates.** Nuuk v20–v23 never modelled the
+   off-peak hourly rental coverage gate the report names as the funding
+   KPI.
+   **Addressed in v27 onward.** The `drop_in_capacity_surplus_dkk`
+   calculation tests this gate explicitly with threshold `>= 0`. v29
+   onward also makes the rental shortfall causally derived from the same
+   capacity inputs, so the gate's failure mode is wired into the
+   combined viability test as well.
+
+Of the issues from the morning's 0516 doc (which I wrote against an
+end-of-morning state), most have been closed too:
+
+- *Bounds-skip-but-no-calc* — addressed (above).
+- *Dead-end bounded inputs* — addressed (above).
+- *Currency support codification* — addressed in PR #705. The
+  ten-currency allowlist (`eur/usd/gbp/dkk/nok/sek/isk/chf/jpy/cny/inr`)
+  is gone; the runner discovers currency codes from declared input
+  units via 3-letter uppercase token scan. A synthetic INR project
+  produces "INR" for derived outputs with zero code changes.
+- *`inf`/heavy-tail explanation* — partially addressed by the
+  model-collapse callouts in `summarize-insights`; the section
+  "Numbers the model could not compute" names which inputs are
+  unresolved or which divisors hit zero, but doesn't yet attribute
+  collapse to specific input combinations.
+- *Compressed-vs-full-HTML head-to-head not run* — **still open**.
+- *Single-plan validation* — **still open**. v27–v31 are all Nuuk.
 
 ## Outstanding issues, in rough order of impact
 
-### Carried forward from 2026-05-12 (untouched today)
+### Highest leverage
 
-1. **Bounds-skip-but-no-calc dependency black hole.** Highest-leverage
-   open issue. Needs a coordinated edit to `generate-bounds` (don't
-   skip just because the id looks derivable) and `generate-calculations`
-   (emit functions for unresolved `missing_values_to_estimate` entries
-   that no other stage handles).
-2. **Dead-end bounded inputs.** Reduced in principle by the new
-   canonicalisation and denominator-pairing rules, but I have not
-   re-run bounds/calculations to verify the reduction.
-3. **Currency support codification.** Agents extend `_eur` to `_dkk`
-   ad-hoc; nothing in the prompts mandates the currency-suffix
-   convention. The compressor's "Currency-unit consistency" still-open
-   point in proposal 139 is the same issue from a different angle.
-4. **`inf`/heavy-tail explanation.** Monte Carlo reports the
-   collapse rate but doesn't surface which input combinations
-   triggered it.
+1. **Cross-plan generalisation untested.** Four prompt rules and the
+   strict-schema runner have been validated against one plan (Nuuk Clay
+   Workshop) in one currency (DKK) in one domain (commercial small
+   business). ChatGPT's v31 verdict put this in the same words: *"Next
+   useful test: run this on a very different plan and see whether it
+   still chooses primitive variables, avoids dead-end values, and derives
+   shortfalls instead of sampling them independently."* Until this runs,
+   the rules are claims, not validated behavior.
 
-### New today
-
-5. **Compressed vs full-HTML head-to-head not run.** The
+2. **Compressed-vs-full-HTML head-to-head not run.** The
    `extract-parameters-from-digest` skill exists and produces clean
-   output, but I have not re-run the existing `extract-parameters-from-full`
-   skill on the same plan (the full Nuuk HTML report) and diffed the
-   two parameters.json files. That is the comparison the experiment is
-   here to support, and the next step.
-6. **Single-plan validation.** All today's improvements were tested
-   against one plan (Nuuk Clay Workshop, a commercial small-business
-   plan in DKK with mixed Danish/English content). The denominator-
-   pairing rule and the cross-section canonicalisation rule both rely
-   on the LLM's domain understanding; they need testing on a public-
-   health plan (Leipzig) and an engineering/commercial plan in EUR
-   (Faraday) before I would trust they generalise.
-7. **Budget-vs-revenue rule has not been validated on a non-commercial
-   plan.** For a public-health or renovation plan the
-   "X% from rentals" framing does not apply. The rule's text generalises
-   to "cost-share, margin-share, contribution-share, channel-share" but
-   that has only been claimed, not exercised.
-8. **The mixed-format digest's raw sections add ~30 KB.** The
-   compressed digest alone is ~21 KB; the full 8-section bundle is
-   ~56 KB. Most of that growth is the four raw sections. Worth
-   measuring whether the raw Executive Summary / Project Plan /
-   Assumptions / Data Collection content actually contributes to
-   extraction quality, or whether the same primitives already arrive
-   via the compressed sections — in which case the bundle could be
-   slimmed.
-9. **Validator/repair loop on parameters.json not built.** The current
-   `extract-parameters-from-digest` system prompt carries a lot of
-   schema-discipline rules (no-orphan-formula, dependency-discipline,
-   global-id-uniqueness, combined-viability-gate-preservation). The
-   ChatGPT review of v26 explicitly suggested moving these out of the
-   expensive prompt and into a deterministic Python validator + a cheap
-   repair-model loop. This is a real architectural improvement that
-   would cut extraction cost without losing schema discipline. Not yet
-   built.
-10. **Compressor's role boundary is now load-bearing.** The new design
-    explicitly treats canonicalisation as the consumer's job, not the
-    compressor's. That means the compressor will keep emitting
-    cross-section duplicates by design, and any downstream consumer
-    that forgets to canonicalise will produce a fragmented parameter
-    set. The discipline only works if the contract between stages is
-    documented and tested — currently it is documented in two skill
-    system prompts and proposal 139, but there is no automated check
-    that a downstream consumer actually deduplicates.
+   output, but `extract-parameters-from-full` has not been run on the
+   same plan for direct comparison. That is the comparison the whole
+   experiment is set up to support.
+
+### Architectural
+
+3. **Validator/repair loop on parameters.json not built.** The two
+   extractor prompts now carry a lot of schema-discipline rules
+   (no-orphan-formula, dependency-discipline, global-id-uniqueness,
+   no-dead-end-variables, threshold-friendly-naming, derive-coupled-
+   stressors, frame-consistency). A deterministic Python validator
+   covering the same rules would let us shrink the expensive prompt
+   without losing discipline, and surface violations as structured
+   errors instead of requiring a re-run.
+
+4. **`run-scenarios` is still LLM-driven.** The same architectural
+   problem that motivated lifting Monte Carlo into Python applies here:
+   the LLM cannot actually execute Python functions in-prompt. The
+   skill's system prompt now correctly reads `output_name` and
+   `output_unit` directly from the parameters, so the simulation half is
+   easier to do mechanically — a small Python runner would be a natural
+   PR.
+
+5. **Compressor's role boundary is now load-bearing.** Canonicalisation
+   is documented as the consumer's job, not the compressor's. That means
+   the compressor will keep emitting cross-section duplicates by design,
+   and any downstream consumer that forgets to canonicalise will produce
+   a fragmented parameter set. Currently documented in two skill system
+   prompts and proposal 139; no automated check that a downstream
+   consumer actually deduplicates.
+
+### Minor
+
+6. **Insights' model-collapse alert doesn't attribute the cause.** The
+   summarizer says "blank in X% of runs — typically a missing input or a
+   divisor that hit zero" but doesn't name *which* input. The runner has
+   the per-run pool state at the moment of the failure; it could log
+   which arguments were missing for each function call.
+
+7. **The mixed-format digest's raw sections add ~30 KB.** Compressed
+   alone is ~21 KB; full bundle is ~56 KB. Worth measuring whether the
+   raw Executive Summary / Project Plan / Assumptions / Data Collection
+   content contributes to extraction quality, or whether the same
+   primitives already arrive via the compressed sections.
+
+8. **The `output/` tree is gitignored.** v27–v31 reference outputs exist
+   only locally on my machine. If the experiment is going to be
+   reproducible by a new contributor, the synthetic smoke fixture under
+   `tests/fixtures/smoke/` is the only canonical artifact in the repo.
+   Worth considering whether one reference plan's full output should be
+   committed as a regression baseline.
 
 ## What I would do next, if continuing
 
 In order:
 
-1. Run the existing `extract-parameters-from-full` skill on the full Nuuk HTML
-   report; diff the resulting parameters.json against
-   `parameters_b.json` from the compressed pipeline. This is the
-   experimental comparison the whole napkin_math experiment is set up
-   to support; we have not done it.
-2. Run the compressed pipeline against Leipzig and Faraday samples to
-   validate that the denominator-pairing rule and the canonicalisation
-   rule generalise across domains, not just commercial small business.
-3. Re-run the full downstream pipeline (`generate-bounds` →
-   `generate-calculations` → `run-scenarios` → `monte-carlo`) on the
-   v26 parameters and check whether issues (1)–(3) from the 0512
-   assessment are still observable. The compressed pipeline plausibly
-   moves issue 3; only a re-run shows whether it does.
-4. Start on the deterministic validator + repair loop the ChatGPT
-   review recommended. The extraction prompt has accumulated enough
-   validator-style rules that a code-side validator would let us
-   shrink the expensive prompt without losing discipline.
+1. **Run the pipeline against a different plan.** Pick one of the
+   existing Leipzig or Faraday samples (referenced in earlier
+   `planexe_simulator/output/v*/` artifacts), produce a digest with
+   `prepare_extract_input.py`, apply `extract-parameters-from-digest`,
+   and walk the resulting JSON through bounds → calculations →
+   scenarios → monte-carlo → insights. The four prompt rules are
+   claims about generalisable behaviour; this is the experiment that
+   either confirms or breaks them. Capture the result as a comparison
+   doc.
+
+2. **Run the existing `extract-parameters-from-full` skill on the full
+   Nuuk HTML report** and diff the resulting parameters.json against
+   v31's. This is the experimental comparison the whole napkin_math
+   experiment is here to support; it has not been done.
+
+3. **Lift `run-scenarios` to a Python runner**, mirroring what PR #705
+   did for Monte Carlo. The strict schema makes this a straight port —
+   the skill just reads `output_name` / `output_unit` and calls the
+   functions in order.
+
+4. **Build a deterministic validator + repair loop** for parameters.json.
+   The extraction prompt has accumulated enough validator-style rules
+   (no-orphan-formula, depends-on-discipline, threshold-friendly-naming,
+   no-dead-end-variables, derived-stressor-detection, frame-consistency)
+   that a code-side validator would let us shrink the expensive prompt
+   substantially and surface violations as structured errors instead of
+   requiring a re-run.
 
 ## Closing thought
 
-Today's work moved the input quality and structural cleanliness of the
-parameter-extraction stage in a coherent direction. The biggest single
-win was probably the denominator-pairing rule — it gives the downstream
-extractor the hooks it needs to wire executable formulas, which the
-0512 assessment named as one of the three biggest structural gaps.
-The biggest single near-miss was the `PROTECTED_MODELLING_TERMS`
-experiment, which would have silently introduced a language and domain
-bias into the ranker. The catch was the user's, not mine.
+Today moved the pipeline from "LLM-driven simulation that couldn't
+actually simulate" to "Python-driven simulation with strict schema and
+project-manager-facing output". The four prompt rules accumulated in
+PR #706 each came from a single round of external review, and each one
+is small enough to read in one sitting — the rules grew organically
+from concrete failure modes on one plan, which is good for
+specificity but means none of them have been pressure-tested across
+domains.
 
-But the actual headline question of this experiment — "does compressing
-the report into a smaller digest produce a better parameters.json than
-feeding the full HTML?" — remains unanswered. We have produced six
-versions of compressed digests and three versions of extracted
-parameters; we have not produced one full-HTML extraction on the same
-plan to compare against. Until that comparison is run, the experiment
-is incomplete.
+The single biggest remaining gap is **cross-plan validation**. v31 is
+the best version this loop produced on the Nuuk Clay Workshop, but the
+Nuuk plan is a 2 MDKK commercial small-business in Greenland; the
+prompt rules' real test is whether they hold up on a public-health
+plan in EUR or an engineering plan with non-monetary primary outputs.
+That test is the natural next session.


### PR DESCRIPTION
## Summary

ChatGPT reviewed the v27 Nuuk plan run and verdict was "the best version so far" — pipeline closed end-to-end, Monte Carlo runs clean with zero warnings, validation passes, scenarios produce useful conclusions. One thing flagged: `rental_revenue_gap_dkk` is directionally confusing. The output is tested with `<= 0` ("no gap"), but the reader has to re-derive which sign is the good one. Suggestion: rename to `drop_in_capacity_surplus_dkk` with threshold `>= 0`.

This PR generalises that lesson into a new prompt rule rather than hand-patching one entry.

## What changed

Both extractor skill prompts (`extract-parameters-from-full` and `extract-parameters-from-digest`) gain a **Threshold-friendly output naming** section:

- When a calculation is meant to be compared against a threshold, name it so that **positive = pass**.
- Prefer suffixes: `_surplus`, `_buffer`, `_margin`, `_coverage`.
- Avoid: `_gap` (direction ambiguous), `_deficit` (implies always bad), `_shortfall` (only when the formula matches the name).
- Flip the formula sign rather than emit a confusingly-named output. The rule is explicit: "if you would naturally write `x_gap = expected - capacity` with threshold `<= 0`, instead write `x_capacity_surplus = capacity - expected` with threshold `>= 0`".

Also fixed two pre-existing conflicting examples in the same prompts (`revenue_gap = required - expected`, `funding_gap = required - available`) so the "Preferred patterns" list and the "Commercial gate execution rule" no longer contradict the new naming rule.

## Demonstration

Regenerated `output/v28/20260215_nuuk_clay_workshop/` locally (the `output/` tree is gitignored, consistent with v24–v27). Same plan, same digest, applying the new rule by hand as a future LLM run would.

- `rental_revenue_gap_dkk` (threshold `<= 0`) → `drop_in_capacity_surplus_dkk` (threshold `>= 0`)
- Formula sign flipped: `(rate * hours) - expected_revenue` instead of `expected_revenue - (rate * hours)`
- All three scenarios now produce **negative** surplus (-84k / -326k / -506k) — same finding as v27 but the sign convention now matches the verdict direction.

Headline shift in `insights.md`:
- v27: `P(rental_revenue_gap_dkk <= 0) = 0.14%` — DOOM
- v28: `P(drop_in_capacity_surplus_dkk >= 0) = 0.14%` — DOOM

Same number, plain-English reading.

## Test plan

- [x] Smoke 8/8 (`tests/run_smoke.py`)
- [x] Unittest 45/45 (`tests/test_run_monte_carlo.py`)
- [x] v28 end-to-end: scenarios, monte-carlo, and insights all regenerate cleanly
- [ ] Reviewer to confirm the prompt rule reads as language- and domain-neutral (no English-token bias, no commercial-domain assumption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)