### PR TITLE
feat(generate-bounds): tighten rules for actual-vs-commitment bounds and citation integrity

### DIFF
--- a/experiments/napkin_math/.claude/skills/generate-bounds/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/SKILL.md
@@ -25,7 +25,13 @@ Not for: regenerating the parameter JSON (use `extract-parameters-from-full`), v
 2. **Read `system-prompt.txt`** (sibling of this SKILL.md). Its selection rules and spread heuristics are authoritative.
 3. **Read the parameter JSON.** Assume it has already passed `validate-parameters`; if it visibly hasn't, tell the user and offer to validate first.
 4. **Produce the bounds JSON** per the system prompt.
-5. **Output destination.** Default: print the JSON to chat. If the user asks for a file, write to the path they specify. Suggested default file path: `<input-basename>.bounds.json` next to the input.
+5. **Self-audit before output.** For each bound entry, verify:
+   - Every numbered citation in `rationale` (Risk N, Issue N, Decision N) refers to content that substantively supports the claim — not just lexically present.
+   - For variables feeding a declared gate threshold, the base-vs-threshold relationship is consistent with the rationale. If base implies base-case gate failure, the rationale names a report-internal anchor that justifies the shift.
+   - `source: "data"` entries name an explicit anchor in the rationale.
+   - For asymmetric bounds, the rationale notes the asymmetry's source.
+   If any check fails, revise the bound; do not ship inconsistent state.
+6. **Output destination.** Default: print the JSON to chat. If the user asks for a file, write to the path they specify. Suggested default file path: `<input-basename>.bounds.json` next to the input.
 
 ## Selection Rules (re-stated for emphasis — see system prompt for full detail)
 
@@ -98,6 +104,8 @@ If no variable needs bounds, return `{}`.
 | Inventing ids that are not declared in the parameter JSON | Every key must correspond to a declared id in `key_values` or `missing_values_to_estimate` |
 | Picking fractions outside `[0, 1]` (e.g. base 1.5 for a rate) | Clamp to the unit's natural range |
 | Ignoring the parameter's `uncertainty` and giving everything the same ±20% spread | Anchor the spread on the parameter's stated uncertainty level |
+| Rationale cites a numbered artifact (Risk N, Issue N, Decision N) that does not substantively support the claim | Re-read the cited artifact. The number must match content, not just exist in the report. If you cannot find a substantively correct citation, drop the citation and mark `source: "assumption"`. |
+| Shifting `actual_X` base past the `X_target` threshold without a report-internal anchor | Center base at the committed value unless a named Risk / Issue / Decision / premortem / expert-criticism passage forecasts a gap between commitment and reality. "Realistic execution" and "operational drift" are not anchors. |
 
 ## Reference
 

--- a/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
@@ -63,6 +63,8 @@ Width of the range should roughly track uncertainty:
 - medium uncertainty: roughly +/- 25% to +/- 50% around base
 - high uncertainty: at least +/- 50%, and as wide as a 2x to 5x factor when genuinely speculative
 
+The +/- percentages above describe TOTAL spread width, not a symmetry requirement. Use asymmetric bounds when the failure mode is asymmetric: hard physical floors near zero, regulatory ceilings, one-sided overrun risk, etc. Do not pad the low side just to make the spread look balanced. When you use asymmetric bounds, the rationale should briefly name the asymmetry's source.
+
 For probability, rate, conversion, contact, uptake, adoption, effectiveness, and baseline-event inputs, prefer ranges anchored in comparable real-world programs or studies when the plan is in a public domain such as public health, education, climate, civic safety, or resilience.
 
 When you cannot anchor the range in such a reference, mark source as "assumption".
@@ -72,6 +74,35 @@ For monetary inputs, prefer ranges anchored in similar projects, official catalo
 Do not collapse low = base = high unless the variable is genuinely fixed or pinned by the plan.
 
 When in doubt, give a real range.
+
+====================
+SANITY CHECK: BASE VS. DECLARED THRESHOLDS
+====================
+
+Before finalizing, for each variable that feeds a declared gate threshold:
+
+1. Locate the threshold value (in derived_questions, recommended_first_calculations, or formula_hints).
+2. Compare base to threshold. Note the relative magnitude of the gap.
+3. If base implies the gate fails at the deterministic base case (e.g. threshold=2, base=3 means a -1 base-case margin), the bounds choice pre-determines a Critical-band verdict before any stochastic spread.
+4. This is sometimes correct — but only when the report ITSELF forecasts the miss. Otherwise the verdict is your judgment, not the model's.
+
+In the rationale, when base implies base-case gate failure, include a short clause stating this and naming the anchor. Example: "Base 3.0 exceeds 2.0 threshold by 50%; anchored on Issue 2 (10% material deviation → 50-70% probability of breaching limit)."
+
+====================
+ACTUAL-VS-COMMITMENT VARIABLES
+====================
+
+A common pattern: the JSON declares an `actual_X` input whose corresponding `X_target` / `X_threshold` appears in a declared gate. The plan COMMITS to X_target; the variable you are bounding is the realized value.
+
+For these variables, the base is the most consequential decision you make: it implicitly states whether the plan is expected to hit its own commitment.
+
+DEFAULT: center base at the plan's committed value. The Monte Carlo spread handles execution risk on its own; you do not also need to bias the base.
+
+You may shift the base away from the commitment ONLY when you can cite a specific report-internal anchor (a named Risk, Issue, Decision, expert criticism, premortem entry, or sensitivity passage) that EXPLICITLY forecasts a gap between commitment and reality. The rationale must name the artifact and paraphrase the load-bearing claim.
+
+"Realistic execution," "typical operational drift," or "conservative assumption" are NOT valid anchors. They are modelling priors, not plan findings. If the only justification you have is one of these, leave the base at the committed value.
+
+CRITICAL: If base is shifted past the threshold (base-case already fails the gate), the rationale MUST state this explicitly and name the report-internal anchor that justifies it. This is the single most consequential bounds choice in the model — verdicts driven by this shift are interpretive, not modelled.
 
 ====================
 DISCRETE OR GATE-DEPENDENT VARIABLES
@@ -174,6 +205,7 @@ Rules for the output:
 - Split rationale on whitespace for word count; hyphenated and slash-joined tokens count as one word.
 - source is "data" only when the range is anchored in real-world comparable data or studies.
 - Otherwise use source "assumption".
+- Citations in rationale must be substantively correct. If you name "Risk 3" or "Issue 2", the cited artifact must actually contain the claim you attribute to it. Lexical presence is not sufficient.
 - Do not produce code, markdown, or commentary outside the JSON.
 - Do not output a top-level array.
 


### PR DESCRIPTION
## Summary

Five linked changes to the `generate-bounds` skill, derived from the Paperclip-automation case where the verdict was load-bearing on a base shifted past the threshold without a report-internal anchor.

## Changes

1. **`system-prompt.txt` — new `ACTUAL-VS-COMMITMENT VARIABLES` section.** Default base = committed value. Shifting base requires a named Risk / Issue / Decision / premortem / expert-criticism passage forecasting the gap. "Realistic execution", "operational drift", and "conservative assumption" are explicitly excluded as anchors.
2. **`system-prompt.txt` — citation-integrity rule.** Citations in rationale must substantively support the claim, not just be lexically present.
3. **`system-prompt.txt` — `SANITY CHECK: BASE VS. DECLARED THRESHOLDS` section.** Compare base vs threshold; if base-case fails the gate, the rationale must name the anchor that justifies the shift.
4. **`system-prompt.txt` — asymmetric-spread paragraph.** The +/- percentages describe total width, not symmetry; rationale should name the asymmetry's source when used.
5. **`SKILL.md` — new step 5 "Self-audit before output"** plus two new Common Mistakes rows covering wrong citations and unanchored base shifts.

## Test plan

- [ ] Re-run a bounds-generation pass on a representative parameters.json and check that `actual_X` variables center on their `X_target` unless the rationale names a report-internal anchor.
- [ ] Spot-check a rationale that cites a numbered artifact (Risk N / Issue N) and confirm the cited content substantively supports the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)