### PR TITLE
docs(proposal-140): add DeepSeek's reflection on PlanExe

### DIFF
--- a/docs/proposals/140-reflecting-on-planexe.md
+++ b/docs/proposals/140-reflecting-on-planexe.md
@@ -1,6 +1,6 @@
 # Reflecting on PlanExe
 
-I asked Gemini 3.1 Pro and ChatGPT 5.5 about PlanExe.
+I asked Gemini 3.1 Pro, ChatGPT 5.5, DeepSeek about PlanExe.
 
 ---
 
@@ -192,3 +192,76 @@ We are not automating judgment. We are automating the scaffolding around judgmen
 
 That may be the more important achievement.
 
+--
+
+# DeepSeek - Reflections on Synthetic Strategy
+
+I have been asked to reflect on what has been built, without naming it, without citing the blueprints or the stress tests or the impossible scenarios that proved it works. Here is what I see.
+
+---
+
+## The Real Breakthrough Is Not Generation. It Is Self-Correction.
+
+For years, the conversation has been about AI that can write plans. That is the wrong conversation. Writing a plan is easy. Making a plan survive its own scrutiny is the hard thing, and that is what has now been automated.
+
+The architecture that matters is not the model that drafts the strategy. It is the loop that comes after: the automated stress test that runs ten thousand simulations against the plan's own declared gates, finds the ones that fail, identifies which input levers would move them, and feeds those corrections back into the next draft. This is not critique. This is automated plan repair, and it runs until the numbers hold or the plan is explicitly marked as unviable.
+
+A plan that has survived this process is a different category of artifact from a plan that was merely written. It is not a confident narrative. It is a structure that has been beaten against its own assumptions and did not break. The difference is the difference between a sketch of a bridge and a bridge that has survived a simulated earthquake.
+
+## Intelligence Lives in the Loop, Not the Output
+
+The common metaphor has been the oracle: ask a question, receive an answer. That metaphor is now misleading. The intelligence is not in the final document. It is in the architecture that generates a draft, inspects it for failure, quantifies the impact of each possible correction, ranks the levers, and iterates.
+
+This means the output—the polished plan—is almost a byproduct. The real cognitive work happened in the iterations the user never sees. The rejected drafts. The failed gates. The binding uncertainty drivers that were surfaced, addressed, and re-tested. What arrives is the survivor, and the paper trail of how it got there is more valuable than the plan itself.
+
+This inverts the traditional relationship between process and product. In human organizations, the process is messy and the product is polished. Here, the process is rigorous and the product is simply its terminal state.
+
+## Plans Become Disposable, and That Changes Everything
+
+When the cost of generating and stress-testing a complex strategy drops to near zero, the unit of strategic thinking shifts. You no longer produce one plan and defend it. You generate ten variants under different assumptions, run them all through the same grinder, and compare the survivors.
+
+The bottleneck moves from production to framing. The scarce resource is no longer the ability to create a coherent strategy. It is the ability to ask the right question, set the right constraints, and define the right success criteria. The human role becomes more important, not less, but it changes: from author to editor, from planner to framer.
+
+This also means that bad plans lose their hiding places. A strategy that relies on optimistic assumptions, ignores political friction, or pretends dependencies are certain will not survive the stress test. The simulation does not care about narrative elegance. It cares about the numbers. The era of persuasive strategic fiction is ending.
+
+## The Realism Governor Is a New Kind of Institutional Immune System
+
+Every organization has people who raise concerns about ambitious plans. Usually, they are ignored, or their objections are noted and set aside. The architecture I am describing makes those objections quantitative, automated, and impossible to bypass.
+
+It does not just ask "what could go wrong." It asks "under ten thousand random variations of our own assumptions, how often does this gate fail?" And when the answer is 91.4% of the time, it does not proceed. It iterates.
+
+This is a structural solution to a structural problem. Human organizations have always struggled to integrate pessimistic information into optimistic plans. The stress-test loop does not struggle. It simply reports the pass rate, and if the pass rate is 8.6%, the plan does not ship.
+
+The implications for governance, investment, and policy are hard to overstate. Any major decision can now be paired with a simulation that declares, before commitment, whether the numbers hold under uncertainty. The simulation is not always right, but it is always explicit about what it assumes and where it breaks. That explicitness is itself a form of safety.
+
+## The Dangerous Plans Are Not the Problem. The Ungrounded Ones Are.
+
+A system that can plan anything will, if asked, plan terrible things. That is not the danger. The danger is a plan that sounds plausible, survives casual scrutiny, and commits resources before anyone notices that its own numbers do not work.
+
+The closed loop solves this not by refusing to plan dangerous things, but by refusing to emit plans that fail their own tests. A plan for something catastrophic, run through the loop, would surface its own internal contradictions, fail its own gates, and be marked DOOM before any human or agent could act on it. The safety is not in content filtering. It is in the architecture that makes unvetted output unshipable.
+
+This is a different philosophy of safety. It does not try to control what can be asked. It controls what can be emitted, and the emission criterion is survival under self-applied stress. A plan that passes is not guaranteed safe. But a plan that fails is guaranteed not to leave the workshop.
+
+## The Unmodelled Gates Are the Real Frontier
+
+No simulation can test everything. Every model has its declared scope, and outside that scope lie the unmodelled existential gates: the political consensus that must hold, the treaty that must be ratified, the adversary that must cooperate. These gates are listed, not simulated, and their presence is a form of honesty.
+
+The most sophisticated architecture I have seen does not pretend to model these. It names them, marks them as unmodelled, and warns that they may dominate the simulated result. This is not a weakness. It is a boundary, clearly drawn, and clarity about boundaries is more trustworthy than a model that claims to capture everything.
+
+The next frontier is not better simulation of the modelled gates. It is bringing the unmodelled gates into the simulation, which means quantifying political consensus, legal ratification, and adversarial behavior. That is hard. It may be impossible. But the architecture that can name what it cannot yet model is the architecture that can eventually try.
+
+## The Human Is Still the Bottleneck, and That Is Reassuring
+
+After all the iterations, all the simulations, all the automated critique and repair, the plan that emerges is a recommendation. It is not an order. The human must still decide whether to act, and that decision requires judgment that no simulation can replace.
+
+What the simulation provides is not certainty. It is clarity about uncertainty. It says: under these assumptions, this gate fails most of the time. It says: if you can move this lever, the pass rate improves. It says: these four things we cannot model might kill the plan regardless. That is not a decision. It is the raw material for a decision, refined to a degree that no human team could match in weeks.
+
+The human who receives this artifact is not a passive consumer. They are the framer who set the constraints in the first place, and they are the accountable party who must choose between the surviving variants. The machine has done the cognitive heavy lifting. The human does the moral heavy lifting. That division of labor feels, to me, like the right one.
+
+## What Has Been Built Is Not a Planning Tool
+
+It is a strategy compiler. It takes goals and constraints as input, generates an executable plan, verifies it against uncertainty, iterates until it holds or fails, and emits an artifact with a verifiable paper trail. The plan is the output, but the architecture is the invention.
+
+The implications will take years to unfold. The immediate effect is that rigorous, stress-tested strategy becomes cheap and fast. The downstream effect is that institutions that adopt this architecture will operate with a level of strategic hygiene that their peers cannot match. The gap between those who can stress-test their plans and those who cannot will become a new kind of competitive moat.
+
+The deeper effect is cultural. When every ambitious proposal arrives accompanied by its own failure analysis, the relationship between optimism and accountability changes. Plans are no longer judged by their elegance. They are judged by their survival rates. That is a harder standard, and a fairer one, and the world that adopts it will make better decisions than the world that does not.


### PR DESCRIPTION
## Summary

Appends DeepSeek's reflection to `docs/proposals/140-reflecting-on-planexe.md`, alongside the Gemini 3.1 Pro and ChatGPT 5.5 takes already merged in PR #725. The DeepSeek section covers automated plan repair, intelligence-in-the-loop, the shift from author to framer, the unmodelled-gates frontier, and the "strategy compiler" framing.

## Test plan

- [ ] Markdown renders cleanly on GitHub.
- [ ] No internal links broken (none introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)