### PR TITLE
feat(napkin-math): shared-pool legitimacy check for aggregate surplus tests

### DIFF
--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -269,6 +269,37 @@ modelling_frame describes the scope of what the calculations actually evaluate, 
 
 Concrete pattern: if the frame says "buffers against A, B, and C shocks" and you only retained calculations that test A and B, the frame must say "buffers against A and B shocks". Do not paper over the gap by keeping the dropped concept in the prose.
 
+Shared-pool legitimacy check for combined surplus tests:
+
+When an aggregate test (combined_viability_surplus, program_viability_surplus, total_capacity_surplus, …) subtracts multiple pressures from one reserve, verify those pressures actually draw from the same pool. The source has to say it — the same named buffer, the same line item, the same budget envelope. If they do, additive netting is correct. If they don't, do not pretend they are fungible: use min() over the individual surplus calculations instead.
+
+Correct additive form (single pool absorbs every pressure):
+
+combined_viability_surplus = pool_reserve - pressure_a - pressure_b - pressure_c
+
+Use this when the source explicitly names one reserve that all pressures debit (example: a 15% contingency that the plan's risk register repeatedly says absorbs labor-law shocks AND revenue shortfalls AND utility overruns).
+
+Correct min() form (separate pools, separate pressures):
+
+combined_viability_surplus = min(surplus_a, surplus_b, surplus_c)
+  where surplus_a = pool_a_reserve - pressure_a
+        surplus_b = pool_b_reserve - pressure_b
+        surplus_c = pool_c_reserve - pressure_c
+
+Use this when each pressure draws on a different pool — settlement liquidity vs revenue economics vs operator cost recovery, for instance. The aggregate threshold "all gates pass" remains meaningful (min >= 0 iff every individual surplus >= 0), but the formula no longer assumes one pool can absorb every shock.
+
+Signs the additive form is wrong (and you should use min()):
+- the pressures are different in kind: liquidity vs revenue vs cost vs capacity vs schedule;
+- different stakeholders own each pool (a clearing-house bank account vs an annual revenue stream vs each operator's IT budget);
+- the source describes each pressure as drawing on a different reserve, even when the absolute numbers are similar.
+
+Signs the additive form is correct:
+- the source explicitly names one buffer that absorbs all of the listed pressures;
+- the pressures are denominated against the same envelope;
+- the risk register repeatedly debits the same pool for each scenario.
+
+The aggregate name should match the form. "combined_viability_surplus" without qualification reads as additive; if you must use min(), prefer a name like "weakest_gate_surplus" or "worst_case_pool_surplus" to signal to a reader that the test is "every gate independently", not "one buffer absorbs everything".
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
@@ -232,6 +232,37 @@ modelling_frame describes the scope of what the calculations actually evaluate, 
 
 Concrete pattern: if the frame says "buffers against A, B, and C shocks" and you only retained calculations that test A and B, the frame must say "buffers against A and B shocks". Do not paper over the gap by keeping the dropped concept in the prose.
 
+Shared-pool legitimacy check for combined surplus tests:
+
+When an aggregate test (combined_viability_surplus, program_viability_surplus, total_capacity_surplus, …) subtracts multiple pressures from one reserve, verify those pressures actually draw from the same pool. The plan's text has to say it — the same named buffer, the same line item, the same budget envelope. If they do, additive netting is correct. If they don't, do not pretend they are fungible: use min() over the individual surplus calculations instead.
+
+Correct additive form (single pool absorbs every pressure):
+
+combined_viability_surplus = pool_reserve - pressure_a - pressure_b - pressure_c
+
+Use this when the plan explicitly names one reserve that all pressures debit (example: a 15% contingency that the plan's risk register repeatedly says absorbs labor-law shocks AND revenue shortfalls AND utility overruns).
+
+Correct min() form (separate pools, separate pressures):
+
+combined_viability_surplus = min(surplus_a, surplus_b, surplus_c)
+  where surplus_a = pool_a_reserve - pressure_a
+        surplus_b = pool_b_reserve - pressure_b
+        surplus_c = pool_c_reserve - pressure_c
+
+Use this when each pressure draws on a different pool — settlement liquidity vs revenue economics vs operator cost recovery, for instance. The aggregate threshold "all gates pass" remains meaningful (min >= 0 iff every individual surplus >= 0), but the formula no longer assumes one pool can absorb every shock.
+
+Signs the additive form is wrong (and you should use min()):
+- the pressures are different in kind: liquidity vs revenue vs cost vs capacity vs schedule;
+- different stakeholders own each pool (a clearing-house bank account vs an annual revenue stream vs each operator's IT budget);
+- the plan's text describes each pressure as drawing on a different reserve, even when the absolute numbers are similar.
+
+Signs the additive form is correct:
+- the plan explicitly names one buffer that absorbs all of the listed pressures;
+- the pressures are denominated against the same envelope;
+- the risk register repeatedly debits the same pool for each scenario.
+
+The aggregate name should match the form. "combined_viability_surplus" without qualification reads as additive; if you must use min(), prefer a name like "weakest_gate_surplus" or "worst_case_pool_surplus" to signal to a reader that the test is "every gate independently", not "one buffer absorbs everything".
+
 If the necessary input is missing, add that input to missing_values_to_estimate and use it in the formula.
 
 If space limits prevent adding the missing input, omit the derived question rather than emitting formula_hint: null.

--- a/experiments/napkin_math/docs/20260516_claude.md
+++ b/experiments/napkin_math/docs/20260516_claude.md
@@ -1,30 +1,52 @@
 # Pipeline status — Claude's view, 2026-05-16
 
-End-of-day snapshot. This is the second of two same-day updates: an
-earlier version of this doc captured the morning's compression-stage and
-parameter-extraction work; this version expands it with two follow-on
-sessions that lifted the Monte Carlo stage out of the LLM, locked the
-pipeline schema across stages, and ran four iterations of a ChatGPT
-review loop on the Nuuk plan.
+End-of-day snapshot. This is the third same-day update: an
+earlier version captured the morning's compression-stage and
+parameter-extraction work, a second version expanded it with the
+afternoon sessions that lifted the Monte Carlo stage out of the LLM
+and ran four iterations of a ChatGPT review loop on the Nuuk plan,
+and this version folds in the late-evening fifth prompt rule
+(shared-pool legitimacy), the summarize-insights reordering, and
+two new cross-plan runs that put all five rules through their
+generalisation test on different domains.
 
 The headline state at end-of-day: the pipeline is **closed end-to-end**
-on the Nuuk Clay Workshop sample using the digest variant, with
-deterministic Python at the simulation stage, strict schema validation
-between LLM stages, automated tests in CI, a project-manager-facing
-insights report, and four prompt rules added in response to four rounds
-of external review. The Monte Carlo runs with zero warnings, validation
-is clean, and the verdicts read coherently:
+on three different plans across two distinct domains, with deterministic
+Python at the simulation stage, strict schema validation between LLM
+stages, automated tests in CI, a project-manager-facing insights report,
+and five prompt rules added in response to five rounds of external
+review across the three plans. The Monte Carlo runs with zero warnings
+on every plan and the verdicts read coherently:
 
 ```
-P(combined_viability_surplus_dkk >= 0) = 1.09%     DOOM
-P(single_shock_buffer_dkk        >= 0) = 81.97%    ROBUST
-P(drop_in_capacity_surplus_dkk   >= 0) = 0.14%     DOOM
-P(taster_conversion_margin       >= 0) = 74.92%    MARGINAL
+Nuuk Clay Workshop (DKK, commercial small-business):
+  P(combined_viability_surplus_dkk >= 0) = 1.09%     DOOM
+  P(single_shock_buffer_dkk        >= 0) = 81.97%    ROBUST
+  P(drop_in_capacity_surplus_dkk   >= 0) = 0.14%     DOOM
+  P(taster_conversion_margin       >= 0) = 74.92%    MARGINAL
+
+Cross-Border Rail Ticketing (EUR, EU public infrastructure):
+  P(clearing_capacity_surplus_eur                 >= 0) = 100.00%  ROBUST
+  P(royalty_cost_coverage_surplus_eur             >= 0) =  54.46%  MARGINAL
+  P(clearing_initial_float_buffer_eur             >= 0) =  53.74%  MARGINAL
+  P(regulatory_risk_buffer_surplus_eur            >= 0) =  48.34%  FRAGILE
+  P(weakest_financial_gate_surplus_eur (min)      >= 0) =  26.15%  FRAGILE
+  P(adoption_margin                               >= 0) =  10.22%  DOOM
+
+Faraday Enclosure Launch (EUR, commercial hardware launch):
+  P(presales_iso_threshold_margin_units >= 0) = 44.66%  FRAGILE
+  P(inventory_overhang_buffer_eur       >= 0) = 22.98%  FRAGILE
+  P(cash_flow_trigger_surplus_eur       >= 0) =  4.63%  DOOM
+  P(mil_std_cert_funding_surplus_eur    >= 0) =  2.23%  DOOM
+  P(weakest_program_gate_surplus_eur (min) >= 0) =  1.74%  DOOM
 ```
 
-The biggest remaining structural question — *does the pipeline
-generalise beyond the Nuuk case?* — is still open. Every prompt rule was
-validated against one plan in one currency in one domain.
+Each plan produced a domain-appropriate model. None of the three is a
+template overfit of another. The biggest structural question that was
+open this morning — *does the pipeline generalise beyond the Nuuk
+case?* — is now substantively answered for two new domains. The
+remaining headline gap is the original compressed-vs-full-HTML
+head-to-head, which still has not been run.
 
 ## TL;DR — what shipped today
 
@@ -79,7 +101,7 @@ Three branches, three coherent slabs of work.
 - **v27 reference run** of the full pipeline on the Nuuk digest, all
   files clean end-to-end, gitignored output tree.
 
-**3. `feat/napkin-math-metric-naming` (PR #706, current, four commits, not merged):**
+**3. `feat/napkin-math-metric-naming` (PR #706, merged):**
 Four prompt-rule additions, each driven by a single round of ChatGPT
 feedback against the previous version. Each round generated a numbered
 output dir under `output/v{27..31}/` (all gitignored).
@@ -92,7 +114,60 @@ output dir under `output/v{27..31}/` (all gitignored).
 | v30 → v31 | **Keep `modelling_frame` consistent with the executable model.** When a concept is dropped from the variable set, drop it from the frame too. The frame should describe what the simulation actually evaluates, not the full plan as written. | v30's frame mentioned "fixed Arctic operating costs" (overpromised — model only handles labor) and omitted the Taster KPI dimension. v31's frame names all four executable threshold tests by their semantics. |
 
 ChatGPT's v31 verdict: *"Keep this as the current best version. Further
-tuning on the Nuuk case probably gives diminishing returns."*
+tuning on the Nuuk case probably gives diminishing returns. Next useful
+test: run this on a very different plan and see whether it still chooses
+primitive variables, avoids dead-end values, and derives shortfalls
+instead of sampling them independently."*
+
+**4. `feat/napkin-math-shared-pool` (PR #707, current, two commits, not merged):**
+Driven by ChatGPT's review of the first cross-plan run (the Cross-Border
+European Rail Ticketing plan at `output/v31/20260514_cross_border_rail_ticketing/`).
+The v31 rail model used an additive `combined_program_viability_surplus_eur`
+that subtracted both peak clearing obligation AND enforcement-delay
+revenue shortfall from the same `(clearing_float + emergency_reserve)`
+pool. ChatGPT flagged that those two pressures actually draw on
+different pools — the digest scopes the €300M reserve to the clearing
+mechanism only — so additive netting overstated the aggregate's
+headroom (47.3% pass under additive vs 26.2% under the correct min()).
+
+| Round | Prompt rule added | Demonstrated in |
+|---|---|---|
+| v31 → v32 | **Shared-pool legitimacy check for combined surplus tests.** When an aggregate test subtracts multiple pressures from one reserve, verify those pressures actually draw from the same pool. Same named buffer, same line item, same envelope. If yes (Nuuk: the 15% DKK contingency absorbs labor + rental + kiln shocks), additive subtraction is correct. If no (rail: clearing pool vs revenue pool vs operator IT budget), use `min()` over individual surpluses and rename the aggregate to `weakest_*_surplus`. | `combined_program_viability_surplus_eur` (additive, 47.3% pass) replaced with `weakest_financial_gate_surplus_eur = min(clearing_capacity_surplus, regulatory_risk_buffer_surplus, royalty_cost_coverage_surplus)` (26.2% pass). Other five rail gates individually scoped, unchanged. Nuuk additive form re-validated against the digest text and confirmed correct — no change there. |
+
+The same PR also tweaked `summarize_insights.py`: ChatGPT's caveat was
+that `min()` aggregates carry pass/fail meaning but their *magnitude*
+should not be read as a usual monetary surplus (it picks the worst
+gate's number, dominated by whichever has the largest swings). The
+summarizer now detects `min()`-style aggregates via a formula-text scan
+and demotes them after individual gates within each severity band,
+adding a leading `min` marker. Additive aggregates (Nuuk's
+`combined_viability_surplus_dkk`) keep their natural severity-sorted
+position because their magnitude is a real pool depletion.
+
+**Cross-plan validation** of all five prompt rules:
+
+| Plan | Domain | Currency | Result |
+|---|---|---|---|
+| Nuuk Clay Workshop | commercial small-business | DKK | v31 (best for plan), v33 reporting tweak |
+| Cross-Border EU Rail | public infrastructure / regulatory | EUR | v32 with shared-pool fix, v33 reporting tweak |
+| Faraday Enclosure | commercial hardware launch | EUR | v33 first run, structurally fragile per the model |
+
+Each plan produced a domain-appropriate model with no template overfit.
+Verdict shape varies meaningfully:
+
+- Nuuk: two DOOM (the combined viability + drop-in capacity gates), one
+  MARGINAL (taster KPI), one ROBUST (single-shock buffer). The
+  combined-viability DOOM is the plan-level finding.
+- Rail: one DOOM (adoption against the 40% target), one ROBUST
+  (full clearing capitalisation), three MARGINAL/FRAGILE (royalty
+  sustainability, initial-float buffer, regulatory enforcement
+  exposure), the `min()` aggregate at 26.2% FRAGILE.
+- Faraday: three DOOM (cash-flow trigger, MIL-STD cert funding,
+  weakest gate), two FRAGILE (inventory overhang, pre-sales floor).
+  The model rediscovers the plan's own stated Risk 4 ("at €99 price,
+  2,000-unit run generates only ~€89k gross profit, insufficient for
+  €120k MIL-STD") as a Monte Carlo finding rather than just a
+  scenario note.
 
 ## What changed today, skill by skill
 
@@ -322,20 +397,30 @@ end-of-morning state), most have been closed too:
 
 ### Highest leverage
 
-1. **Cross-plan generalisation untested.** Four prompt rules and the
-   strict-schema runner have been validated against one plan (Nuuk Clay
-   Workshop) in one currency (DKK) in one domain (commercial small
-   business). ChatGPT's v31 verdict put this in the same words: *"Next
-   useful test: run this on a very different plan and see whether it
-   still chooses primitive variables, avoids dead-end values, and derives
-   shortfalls instead of sampling them independently."* Until this runs,
-   the rules are claims, not validated behavior.
+1. **Cross-plan generalisation — substantively closed, narrowly open.**
+   This morning's status doc named this as the highest-leverage open
+   issue. It is now substantively closed: all five prompt rules have
+   been run on three different plans (Nuuk Clay Workshop in DKK
+   commercial small-business, Cross-Border EU Rail in EUR public
+   infrastructure, Faraday Enclosure in EUR commercial hardware
+   launch), and each produced a domain-appropriate model with no
+   template overfit. The Faraday run was the toughest test of the
+   rules — different revenue model, different funding structure,
+   different gate semantics — and the rules held. What remains
+   narrowly open is whether a fourth domain (e.g., the Leipzig
+   public-health resilience plan still on disk under
+   `/Users/neoneye/git/neoneye_lab/planexe_simulator/output/v16/`)
+   would break any rule. Worth running, but the marginal information
+   per additional plan is dropping.
 
-2. **Compressed-vs-full-HTML head-to-head not run.** The
-   `extract-parameters-from-digest` skill exists and produces clean
-   output, but `extract-parameters-from-full` has not been run on the
-   same plan for direct comparison. That is the comparison the whole
-   experiment is set up to support.
+2. **Compressed-vs-full-HTML head-to-head not run.** Unchanged from
+   this morning's doc. The `extract-parameters-from-digest` skill
+   exists and has now been run against three different plans
+   producing clean output, but `extract-parameters-from-full` has not
+   been run on any of the three for direct comparison. That is the
+   original headline question of the experiment ("is the digest a
+   better extractor input than the full HTML?") and it remains
+   unanswered.
 
 ### Architectural
 
@@ -389,48 +474,82 @@ end-of-morning state), most have been closed too:
 
 In order:
 
-1. **Run the pipeline against a different plan.** Pick one of the
-   existing Leipzig or Faraday samples (referenced in earlier
-   `planexe_simulator/output/v*/` artifacts), produce a digest with
-   `prepare_extract_input.py`, apply `extract-parameters-from-digest`,
-   and walk the resulting JSON through bounds → calculations →
-   scenarios → monte-carlo → insights. The four prompt rules are
-   claims about generalisable behaviour; this is the experiment that
-   either confirms or breaks them. Capture the result as a comparison
-   doc.
+1. **Run `extract-parameters-from-full` on one of the three plans for a
+   head-to-head against the digest output.** This is the original
+   experimental question and still has not been done. Suggested target:
+   Nuuk Clay Workshop, where the digest extractor has produced six
+   reviewed iterations (v27 → v32). Run the full-HTML extractor against
+   the same source and diff the resulting `parameters.json` files. The
+   comparison should answer: does compression cost us extraction
+   quality (variable count, missing-data coverage, dead-end rate), or
+   does the digest help by forcing the LLM to triage upstream?
 
-2. **Run the existing `extract-parameters-from-full` skill on the full
-   Nuuk HTML report** and diff the resulting parameters.json against
-   v31's. This is the experimental comparison the whole napkin_math
-   experiment is here to support; it has not been done.
+2. **Run the pipeline against one more domain.** Three plans validates
+   the rules across two distinct domains (commercial and public
+   infrastructure). A public-health plan (the Leipzig Heat Response
+   sample still on disk) would add a third domain with non-monetary
+   primary outputs (avoided harm, contact rates) and test whether the
+   threshold-friendly-naming and shared-pool rules generalise outside
+   monetary surplus framing.
 
 3. **Lift `run-scenarios` to a Python runner**, mirroring what PR #705
    did for Monte Carlo. The strict schema makes this a straight port —
    the skill just reads `output_name` / `output_unit` and calls the
-   functions in order.
+   functions in order. All three plan runs this evening had to
+   hand-compute the scenario table because run-scenarios is still
+   LLM-driven; that is now the most expensive remaining LLM stage.
 
 4. **Build a deterministic validator + repair loop** for parameters.json.
    The extraction prompt has accumulated enough validator-style rules
    (no-orphan-formula, depends-on-discipline, threshold-friendly-naming,
-   no-dead-end-variables, derived-stressor-detection, frame-consistency)
-   that a code-side validator would let us shrink the expensive prompt
-   substantially and surface violations as structured errors instead of
-   requiring a re-run.
+   no-dead-end-variables, derived-stressor-detection, frame-consistency,
+   shared-pool-legitimacy) that a code-side validator would let us
+   shrink the expensive prompt substantially and surface violations as
+   structured errors instead of requiring a re-run. A small in-Python
+   dead-end check has already been used as a one-off in this session;
+   wiring it (plus the other rules) into a `validate_parameters.py`
+   script is the natural follow-up.
 
 ## Closing thought
 
 Today moved the pipeline from "LLM-driven simulation that couldn't
-actually simulate" to "Python-driven simulation with strict schema and
-project-manager-facing output". The four prompt rules accumulated in
-PR #706 each came from a single round of external review, and each one
-is small enough to read in one sitting — the rules grew organically
-from concrete failure modes on one plan, which is good for
-specificity but means none of them have been pressure-tested across
-domains.
+actually simulate" to "Python-driven simulation with strict schema, a
+project-manager-facing insights report, and five prompt rules
+cross-validated against three different plans in two domains".
 
-The single biggest remaining gap is **cross-plan validation**. v31 is
-the best version this loop produced on the Nuuk Clay Workshop, but the
-Nuuk plan is a 2 MDKK commercial small-business in Greenland; the
-prompt rules' real test is whether they hold up on a public-health
-plan in EUR or an engineering plan with non-monetary primary outputs.
-That test is the natural next session.
+This morning's doc named cross-plan validation as the largest
+remaining gap. That gap is now substantively closed. Each of the five
+prompt rules survived its toughest test: the Faraday Enclosure plan
+has a fundamentally different funding shape (split production, binary
+ISO commitment, conditional follow-on tied to operations cash) from
+either Nuuk or the rail program, and the rules produced a coherent
+model whose verdicts rediscover the plan's own stated risks as
+quantified Monte Carlo probabilities. None of the rules had to be
+re-tuned or relaxed to fit a new domain.
+
+The Faraday pass also surfaced one self-inflicted issue worth
+recording. My first draft of the Faraday model subtracted all Year-1
+spend (marketing, certification, ongoing ops) from gross profit to
+compute "net cash from operations", which mis-modelled the funder's
+"€50k net cash from operations, excluding the initial €400k
+investment" — that wording explicitly treats the upfront marketing
+and certification as investment, not operating cost. The first-draft
+deterministic scenarios came back with weakest-gate surplus of -€271k
+at the high end, which is louder than the plan deserves. Tightening
+the bound to just the ongoing run-rate produced the actual structural
+finding: "Year-1 ops cannot fund the €120k MIL-STD cert from a
+€99-per-unit product" (the plan's own Risk 4, now reproduced as a
+2.2% Monte Carlo probability rather than a stated risk). The
+deterministic three-scenario table caught my mis-definition before
+Monte Carlo ran — gross profit positive but net cash deeply negative
+across all three scenarios is the kind of direction that should
+trigger a re-check of the formula. Worth keeping that pattern:
+when the deterministic table reads as obviously worse than the plan
+itself frames the risks, the model is probably wrong, not the plan.
+
+The original headline question of the napkin_math experiment —
+*"does compressing the report into a smaller digest produce a better
+parameters.json than feeding the full HTML?"* — is now the single
+biggest remaining gap. Six digest-extraction iterations on Nuuk, two
+on the rail plan, and one on Faraday have not been compared against a
+single full-HTML run. That is the natural next session.

--- a/experiments/napkin_math/summarize_insights.py
+++ b/experiments/napkin_math/summarize_insights.py
@@ -87,6 +87,28 @@ def render_plan_summary(params: dict | None) -> list[str]:
     return lines
 
 
+def aggregate_output_ids(params: dict | None) -> set[str]:
+    """Return output_ids whose formula uses min() over other gates.
+
+    Those magnitudes are not a usual monetary surplus — they pick the worst
+    of several independent gates. The verdict pass/fail is meaningful, the
+    raw number is not. Report them after the individual gates.
+
+    Additive aggregates (Nuuk-style: pool - shock_a - shock_b) are NOT
+    demoted: when the source explicitly names one pool absorbing every
+    pressure, the magnitude is a real depletion of that pool.
+    """
+    if not params:
+        return set()
+    ids: set[str] = set()
+    for src in ("recommended_first_calculations", "derived_questions"):
+        for entry in params.get(src, []):
+            hint = entry.get("formula_hint") or ""
+            if "min(" in hint and entry.get("output_name"):
+                ids.add(entry["output_name"])
+    return ids
+
+
 def classify_thresholds(mc: dict | None) -> dict[str, list[tuple[str, dict, str]]]:
     """Bucket thresholds by verdict severity. Returns {verdict: [(id, threshold, note)]}."""
     buckets: dict[str, list[tuple[str, dict, str]]] = {}
@@ -98,14 +120,20 @@ def classify_thresholds(mc: dict | None) -> dict[str, list[tuple[str, dict, str]
     return buckets
 
 
+def sort_aggregates_last(entries, output_id_index, aggregates):
+    """Stable sort: non-aggregates first, then aggregates."""
+    return sorted(entries, key=lambda e: 1 if e[output_id_index] in aggregates else 0)
+
+
 def render_bad_news_first(mc: dict | None, scenarios: dict | None,
                           params: dict | None, bounds: dict | None) -> list[str]:
     """Consolidate every signal that the plan is in trouble into a single
     top-of-report block. If nothing qualifies, emit nothing."""
     rows: list[str] = []
     buckets = classify_thresholds(mc)
-    doom = buckets.get("DOOM", [])
-    fragile = buckets.get("FRAGILE", [])
+    aggregates = aggregate_output_ids(params)
+    doom = sort_aggregates_last(buckets.get("DOOM", []), 0, aggregates)
+    fragile = sort_aggregates_last(buckets.get("FRAGILE", []), 0, aggregates)
 
     scenario_warns = (scenarios or {}).get("warnings", []) if scenarios else []
     collapses: list[tuple[str, float]] = []
@@ -190,31 +218,36 @@ def render_bad_news_first(mc: dict | None, scenarios: dict | None,
     return rows
 
 
-def render_threshold_verdicts(mc: dict | None) -> list[str]:
+def render_threshold_verdicts(mc: dict | None, params: dict | None = None) -> list[str]:
     if not mc or not mc.get("thresholds"):
         return []
     n_runs = mc.get("settings", {}).get("n_runs")
     runs_phrase = f"{n_runs:,} simulated runs" if isinstance(n_runs, int) else "the simulated runs"
+    aggregates = aggregate_output_ids(params)
     rows = [
-        "## Verdict table (all thresholds, worst first)",
+        "## Verdict table (all thresholds, worst first; min() aggregates after individual gates)",
         "",
         f"For each success condition the plan needs to meet, this is how often it actually meets it across {runs_phrase} that vary every uncertain input within its plausible range.",
         "",
         "Bands: at least 80% **ROBUST**, 50–80% **MARGINAL**, 20–50% **FRAGILE**, under 20% **DOOM**.",
         "",
-        "| What we wanted | Condition | How often it holds | Verdict | What that means |",
-        "|---|---|---:|---|---|",
+        "Rows with a leading `min` marker are aggregate gates computed via `min()` over independent pools. Their verdict (pass/fail) is meaningful; their raw magnitude picks the worst gate's number and is not a real monetary surplus. Individual gates are listed first within each severity band, then the aggregates.",
+        "",
+        "| | What we wanted | Condition | How often it holds | Verdict | What that means |",
+        "|---|---|---|---:|---|---|",
     ]
-    entries: list[tuple[int, str, dict, str, str]] = []
+    entries: list[tuple[int, int, str, dict, str, str]] = []
     for output_id, t in mc["thresholds"].items():
         verdict, note = verdict_for(t.get("probability"))
-        entries.append((VERDICT_SEVERITY.get(verdict, 99), output_id, t, verdict, note))
-    entries.sort(key=lambda x: x[0])
-    for _sev, output_id, t, verdict, note in entries:
+        is_agg = 1 if output_id in aggregates else 0
+        entries.append((VERDICT_SEVERITY.get(verdict, 99), is_agg, output_id, t, verdict, note))
+    entries.sort(key=lambda x: (x[0], x[1]))
+    for _sev, is_agg, output_id, t, verdict, note in entries:
         prob = t.get("probability")
         prob_str = f"{prob * 100:.1f}%" if prob is not None else "n/a"
+        marker = "min" if is_agg else ""
         rows.append(
-            f"| `{output_id}` | {t['operator']} {fmt_number(t['value'])} | {prob_str} | "
+            f"| {marker} | `{output_id}` | {t['operator']} {fmt_number(t['value'])} | {prob_str} | "
             f"**{verdict}** | {note} |"
         )
     rows.append("")
@@ -359,7 +392,7 @@ def build_insights(params: dict | None, bounds: dict | None,
     sections: list[list[str]] = [
         render_plan_summary(params),
         render_bad_news_first(mc, scenarios, params, bounds),
-        render_threshold_verdicts(mc),
+        render_threshold_verdicts(mc, params),
         render_distributions(mc),
         render_sensitivity(mc),
         render_scenarios(scenarios),


### PR DESCRIPTION
## Summary

ChatGPT reviewed the v31 cross-border rail ticketing run (the cross-plan generalisation test from PR #706) and flagged one real modelling discipline issue:

> The `combined_program_viability_surplus_eur` may be too aggressive or conceptually overloaded. It mixes liquidity/clearing solvency with revenue loss from enforcement delay. Those may not draw on the same reserve unless the report explicitly says the emergency float reserve also backstops regulatory/revenue shortfalls.

The rail digest explicitly scopes the €300M emergency reserve to the clearing mechanism — those two pressures draw on different pools. Additive netting overstated headroom. Conceptually correct form is `min()` over the individual surplus calculations.

## What changed

Both extractor prompts (`extract-parameters-from-full`, `extract-parameters-from-digest`) gain a **Shared-pool legitimacy check for combined surplus tests** rule:

- When an aggregate test subtracts multiple pressures from one reserve, verify those pressures actually draw from the same pool — same named buffer, same line item, same envelope.
- If yes (single pool absorbs every pressure): additive form is correct.
  - `combined_viability_surplus = pool_reserve - pressure_a - pressure_b - pressure_c`
- If no (separate pools): use `min()` over individual surpluses.
  - `combined_viability_surplus = min(surplus_a, surplus_b, surplus_c)`
- Concrete signs of each pattern listed. Aggregate name should match the form: prefer `weakest_gate_surplus` / `worst_case_pool_surplus` when using `min()`.

## Cross-validated against both reference plans

**Nuuk Clay Workshop**: digest explicitly says the same 15% DKK contingency absorbs labor-law, rental, and kiln-failure shocks. Additive form (`contingency - labor_shock - rental_shortfall`) is correct under the new rule. **No model change needed.**

**Cross-border rail ticketing**: v32 replaces additive `combined_program_viability_surplus_eur` with:
```
weakest_financial_gate_surplus_eur = min(
  clearing_capacity_surplus_eur,
  regulatory_risk_buffer_surplus_eur,
  royalty_cost_coverage_surplus_eur,
)
```

### Numerical effect of the framing change

| Metric | v31 (additive) | v32 (min) |
|---|---:|---:|
| Aggregate pass probability | 47.33% (FRAGILE) | **26.15% (FRAGILE, near DOOM)** |
| Base scenario value | +87.5M EUR | **0 EUR** |
| Low scenario value | +400M EUR | **−500k EUR** |
| High scenario value | −800M EUR | −600M EUR |

The other five individually-scoped gates are unchanged. The additive form was netting deficits in revenue economics against surplus in clearing liquidity — different stakeholders, different pools. The min() form correctly says "all three gates must independently hold".

## Test plan

- [x] Smoke 8/8 (`tests/run_smoke.py`)
- [x] Unittest 45/45 (`tests/test_run_monte_carlo.py`)
- [x] v32 rail regenerated with min() framing; runner emits zero warnings; insights.md reads cleanly with the new headline
- [x] Nuuk's additive form re-validated against the digest text — no change needed
- [ ] Reviewer: confirm the prompt rule's `min()` direction is the right default when the source is ambiguous (current text leans toward min() unless the source explicitly names a shared pool — fail safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)