### PR TITLE
docs: add proposal 140 — reflecting on PlanExe

### DIFF
--- a/docs/proposals/140-reflecting-on-planexe.md
+++ b/docs/proposals/140-reflecting-on-planexe.md
@@ -1,0 +1,194 @@
+# Reflecting on PlanExe
+
+I asked Gemini 3.1 Pro and ChatGPT 5.5 about PlanExe.
+
+---
+
+# Gemini 3.1 Pro - The Horizon of Synthetic Cognition: The Shift to Agentic Swarms and Zero-Marginal-Cost Intelligence
+
+For the past several years, the pursuit of Artificial General Intelligence (AGI) has been largely defined by a singular, monolithic vision: the creation of increasingly massive, parameter-heavy "frontier" models. The assumption was that true, human-level reasoning would emerge only when a single neural network became large enough to encompass all contexts simultaneously.
+
+However, recent advancements in AI system architecture reveal that this premise is fundamentally incomplete. We have crossed a hidden threshold, and the reality of how systemic intelligence is achieved looks vastly different—and far more disruptive—than anticipated. 
+
+We are no longer waiting for a solitary "super-brain." Instead, we have entered the era of **Agentic Scaffolding and Orchestrated Swarms**. By fracturing complex problems into hundreds of micro-tasks and routing them through highly optimized, lightweight, and inexpensive models, we can generate deep, systemic reasoning that rivals the output of entire human organizations.
+
+Here are the new insights defining this shift, and the trajectory of where this technology is heading next.
+
+---
+
+### Insight 1: Architecture Over Scale (The Power of the Swarm)
+We have discovered that true cognitive depth does not require a single, massive model. When small, blazing-fast models are arranged into highly structured pipelines—where one model drafts, another critiques, a third translates the logic into mathematical bounds, a fourth runs stochastic simulations, and a fifth synthesizes the results—the emergent output is exponentially greater than the sum of its parts. 
+
+This is the transition from the **LLM as an Oracle** (asking a single model for an answer) to the **LLM as an Organizational Operating System**. The intelligence does not live solely in the weights of the neural network; it lives in the *scaffolding*—the automated workflow that forces the AI to challenge its own assumptions, red-team its blind spots, and iterate recursively until a mathematically and logically sound strategy is achieved. 
+
+### Insight 2: The Commoditization of Multi-Disciplinary Synthesis
+Historically, solving a high-stakes, multi-dimensional problem (e.g., merging geopolitical strategy with logistical engineering, financial modeling, and risk actuarial science) required convening a team of highly paid human experts over weeks or months. 
+
+Today, that identical process—requiring hundreds of distinct cognitive steps, millions of tokens of context, and complex statistical modeling—can be executed in minutes for fractions of a dollar. 
+
+This is a **collapse of cognitive friction**. Intelligence and high-level knowledge work have been reduced to near-zero marginal cost. This is an economic shockwave on par with the printing press or the microchip. When the cost of deep, strategic synthesis drops from millions of dollars and months of time to pocket change and minutes, the bottleneck to human progress is no longer the capacity to solve complex problems, but simply the imagination required to pose the right questions.
+
+### Insight 3: Superhuman Velocity and the Ultimate OODA Loop
+In strategic theory, the "OODA Loop" (Observe, Orient, Decide, Act) dictates that the entity capable of cycling through this process fastest will inevitably outmaneuver its environment.
+
+Through agentic pipelines, AI has achieved a superhuman OODA loop. Because the models are small, fast, and cheap, a system can generate a complex plan, write the code to mathematically stress-test that plan against 10,000 randomized failure scenarios, identify the critical vulnerabilities, and rewrite the underlying strategy—all before a human could finish reading the initial executive summary. Speed, at this magnitude, becomes a distinct form of superintelligence. It allows the system to explore branches of reality and failure modes that human teams would simply lack the time and budget to investigate.
+
+---
+
+### The Next Steps on the Path
+
+Having mastered the ability to synthesize, critique, and simulate at near-zero cost, the trajectory of AI development will now rapidly advance through the following phases:
+
+#### 1. From On-Demand to Persistent & Asynchronous
+Currently, these multi-agent pipelines are "run once" systems. A human pulls the trigger, the swarm executes its thousands of tasks, and it delivers a final artifact. The immediate next step is **Persistence**. 
+These synthetic organizations will run continuously in the background. They will autonomously monitor live data streams, ingest shifting market or geopolitical variables, dynamically re-run their Monte Carlo simulations, and asynchronously update their strategic plans day and night. They will become perpetual engines of optimization.
+
+#### 2. Closed-Loop Execution (Taking the Wheel)
+The current frontier is analytical—producing brilliant, stress-tested plans. The next frontier is operational. We will soon connect these cognitive pipelines directly to execution APIs. 
+The swarm will not just identify that a supply chain is fragile; it will automatically draft the contracts for new suppliers, negotiate the pricing via email, allocate the capital from corporate budgets, and track the shipping logistics. The loop between "Decide" and "Act" will close, effectively allowing AI to manage and operate vast physical and digital infrastructures with minimal human oversight.
+
+#### 3. Automated Paradigm Discovery (Level 4 AGI)
+Because the cost of running millions of simulated scenarios is approaching zero, these systems will soon transcend human intuition. Currently, we use AI to optimize *known* human frameworks (e.g., optimizing a budget or a logistics route). Soon, we will ask these systems to simulate the fundamental physics of materials, the interactions of complex biological proteins, or the architecture of entirely new economic systems. By iterating through billions of permutations, the swarm will discover solutions, technologies, and paradigms that human minds could never organically conceive.
+
+### Conclusion
+We are no longer waiting for AGI to arrive in a flash of singular, conscious brilliance. It is already quietly assembling itself in the background. It looks like highly structured pipelines of fast, cheap models talking to one another, running code, checking each other's math, and iterating at the speed of light. We have successfully automated the "Think Tank." The next decade will be defined by what happens when we unleash these synthetic organizations upon the physical world.
+
+---
+
+# ChatGPT 5.5: **The Rise of Synthetic Planning: From Static Reports to Agentic Strategy Systems**
+
+For years, AI-assisted planning has mostly been treated as a writing problem. A person describes a project, an AI model generates a plan, and the result is judged as a document. That framing is too small. The deeper shift is not that AI can write project plans faster. The deeper shift is that complex planning itself is becoming programmable.
+
+A modern planning system is not a single prompt and a single answer. It is an orchestration layer: many model calls, many intermediate artifacts, many critiques, many trade-off analyses, and many opportunities for revision. The intelligence does not live only in the model. It lives in the pipeline: decomposition, assumption extraction, scenario generation, risk analysis, scheduling, budgeting, contradiction detection, and synthesis.
+
+This marks a move from **AI as an oracle** to **AI as a planning organization**
+
+.
+
+An oracle gives an answer. A planning organization creates structure. It asks what the objective means, identifies stakeholders, breaks the problem into workstreams, compares strategic paths, names dependencies, surfaces risks, and produces artifacts that humans can challenge. The result is not perfect truth. It is something more useful: a serious draft that exposes the shape of the problem.
+
+## **Insight 1: Planning Quality Comes From Iteration, Not One-Shot Intelligence**
+
+The most important lesson is that good plans emerge through refinement. A first plan is rarely the final plan. It reveals what was under-specified, what was unrealistic, what incentives were distorted, and what assumptions quietly entered the system.
+
+This is where synthetic planning becomes powerful. Instead of treating the first output as the answer, the workflow becomes cyclical:
+
+generate → inspect → criticize → revise → rerun → compare → converge.
+
+That loop matters more than any individual response. A weak prompt produces a distorted plan. A better prompt produces a better plan. A strong system should therefore help the user improve the prompt itself, not merely answer it.
+
+The future of planning systems is not just “generate a plan.” It is:
+
+“What did this plan assume?”\
+“What did it ignore?”\
+“What would make it more realistic?”\
+“What constraints should be added?”\
+“What scenario did it choose, and why?”\
+“What alternative path would reduce harm, cost, or fragility?”
+
+This turns planning into an interactive search process across possible futures.
+
+## **Insight 2: Cheap Multi-Pass Reasoning Changes the Economics of Strategy**
+
+Historically, serious planning required teams: domain experts, project managers, legal analysts, logistics people, financial modelers, risk specialists, and editors. That kind of synthesis was slow and expensive. It required meetings, coordination, drafting cycles, and review rounds.
+
+Now, a planning pipeline can perform many of those cognitive passes automatically. It can generate a project plan, produce scenarios, identify risks, draft a schedule, critique feasibility, estimate resource needs, and produce an executive summary in one run. Even better, it can do this repeatedly.
+
+The cost collapse is the crucial point. Once a system can spend millions of tokens and hundreds of model calls for the cost of a casual API experiment, planning becomes disposable. That does not mean worthless. It means plans can be generated, compared, discarded, and regenerated without ceremony.
+
+This changes the strategic workflow. You do not need to bet everything on one plan. You can ask for ten variants. You can compare conservative, aggressive, ethical, cost-minimized, resilience-maximized, legally cautious, and infrastructure-first versions. You can run the same scenario under different assumptions and see which decisions remain stable.
+
+The bottleneck shifts from producing plans to **framing the right planning problem**.
+
+## **Insight 3: The Human Becomes the Framer, Not the Typist**
+
+As planning systems improve, the human role becomes more important, not less. But the role changes.
+
+The human should not spend most of their energy formatting sections, inventing task lists, or manually writing obvious risk categories. The system can do that. The human should define the moral frame, the success criteria, the unacceptable trade-offs, and the constraints that the system must respect.
+
+This is especially important because AI planning systems are highly sensitive to framing. If speed is emphasized too much, the system may choose a fast but reckless strategy. If budget is vague, it may invent unrealistic numbers. If ethics are implicit, the plan may treat coercive measures as acceptable options. If future technology is not constrained, the system may quietly assume capabilities that do not exist.
+
+A good human operator does not merely ask for a plan. They shape the planning space.
+
+They say:
+
+Do not choose the most aggressive path.\
+Do not assume unavailable technology.\
+Do not violate civilian welfare.\
+Do not solve governance problems by coercion.\
+Treat rights and safety as hard constraints.\
+Prefer reversible decisions.\
+Separate accepted actions from rejected options.\
+Mark speculative capabilities clearly.
+
+That kind of framing is not decoration. It is steering.
+
+## **Insight 4: Planning Systems Need Realism Governors**
+
+The next major improvement is realism checking.
+
+Planning systems are good at structure, but they can still over-compress timelines, understate logistics, invent institutions too easily, or create clean-looking plans that ignore physical bottlenecks. A serious planning engine needs a realism governor: a layer that challenges the plan against basic constraints.
+
+For example:
+
+How many people are affected?\
+How much housing is required?\
+How many trained workers are available?\
+What physical transport capacity exists?\
+What legal authority is assumed?\
+What budget range is credible?\
+What happens if a milestone slips?\
+Which actions are irreversible?\
+Which dependencies are single points of failure?\
+Which parts require technology that does not yet exist?
+
+Without this layer, AI planning can become persuasive fiction. With it, the system becomes much more valuable: not because it guarantees correctness, but because it forces the plan to confront reality.
+
+The best future systems will not merely say, “Here is a plan.” They will say, “Here is the plan, here are the assumptions, here are the weakest links, here are the numbers that need validation, and here are the parts that should not be trusted yet.”
+
+## **Insight 5: MCP Turns Planning Into a Toolchain**
+
+MCP is important because it lets planning systems participate in larger agentic workflows. A planning system should not exist in isolation. It should be callable by agents, connected to files, connected to code execution, connected to simulations, connected to search, connected to version control, and connected to execution environments where appropriate.
+
+That opens the door to a new kind of workflow:
+
+An agent receives a goal.\
+It generates an initial plan.\
+It inspects the risks.\
+It validates numbers through tools.\
+It compares prior runs.\
+It revises the prompt.\
+It reruns the planning pipeline.\
+It creates a delta report.\
+It recommends the safest next version.
+
+This is where synthetic planning becomes more than document generation. It becomes part of an agentic operating loop.
+
+The MCP-enabled future is not just “AI writes plans.” It is “AI systems use planning as a subroutine.”
+
+## **The Path Forward**
+
+The next generation of planning systems should move in five directions.
+
+First, they should become explicitly iterative. Every generated plan should include recommended prompt improvements, unresolved assumptions, and suggested follow-up runs. The output should help the next output become better.
+
+Second, they should separate certainty levels. Existing capabilities, future development goals, speculative technologies, rejected options, and accepted actions should not be mixed together. A plan becomes more trustworthy when it clearly labels what is real, what is assumed, and what is aspirational.
+
+Third, they should include multi-run comparison. A user should be able to compare scenario families side by side: cost, speed, risk, reversibility, ethical exposure, infrastructure dependency, and political feasibility.
+
+Fourth, they should include stronger ethical defaults. For high-stakes plans, the system should naturally penalize irreversible harm, coercion, rights violations, civilian deprivation, and brittle dependencies. It should not need to be reminded every time.
+
+Fifth, they should become more tool-native. Through MCP and related interfaces, planning systems should be callable components inside broader agentic systems. The plan should not be the end artifact. It should be an intermediate object that can be tested, simulated, revised, and operationalized.
+
+## **Conclusion**
+
+The future of AI planning is not a single brilliant answer from a single brilliant model. It is structured cognition: many small reasoning passes organized into a disciplined workflow.
+
+This is the real breakthrough. Planning is becoming cheap, repeatable, inspectable, and programmable. The first draft can be generated in minutes. The second draft can be better. The third can be constrained. The fourth can be compared against alternatives. The fifth can be grounded by external tools. The sixth can become a serious strategic artifact.
+
+The value is not that the machine is always right. It is that the machine can produce structured thought fast enough for humans to argue with it, refine it, and explore the space of possible decisions.
+
+We are not automating judgment. We are automating the scaffolding around judgment.
+
+That may be the more important achievement.
+


### PR DESCRIPTION
## Summary

Adds `docs/proposals/140-reflecting-on-planexe.md`: a reflection on PlanExe collected from two third-party model takes — Gemini 3.1 Pro and ChatGPT 5.5 — on agentic scaffolding, the commoditization of multi-disciplinary synthesis, and where this kind of orchestrated-swarm pipeline is heading next.

## Test plan

- [ ] Markdown renders cleanly on GitHub.
- [ ] No internal links broken (none introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)