### PR TITLE
feat(napkin-math): sharper severity wording in Suggested next actions + MARGINAL bucketing

### DIFF
--- a/experiments/napkin_math/summarize_assessment.py
+++ b/experiments/napkin_math/summarize_assessment.py
@@ -728,12 +728,22 @@ def render_decision_implications(mc: dict | None, params: dict | None) -> list[s
                 f"({(1 - prob) * 100:.1f}%). External commitments built on this "
                 f"gate are exposed."
             )
-        else:  # MARGINAL
-            consequence = (
-                f"The `{cond}` requirement passes {prob * 100:.1f}% of runs — "
-                f"close enough to coin-flip that downstream commitments should "
-                f"not assume it holds."
-            )
+        else:  # MARGINAL (50–80% pass rate)
+            # The MARGINAL band spans a large range. A 51% pass is genuinely
+            # coin-flip; a 79% pass is one slip from ROBUST. Bucket the
+            # wording so the language tracks the position within the band.
+            if prob >= 0.70:
+                consequence = (
+                    f"The `{cond}` requirement passes {prob * 100:.1f}% of runs — "
+                    f"just below the ROBUST band. The gate passes in most runs, "
+                    f"but downstream commitments should not treat it as secure."
+                )
+            else:
+                consequence = (
+                    f"The `{cond}` requirement passes {prob * 100:.1f}% of runs — "
+                    f"close to coin-flip. Downstream commitments should not "
+                    f"assume it holds."
+                )
         drivers = quartile.get(r["id"]) or []
         top = max(drivers, key=lambda d: abs(d.get("delta_pp", 0)), default=None)
         if is_saturated_failure(r["probability"], top):
@@ -941,13 +951,37 @@ def render_suggested_next_actions(mc: dict | None, params: dict | None) -> list[
         "",
     ]
     if failing:
+        # Distinguish DOOM (<20%) from FRAGILE (20–50%) and name the worst
+        # gate by id + pass rate. "N gates fail" by itself understates a
+        # 0.0% DOOM the way "1 gate fails" understates total structural
+        # failure.
+        doom_sorted = sorted(
+            (r for r in thresholds if r["verdict"] == "DOOM"),
+            key=lambda r: r["probability"] if r["probability"] is not None else 1.0,
+        )
+        fragile_sorted = sorted(
+            (r for r in thresholds if r["verdict"] == "FRAGILE"),
+            key=lambda r: r["probability"] if r["probability"] is not None else 1.0,
+        )
+        worst = doom_sorted[0] if doom_sorted else fragile_sorted[0]
+        worst_pct = (worst["probability"] or 0) * 100
+        band_parts = []
+        if doom_sorted:
+            band_parts.append(
+                f"{len(doom_sorted)} declared gate{'s' if len(doom_sorted) != 1 else ''} in the DOOM band"
+            )
+        if fragile_sorted:
+            band_parts.append(
+                f"{len(fragile_sorted)} in the FRAGILE band"
+            )
+        band_summary = "; ".join(band_parts)
         rows.append(
-            "1. To answer whether the plan is viable, lead with the gate verdicts above — not the source plan's narrative. "
-            f"{len(failing)} gate(s) currently fail at the 50% pass-rate bar."
+            f"1. To answer whether the plan is viable, lead with the gate verdicts above — not the source plan's narrative. "
+            f"{band_summary}. Worst: `{worst['id']}` at {worst_pct:.1f}% pass rate under current bounds."
         )
     else:
         rows.append(
-            "1. To answer whether the plan is viable, lead with the gate verdicts above. No gate currently fails the 50% pass-rate bar — but read the bounds and trust boundaries before treating that as a green light."
+            "1. To answer whether the plan is viable, lead with the gate verdicts above. No declared gate is in the DOOM or FRAGILE band — but read the bounds and trust boundaries before treating that as a green light."
         )
     rows.append(
         "2. To prioritise data-gathering, inspect `missing_value_priority` in `montecarlo.json`. The top-scored entries are the cheapest improvements to the simulation's predictive value."


### PR DESCRIPTION
## Summary

ChatGPT review of the v44 casino_royale assessment flagged two wording issues — both in `summarize_assessment.py`, both pure rendering, no schema change.

### 1. Suggested next actions item #1 understated DOOM

Old:
> "1 gate(s) currently fail at the 50% pass-rate bar."

That phrasing reads identically whether the worst gate is FRAGILE at 49% or DOOM at 0%. ChatGPT: *"the worst gate has 0.0% pass rate, which is not just 'below 50%'; it is a structural failure under current bounds."*

New (mixed example):
> "2 declared gates in the DOOM band; 3 in the FRAGILE band. Worst: `sponsor_profitability_window_margin_days` at 0.0% pass rate under current bounds."

New (single-DOOM example, matches casino_royale v44):
> "1 declared gate in the DOOM band. Worst: `sponsor_profitability_window_margin_days` at 0.0% pass rate under current bounds."

The summary distinguishes DOOM count from FRAGILE count and names the worst gate by id and pass rate.

### 2. MARGINAL "coin-flip" wording over-fired at 79.8%

Old Decision implications for MARGINAL was a single template:
> "passes 79.8% of runs — close enough to coin-flip that downstream commitments should not assume it holds."

ChatGPT: *"At 79.8%, it barely misses ROBUST. Calling it 'close enough to coin-flip' is too harsh. It is not coin-flip; it is near the ROBUST threshold."*

The MARGINAL band is 50–80%. A 51% pass is genuinely coin-flip; a 79% pass is one slip from ROBUST. Bucketed at 70%:

- **≥ 70%**: *"just below the ROBUST band. The gate passes in most runs, but downstream commitments should not treat it as secure."*
- **< 70%**: keeps the *"close to coin-flip"* framing.

## Test plan

- [x] Smoke 9/9, unit 50/50 green.
- [x] v44 casino_royale regenerated locally: item #1 now reads `1 declared gate in the DOOM band. Worst: sponsor_profitability_window_margin_days at 0.0% pass rate under current bounds.` and the 79.8% AML-adjusted NOI gate's Decision implications row now reads `just below the ROBUST band. The gate passes in most runs, but downstream commitments should not treat it as secure.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)