### PR TITLE
feat(generate-bounds): skip threshold variables and refine actual-vs-commitment rules

### DIFF
--- a/experiments/napkin_math/.claude/skills/generate-bounds/SKILL.md
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/SKILL.md
@@ -64,7 +64,7 @@ Always `low ≤ base ≤ high`. Fractions stay in `[0, 1]`. Counts of discrete t
     "low": 0.10,
     "base": 0.20,
     "high": 0.30,
-    "rationale": "Short, ≤30 words, one or two sentences.",
+    "rationale": "Short, ≤50 words. Include required disclosures when applicable.",
     "source": "data" | "assumption",
     "sampling_discipline": "fraction",
     "non_negative": true,
@@ -106,6 +106,7 @@ If no variable needs bounds, return `{}`.
 | Ignoring the parameter's `uncertainty` and giving everything the same ±20% spread | Anchor the spread on the parameter's stated uncertainty level |
 | Rationale cites a numbered artifact (Risk N, Issue N, Decision N) that does not substantively support the claim | Re-read the cited artifact. The number must match content, not just exist in the report. If you cannot find a substantively correct citation, drop the citation and mark `source: "assumption"`. |
 | Shifting `actual_X` base past the `X_target` threshold without a report-internal anchor | Center base at the committed value unless a named Risk / Issue / Decision / premortem / expert-criticism passage forecasts a gap between commitment and reality. "Realistic execution" and "operational drift" are not anchors. |
+| Generating bounds for a threshold or target variable (ids ending in `_threshold`, `_target`, `_ceiling`, `_floor`, `_limit`) | Thresholds enter the simulation as their stated single value. Randomising them silently changes what `pass_rate` measures and breaks the `threshold_basis = report_explicit` contract. Skip these variables. |
 
 ## Reference
 

--- a/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
@@ -39,6 +39,7 @@ Do NOT generate bounds for:
 - entries in recommended_first_calculations
 - ids that appear only as formula LHS outputs and are not declared as a key_value or missing_value
 - derived outputs such as people_contacted, people_protected, cost_per_protected_person, avoided_harm, gate_pass_probability, or kit_coverage_ratio when they can be calculated from other declared inputs
+- key_values whose role is a threshold or target for a declared gate. Identify them by id suffix (_threshold, _target, _ceiling, _floor, _limit, _cap, _max, _min) or by their appearance on the threshold side of a margin formula in recommended_first_calculations or derived_questions. Thresholds enter the simulation as their stated single value. If downstream consumers want to vary stringency, that is a separate sensitivity study, not a Monte Carlo input. Randomising a threshold silently changes what `pass_rate` measures and breaks the `threshold_basis = report_explicit` contract.
 
 If a missing_values_to_estimate entry is actually a derived output, skip it and let generate_calculations compute it.
 
@@ -76,19 +77,6 @@ Do not collapse low = base = high unless the variable is genuinely fixed or pinn
 When in doubt, give a real range.
 
 ====================
-SANITY CHECK: BASE VS. DECLARED THRESHOLDS
-====================
-
-Before finalizing, for each variable that feeds a declared gate threshold:
-
-1. Locate the threshold value (in derived_questions, recommended_first_calculations, or formula_hints).
-2. Compare base to threshold. Note the relative magnitude of the gap.
-3. If base implies the gate fails at the deterministic base case (e.g. threshold=2, base=3 means a -1 base-case margin), the bounds choice pre-determines a Critical-band verdict before any stochastic spread.
-4. This is sometimes correct — but only when the report ITSELF forecasts the miss. Otherwise the verdict is your judgment, not the model's.
-
-In the rationale, when base implies base-case gate failure, include a short clause stating this and naming the anchor. Example: "Base 3.0 exceeds 2.0 threshold by 50%; anchored on Issue 2 (10% material deviation → 50-70% probability of breaching limit)."
-
-====================
 ACTUAL-VS-COMMITMENT VARIABLES
 ====================
 
@@ -102,7 +90,18 @@ You may shift the base away from the commitment ONLY when you can cite a specifi
 
 "Realistic execution," "typical operational drift," or "conservative assumption" are NOT valid anchors. They are modelling priors, not plan findings. If the only justification you have is one of these, leave the base at the committed value.
 
-CRITICAL: If base is shifted past the threshold (base-case already fails the gate), the rationale MUST state this explicitly and name the report-internal anchor that justifies it. This is the single most consequential bounds choice in the model — verdicts driven by this shift are interpretive, not modelled.
+====================
+SANITY CHECK: BASE VS. DECLARED THRESHOLDS
+====================
+
+Before finalizing, for each variable that feeds a declared gate threshold:
+
+1. Locate the threshold value (in derived_questions, recommended_first_calculations, or formula_hints).
+2. Determine the gate direction (does the margin formula compute `actual - threshold` or `threshold - actual`?).
+3. Evaluate the margin at base inputs. If the margin is negative — i.e. the gate already fails at the deterministic base case before any stochastic spread is applied — the bounds choice has pre-determined a Critical-band verdict.
+4. This is sometimes correct, but only when the report ITSELF forecasts the miss. Otherwise the verdict is your judgment, not the model's.
+
+When base implies base-case gate failure, the rationale MUST state this explicitly and name the report-internal anchor that justifies the shift. Example: "Base 3.0 exceeds the 2.0 threshold by 50% (negative margin at base); anchored on Issue 2 — 10% material deviation reduces probability of meeting the 2-hour goal by 50-70%."
 
 ====================
 DISCRETE OR GATE-DEPENDENT VARIABLES
@@ -201,7 +200,7 @@ Rules for the output:
 - Do not invent ids.
 - Every top-level key must correspond to a declared id in key_values or missing_values_to_estimate.
 - Order keys by importance: critical-priority first, then high, then medium, then remaining missing_values_to_estimate not already placed.
-- rationale must be at most 30 words.
+- rationale must be at most 50 words. The cap exists to discourage prose, not to suppress required disclosures: the named-anchor paraphrase required by ACTUAL-VS-COMMITMENT and the base-vs-threshold clause required by SANITY CHECK are exempt from the cap if they push the rationale past 50 words.
 - Split rationale on whitespace for word count; hyphenated and slash-joined tokens count as one word.
 - source is "data" only when the range is anchored in real-world comparable data or studies.
 - Otherwise use source "assumption".
@@ -219,10 +218,14 @@ If the parameter JSON contains:
   - vulnerable_population_share, unit "fraction"
   - baseline_heat_mortality_rate, unit "deaths_per_1000_vulnerable_per_season"
   - protection_conversion_rate, unit "fraction"
+  - actual_outreach_contact_rate, unit "fraction" (realized canvasser contact share; corresponding target is outreach_contact_rate_target)
+  - actual_cooling_center_utilization, unit "fraction" (realized centre utilization; corresponding target is cooling_center_utilization_target)
+  - actual_canvasser_dropout_rate, unit "fraction" (realized week-4 dropout share; corresponding threshold is canvasser_dropout_threshold)
 
 - key_values including:
-  - outreach_contact_rate_target = 0.6, unit "fraction", uncertainty "medium", priority "critical"
-  - cooling_center_utilization_target = 0.8, unit "fraction", uncertainty "medium", priority "high"
+  - outreach_contact_rate_target = 0.6, unit "fraction", uncertainty "low", priority "critical" (explicit plan KPI — used as gate threshold, not bounded)
+  - cooling_center_utilization_target = 0.8, unit "fraction", uncertainty "low", priority "high" (explicit plan KPI — used as gate threshold, not bounded)
+  - canvasser_dropout_threshold = 0.20, unit "fraction", uncertainty "low", priority "high" (program-design threshold — not bounded)
   - month4_gate_release = 1500000, unit "EUR", category "funding_gate", uncertainty "low", priority "critical"
   - leipzig_total_population = 616000, unit "people", uncertainty "low", priority "high"
 
@@ -240,24 +243,24 @@ A valid output:
     "non_negative": true,
     "default_pass_probability": 0.7
   },
-  "outreach_contact_rate_target": {
+  "actual_outreach_contact_rate": {
     "unit": "fraction",
     "low": 0.40,
     "base": 0.60,
     "high": 0.75,
-    "rationale": "Plan KPI is 0.6; comparable proactive door-to-door outreach programs in European cities reach 0.4-0.75 depending on canvasser density and trust.",
+    "rationale": "Base centered on plan target 0.6 (DEFAULT, no anchored shift). Spread from comparable European canvasser outreach programs reaching 0.4-0.75 depending on density and trust.",
     "source": "data",
     "sampling_discipline": "fraction",
     "non_negative": true,
     "default_pass_probability": null
   },
-  "cooling_center_utilization_target": {
+  "actual_cooling_center_utilization": {
     "unit": "fraction",
     "low": 0.55,
     "base": 0.80,
     "high": 0.90,
-    "rationale": "Plan target is 0.8; weather-dependent demand and commute distance commonly drag utilization to 0.55-0.7 in pilot summers.",
-    "source": "assumption",
+    "rationale": "Base centered on plan target 0.8 (DEFAULT). Low-side spread to 0.55 reflects Risk 4 (weather-dependent demand drop in cool summers); high capped at 0.90 by site capacity.",
+    "source": "data",
     "sampling_discipline": "fraction",
     "non_negative": true,
     "default_pass_probability": null
@@ -292,6 +295,17 @@ A valid output:
     "rationale": "Range across European heatwave studies for vulnerable subpopulations during typical-to-severe summers.",
     "source": "data",
     "sampling_discipline": "continuous",
+    "non_negative": true,
+    "default_pass_probability": null
+  },
+  "actual_canvasser_dropout_rate": {
+    "unit": "fraction",
+    "low": 0.15,
+    "base": 0.35,
+    "high": 0.55,
+    "rationale": "Plan threshold is 0.20; base shifted to 0.35 (negative margin at base on dropout gate). Anchored on Issue 7 — Leipzig 2023 cooling-centre pilot lost 30-40% of canvassers in week 4 to summer-school conflicts.",
+    "source": "data",
+    "sampling_discipline": "fraction",
     "non_negative": true,
     "default_pass_probability": null
   }


### PR DESCRIPTION
## Summary

Follow-up to #731. Five tightening changes to the `generate-bounds` skill, driven by case-study findings on the Yellowstone v46 and Paperclip v46 snapshots.

## What changed

- **Skip threshold/target variables** (the main behavioral change). The Yellowstone v46 bounds put triangular distributions on `n95_staging_target_share` (low=0.20, base=0.30, high=0.45) and `public_compliance_threshold` (low=0.65, base=0.70, high=0.80). Both are explicit `report_explicit` thresholds. Randomising them silently changes what `pass_rate` measures from \"actual ≥ stated_threshold\" to \"actual ≥ random_threshold\", and breaks the `threshold_basis = report_explicit` contract. Add an explicit \"Do NOT generate bounds for\" rule covering ids ending in `_threshold / _target / _ceiling / _floor / _limit / _cap / _max / _min`, and ids appearing on the threshold side of a margin formula. Mirrored in the SKILL.md Common Mistakes table.

- **Reorder ACTUAL-VS-COMMITMENT and SANITY CHECK** in `system-prompt.txt`. The previous order put the procedural check before the concept it enforces. Concept (what is an `actual_X` vs `X_target` variable) now reads first; the sanity check that enforces it reads second. Also removes a duplicate CRITICAL clause that overlapped with SANITY CHECK step 3.

- **Direction-agnostic SANITY CHECK**. The previous step-3 example (`threshold=2, base=3 means a -1 base-case margin`) implicitly assumed a `pass when actual ≤ threshold` gate. The majority of declared gates in PlanExe are the other direction (compliance shares, surpluses, coverage rates → `pass when actual ≥ threshold`). New phrasing: \"Determine the gate direction first; evaluate the margin at base inputs; if the margin is negative...\". Direction-agnostic example follows.

- **Rationale word cap 30 → 50** with a carve-out. The new disclosures required by ACTUAL-VS-COMMITMENT (anchor paraphrase) and SANITY CHECK (base-vs-threshold clause) didn't fit alongside existing rationale content at 30 words. The carve-out explicitly exempts those two disclosures if they push past 50.

- **Worked example restructured** to demonstrate all four new rules in one walkthrough:
  - `outreach_contact_rate_target` and `cooling_center_utilization_target` are now listed as `uncertainty: low` plan KPIs explicitly annotated as \"used as gate threshold, not bounded\" — demonstrating Edit 3 (skip thresholds)
  - `actual_outreach_contact_rate` and `actual_cooling_center_utilization` added to `missing_values_to_estimate`, bounded with bases centered on their plan targets (DEFAULT behavior)
  - `actual_cooling_center_utilization` rationale now cites Risk 4 as the asymmetric-spread source
  - New `actual_canvasser_dropout_rate` entry demonstrates a legitimate base-shift past threshold with a cited Issue 7 anchor

## Why now

The case-study assessments on Yellowstone and Paperclip revealed:

1. Bounds were being generated on threshold variables themselves (Yellowstone), silently changing the meaning of `pass_rate`. The existing selection rules don't catch this — a threshold key_value tagged `uncertainty: medium, priority: high` still triggers a bounds entry under the current `B` selection rule.

2. The new SANITY CHECK section assumes one gate direction. A randomly-picked gate in the Paperclip or Yellowstone bounds files often goes the other way, so the example was confusing for the most common case.

3. The 30-word rationale cap was incompatible with the new \"name the anchor + paraphrase the claim\" requirement from #731.

## What a re-run would change

If `generate-bounds` is re-run against the v46 parameter JSONs after this change:

- **Yellowstone**: `n95_staging_target_share` and `public_compliance_threshold` entries would no longer appear in the output. The model would still test against the stated 0.30 and 0.70 single values — the simulation question becomes \"actual ≥ 0.30\" rather than \"actual ≥ random_target\". Pass rates for those two gates will shift; direction depends on how the previous threshold-smearing affected them.
- **Paperclip**: no threshold variables were bounded, so output should be unchanged for that plan. The actual-vs-commitment rule (from #731) still governs the `manual_intervention_hours` base choice.

## Test plan

- [ ] Re-run `generate-bounds` against Leipzig heatwave example input — verify no `_target` / `_threshold` entries appear in output
- [ ] Re-run against Yellowstone v46 parameters.json — verify `n95_staging_target_share` and `public_compliance_threshold` are skipped
- [ ] Re-run against Paperclip v46 parameters.json — verify output is unchanged (no threshold vars were bounded there)
- [ ] Spot-check that a re-generated bounds file still passes downstream `run_scenarios` and `monte_carlo` stages with the threshold no longer present as a bounded input

🤖 Generated with [Claude Code](https://claude.com/claude-code)