### PR TITLE
docs(napkin-math): plan for addressing Gemini's Monte Carlo methodology critique

### DIFF
--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -84,8 +84,33 @@ sub-components.
 - R2.4 — `cost_eur = hedged × historical_rate + unhedged ×
   simulated_rate` (or the inverse for USD-denominated hardware)
 
-**Skills to change:**
+**Pipeline-stage routing:**
 
+- R1.1 — primary fix in the extract stage. The total/constituent
+  link cuts across sections; compress sees one section at a time and
+  cannot reliably detect it.
+- R2.3 — fix spans **compress** AND extract. The €257.6M/yr holding
+  cost surfaces in the Review Plan section, the matching delay
+  duration surfaces in Review Plan or Premortem. If `compress_report_section.py`
+  flattens "€257.6M/yr" to "€257.6M holding cost", the rate × duration
+  opportunity is lost before extract sees it.
+- R2.4 — the FX master equation is in **Assumption Q5**, which is a
+  **passthrough** section, NOT compressed. `compress_report_section.py`
+  is not in the loop for R2.4; the fix lives entirely in the extract
+  stage, which reads Q5 verbatim.
+
+**Skills / modules to change:**
+
+- `compress_report_section.py` (Stage 1, worker_plan) — two prompt
+  edits to preserve burn-rate structure for R2.3:
+  1. `NUMERIC_VALUES_BUCKET_PROMPT` — require the `label` to include
+     the per-period unit (`/yr`, `/mo`, `/km²`, `/FTE`) when the
+     source states a per-period rate, and require the `modelling
+     role` to read like `burn rate scaling with <X>` so downstream
+     code can detect the multiplication.
+  2. `MISSING_DATA_BUCKET_PROMPT` — extend the denominator-pairing
+     rule (lines 605–624) with: "a per-period burn rate needs the
+     matching duration the rate will be multiplied by".
 - `extract-parameters-from-full`, `extract-parameters-from-digest` —
   system prompts must enumerate the patterns to detect:
   - "total cost / total budget" alongside named constituents → declare
@@ -243,8 +268,22 @@ Two upstream failure modes possible:
 2. Extract declared the variable but defaulted to `>= 0` because the
    formula had not subtracted the requirement.
 
-**Skills to change:**
+A third upstream failure mode is possible too: compress's
+`gates_and_thresholds` bucket may not have surfaced "32.2 km² required
+for 9 GW" as a gate, because the source states it as a capacity
+calculation rather than an explicit pass/fail condition. If extract
+never saw it as a gate, the threshold defaulted to `>= 0`.
 
+**Skills / modules to change:**
+
+- `compress_report_section.py` (Stage 1, worker_plan) — extend
+  `GATES_AND_THRESHOLDS_BUCKET_PROMPT` with: "Capacity requirements
+  count as gates. When the source states a numeric minimum needed to
+  physically support a declared capacity ('32.2 km² to support 9 GW',
+  '11 GVA grid headroom for Phase 1'), the requirement IS the gate.
+  Write it as `If <quantity> falls below <required value>, then
+  <consequence>` even when the source does not frame it that way
+  explicitly."
 - `extract-parameters-from-full`, `extract-parameters-from-digest` —
   system prompts must require: when the plan states an explicit
   requirement for a capacity variable, the gate must be either
@@ -309,8 +348,9 @@ distinguish plans that differ only in unmodelled-gate severity.
 
 ### Changed skills
 
-| Skill | Findings | Type of change |
+| Skill / module | Findings | Type of change |
 |---|---|---|
+| `compress_report_section.py` (Stage 1, worker_plan) | R2.3, R2.5 | Prompt edits: per-period unit preservation in `numeric_values`; burn-rate / duration pairing in `missing_data_to_estimate`; capacity-requirement detection in `gates_and_thresholds` |
 | `extract-parameters-from-full` | R1.1, R2.3, R2.4, R2.5 | System prompt: aggregates / burn rates / FX decomposition / explicit-requirement thresholds |
 | `extract-parameters-from-digest` | R1.1, R2.3, R2.4, R2.5 | Same as above |
 | `generate-bounds` | R1.1, R1.2, R1.3, R1.4, R1.5, R2.2 | System prompt + schema (correlations, lognormal / PERT, plan_type-driven defaults); self-audit examples; strip aggregates |
@@ -348,21 +388,27 @@ Rough order of return on effort:
    R1.2 (base anchoring), R1.5 (citation self-audit examples), R2.2
    (plan_type-driven lognormal default). Run Self-Improve against the
    14-plan baseline before shipping.
-3. **Deterministic backstops** — `verify-bounds-citations` (R1.5);
+3. **Compress-stage prompt edits in `compress_report_section.py`** —
+   R2.3 burn-rate preservation in numeric_values + burn/duration
+   pairing in missing_data; R2.5 capacity-requirement detection in
+   gates_and_thresholds. Lower-risk than the bounds prompt because
+   compress is upstream of the LLM judgments that have been
+   benchmarked by Self-Improve; regenerate snapshot fixtures.
+4. **Deterministic backstops** — `verify-bounds-citations` (R1.5);
    `validate-parameters` extensions for R1.1 (aggregate-not-bounded)
    and R2.5 (requirement-margin pairing).
-4. **Extraction tightening** — `extract-parameters-from-full` /
+5. **Extraction tightening** — `extract-parameters-from-full` /
    `extract-parameters-from-digest` prompts for R1.1, R2.3, R2.4,
    R2.5 (decomposed equations + explicit thresholds).
-5. **Runner: correlation sampling (R1.3)** — copula implementation +
+6. **Runner: correlation sampling (R1.3)** — copula implementation +
    `generate-bounds` schema extension. Slideshow disclosure either way.
-6. **Runner: lognormal / PERT (R1.4, R2.2)** — extend
+7. **Runner: lognormal / PERT (R1.4, R2.2)** — extend
    `VALID_DISCIPLINES`; decide `run-scenarios` policy; extend
    slideshow disclosure with `plan_type` context.
 
-Step 1 alone closes the most visible methodological gap. Steps 2–4
+Step 1 alone closes the most visible methodological gap. Steps 2–5
 reach the bulk of remaining quality gains without touching the
-runner. Steps 5–6 are infrastructure changes that pay off across
+runner. Steps 6–7 are infrastructure changes that pay off across
 every plan.
 
 ## What does not change

--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -2,96 +2,148 @@
 
 ## Context
 
-Gemini reviewed the napkin_math output for `20251114_paperclip_automation`
-(snapshot 49) and surfaced five flaws on top of the earlier correlation
-comment. Four of the five flaws point at upstream LLM stages
-(extract / bounds), one points at the runner, and one is shared between
-upstream prompts and a deterministic backstop. This document maps each
-flaw to the `.claude/skills` (and the Python infrastructure) that has to
-change, and names the new skill(s) that the gap analysis surfaces.
+Gemini reviewed two napkin_math outputs from snapshot 49:
 
-Source critiques:
+- `20251114_paperclip_automation` — small industrial pilot. Surfaced
+  five flaws in extraction, bounds, sampling, and rationale-citation
+  fidelity.
+- `20260516_datacenter_in_france` — 9 GW hyperscale infrastructure
+  megaproject. Surfaced five further findings, two of which extend
+  the first round. This plan scored **100% Robust** in the assessment
+  despite being a €100B+ sovereign-infrastructure project with
+  multiple existential regulatory dependencies.
 
-- **Independence** — runner samples every variable independently, so
-  inflation can land at p95 in the same trial labor cost lands at p05.
-- **Disconnected aggregates** — `actual_total_project_cost_usd` is drawn
-  as an independent bounded variable instead of computed from its
-  constituents. Run #4,592 can pair sub-component p95s with a total p05.
-- **Base = target fallacy** — `generate-bounds` defaults `base` to the
-  commitment value. With `low = 1.0`, `base = 2.0`, `high = 4.5`, the
-  triangular CDF guarantees ~70% of mass above the threshold; the 29.3%
+This document maps each finding to the `.claude/skills` (and the
+Python infrastructure) that has to change, and identifies the new
+skill(s) the gap analysis surfaces. Findings are grouped by theme;
+each is tagged R1 (paperclip) or R2 (datacenter).
+
+### Findings inventory
+
+**Round 1 — paperclip pilot:**
+
+- R1.1 — *Disconnected aggregates.* Total cost drawn independently of
+  sub-component costs; a single trial can pair sub-component p95s
+  with a total p05.
+- R1.2 — *Base = target fallacy.* `generate-bounds` centers `base` on
+  the commitment value. With `low/base/high = 1.0/2.0/4.5`, the
+  triangular CDF guarantees a fail-loaded distribution; the 29.3%
   gate-pass figure is a property of the bound shape, not the plan.
-- **Bounded vs. fat-tail** — triangular `high` is a hard ceiling, so 0%
-  of runs see a $700k overrun on a $500k project. Real R&D blowouts are
-  fat-tailed (lognormal).
-- **Hallucinated citation** — a `generate-bounds` rationale cited
-  "Risk-5 grading-protocol variance" in a paperclip-automation plan
-  whose Risk 5 is about machinery supply-chain delays. Context leak,
-  silently shipped.
+- R1.3 — *Independence.* Runner samples every variable independently;
+  inflation can land at p95 in the same trial labor cost lands at p05.
+- R1.4 — *Bounded vs. fat-tail.* Triangular `high` is a hard ceiling;
+  0% of runs see a $700k overrun on a $500k project.
+- R1.5 — *Hallucinated citation.* Rationale cited "Risk-5
+  grading-protocol variance" in a plan whose Risk 5 is about
+  supply-chain delays.
 
-## Per-flaw mapping
+**Round 2 — 9 GW datacenter:**
 
-### Flaw 1 — Disconnected aggregates
+- R2.1 — *Megaproject illusion.* Existential regulatory gates (RTE
+  grid upgrade, DGSI security clearance, DREAL zoning) are correctly
+  placed in `unmodelled_gates`, so the Monte Carlo evaluates only the
+  benign budget variables. Headline reads 100% Robust, slideshow
+  caveat invisible. The verdict is honest about its scope but framed
+  in a way that lets the scope go unread.
+- R2.2 — *Megaproject distributions.* Same root issue as R1.4, but
+  the fix differs by `plan_type`. Hyperscale / geopolitical
+  megaprojects must use lognormal CAPEX by default (Flyvbjerg's iron
+  law); a $300k paperclip pilot does not.
+- R2.3 — *Time-cost covariance.* Holding cost is named at €257.6M/yr
+  for a 128.8 km² buffer; RTE delays could push the timeline 4 years
+  out. Extract emitted `actual_holding_cost_eur` as a flat bounded
+  variable rather than the deterministic relation
+  `holding_cost = annual_burn × actual_delay_months / 12`.
+- R2.4 — *Missed FX master equation.* Assumption Q5 explicitly states
+  30% of CAPEX is USD-denominated and 70% hedged, with a 10% FX shift
+  worth €4.32B. Extract emitted `phase1_capex_surplus` as a single
+  bounded variable rather than decomposing into civil_works +
+  remediation + hardware_eur + hardware_usd / fx_rate.
+- R2.5 — *Threshold trivialization.* `buildable_area_km2` gate is
+  `>= 0` (the model-defined default) when the plan states 32.2 km² is
+  needed to physically support 9 GW. DREAL forcing the buffer to 20
+  km² is the actual failure scenario; the `>= 0` gate never tests it.
 
-**Root cause:** the extraction stage emitted `actual_total_project_cost_usd`
-as a `missing_values_to_estimate` entry. The bounds stage then dutifully
-bounded it. The runner has no way to know it should equal the sum of
-sub-costs because no `formula_hint` declares that relationship.
+A chunk of R2 (R2.3 holding-cost burn × delay, R2.4 FX × CAPEX) looks
+like a correlation problem on first read but is actually a
+decomposition problem: the plan names the deterministic equation
+explicitly, and the extract should preserve it. The two themes are
+separated below.
+
+## Per-theme mapping
+
+### Theme A — Decomposed equations: aggregates, burn rates, FX
+
+Covers R1.1, R2.3, R2.4. All three are instances of the same upstream
+defect: the extract stage emitted a flat bounded variable when the
+report itself names a deterministic relationship between
+sub-components.
+
+- R1.1 — `total = A + B + C + …`
+- R2.3 — `derived_cost = burn_rate × duration`
+- R2.4 — `cost_eur = hedged × historical_rate + unhedged ×
+  simulated_rate` (or the inverse for USD-denominated hardware)
 
 **Skills to change:**
 
 - `extract-parameters-from-full`, `extract-parameters-from-digest` —
-  system prompts must require: when the report names constituents of a
-  total (or any compound aggregate), the total is a
-  `recommended_first_calculations` entry with
-  `formula_hint = A + B + C + ...`, **never** a
-  `missing_values_to_estimate` entry.
-- `validate-parameters` — add a structural check: a variable that is the
-  LHS of a sum-formula in another entry MUST NOT also appear in
-  `missing_values_to_estimate`. Same posture as the existing 16
-  structural rules. Fail-loud.
-- `generate-bounds` — already strips bounds for threshold variables via
-  `strip_threshold_bounds`. Extend the same deterministic backstop to
-  strip bounds for any variable declared as a calculation LHS. Belongs
-  next to the existing strip logic in `run_monte_carlo.py`.
+  system prompts must enumerate the patterns to detect:
+  - "total cost / total budget" alongside named constituents → declare
+    total as `recommended_first_calculations` with
+    `formula_hint = A + B + C + …`.
+  - "per-year", "per-month", "annual burn", "monthly holding",
+    "PMO overhead" alongside a variable duration → declare the
+    dependent cost as `burn_rate * duration` and bound the duration,
+    not the cost.
+  - Explicit assumption blocks doing the math (e.g., Assumption Q5
+    "30% USD, 10% shift, €4.32B impact") → preserve the decomposition
+    as a calculation; the LLM MUST NOT collapse the explicit
+    decomposition into a single flat variable.
+- `validate-parameters` — extend the structural checks:
+  - A variable that is the LHS of a sum-formula in another entry MUST
+    NOT also appear in `missing_values_to_estimate`.
+  - A variable whose id paraphrases "total", "sum", "aggregate",
+    "holding_cost", "capex_eur" warns when bounded independently of
+    any declared formula. Same backstop pattern as
+    `strip_threshold_bounds`.
+- `generate-bounds` — extend `strip_threshold_bounds` to also strip
+  bounds for any variable declared as a calculation LHS (today it
+  only strips threshold-named variables).
+- `generate-calculations` — no code change; if `formula_hint` is
+  declared correctly upstream, the existing code generator implements
+  the sum / product correctly.
 
-`generate-calculations` does not need to change. If `formula_hint` is
-declared, the existing code generator implements the sum correctly.
+### Theme B — Base anchoring: realistic vs. committed
 
-### Flaw 2 — Base = target fallacy
-
-**Root cause:** the "actual-vs-commitment default" rule in
-`generate-bounds/system-prompt.txt` was added defensively. Without it,
-the LLM was shifting `base` past the threshold with no anchor,
-producing baseline-fail verdicts that were prompt artifacts. The current
-rule overcorrects in the opposite direction: it forces `base` to the
-commitment regardless of whether the report itself names a likely
-shortfall.
+Covers R1.2. The actual-vs-commitment default rule in
+`generate-bounds/system-prompt.txt` overcorrects: it forces `base` to
+the commitment value regardless of whether the plan itself names a
+likely shortfall.
 
 **Skills to change:**
 
-- `generate-bounds` (system-prompt.txt) — rewrite the actual-vs-commitment
-  paragraph as a conditional rule:
-  - If a Premortem / Expert Criticism / Risk-register passage forecasts
-    a gap between commitment and reality, anchor `base` on the
-    plan-internal gap estimate and cite it.
-  - Otherwise, fall back to the commitment value AND tag
+- `generate-bounds` (system-prompt.txt) — rewrite the
+  actual-vs-commitment paragraph as a conditional rule:
+  - If a Premortem / Expert Criticism / Risk-register passage
+    forecasts a gap between commitment and reality, anchor `base` on
+    the plan-internal gap estimate, cite it, tag `source: "data"`.
+  - Otherwise fall back to the commitment value AND tag
     `source: "assumption"` (today the rule silently emits `data`).
   - Make the asymmetry visible in the rationale.
-- `summarize-assessment` — surface in the Missing-inputs-ranked-by-impact
-  table whether `base` was anchored on a report passage or on the
-  commitment-default. The reader currently cannot tell.
+- `summarize-assessment` — surface in
+  *Missing inputs ranked by impact* whether `base` was anchored on a
+  report passage or on the commitment default. The reader currently
+  cannot tell.
 
-This is the change most likely to swing gate verdicts on existing plans,
-so run the Self-Improve optimization loop on `generate-bounds` before
-shipping.
+Most likely to swing gate verdicts on existing plans; run Self-Improve
+against the 14-plan baseline before shipping.
 
-### Flaw 3 — Absence of correlation
+### Theme C — Cross-variable correlation
 
-**Root cause:** runner declares `correlation_groups: []` in
-`DEFAULT_SETTINGS` (line 35), reads it from user settings (line 101),
-and then never references it during sampling. The monte-carlo SKILL.md
-honestly says so at line 70.
+Covers R1.3. Runner declares `correlation_groups: []` in
+`DEFAULT_SETTINGS` (`run_monte_carlo.py:35`), reads it from user
+settings (line 101), and never references it during sampling. The
+monte-carlo SKILL.md acknowledges the gap at line 70.
 
 **Skills to change:**
 
@@ -100,164 +152,259 @@ honestly says so at line 70.
   by the LLM based on plan-internal logic ("if PLC is hostile, OPC UA
   bid is high AND manual-intervention hours are high").
 - `monte-carlo` (runner code) — implement Gaussian-copula sampling.
-  Build rank-correlated uniforms for variables in a group, feed them
-  through each variable's inverse-triangular (or inverse-lognormal).
-  Inputs not in any group stay independent. ~80 lines.
-- `summarize-assessment` — add a slideshow section disclosing the
-  independence assumption when no correlations are declared; surface
-  declared correlation groups when they are.
+  Rank-correlated uniforms for variables in a group fed through each
+  variable's inverse-triangular (or inverse-lognormal). Inputs not in
+  any group stay independent. ~80 lines.
+- `summarize-assessment` — disclose the independence assumption in
+  the slideshow when no correlations are declared; surface declared
+  groups when they are.
 
-**No new skill needed** for correlations. Folding them into
-`generate-bounds` keeps the artifact count down. If correlations grow
-into a multi-page artifact in practice, split out later.
+**No new skill** for correlations. Folding them into `generate-bounds`
+keeps the artifact count down.
 
-### Flaw 4 — Bounded distributions for unbounded risks
+Note: fix Theme A first. A chunk of what reads as correlation
+(holding cost ↔ delay; CAPEX ↔ FX rate) collapses into deterministic
+decomposition once the equations are restored. The remaining
+correlation set is smaller and easier to declare honestly.
 
-**Root cause:** `sampling_discipline` enumerates `fixed / bernoulli_gate
-/ integer / fraction / continuous` and all continuous draws are
-triangular by default. Triangular has zero mass past `high`, which is
-wrong for R&D / integration cost.
+### Theme D — Distribution choice and fat tails
+
+Covers R1.4 and R2.2. Triangular truncates at `high`, which is wrong
+for R&D / integration cost (R1.4) and catastrophically wrong for
+megaproject CAPEX (R2.2).
 
 **Skills to change:**
 
-- `generate-bounds` — add `sampling_discipline: "lognormal"` (and
-  possibly `"pert"`) to the enumeration. System prompt must document
-  when to use it: cost or duration variables tied to integration /
-  R&D / legacy-hardware risk, especially when the source report names
-  "scope creep" / "unknown unknowns". For lognormal, `low / high` mean
-  P5 / P95 rather than hard cutoffs.
-- `monte-carlo` (runner code) — implement lognormal and PERT samplers.
-  Keep triangular as default. Update `VALID_DISCIPLINES`.
-- `run-scenarios` — decide policy. Scenarios evaluate at `low / base /
-  high` deterministically; for a lognormal that means P5 / median / P95.
-  Either run-scenarios learns the new disciplines or `generate-bounds`
-  is constrained to triangular for variables that scenarios must
-  evaluate. Simplest first cut: scenarios continue to use triangular
-  semantics (`base` as point estimate, `low` and `high` as the three-
-  point bracket); the LLM may not select lognormal for variables that
-  also need a scenario row.
+- `generate-bounds` — add `sampling_discipline: "lognormal"` and
+  `"pert"` to the enumeration. System prompt documents when each
+  applies:
+  - **Per-variable rule:** cost / duration variables tied to
+    integration, R&D, legacy hardware, or "scope creep" passages →
+    lognormal.
+  - **`plan_type`-driven default:** if
+    `parameters.plan_summary.plan_type` matches
+    `hyperscale_infrastructure`, `geopolitical_megaproject`, or
+    similar, ALL CAPEX and major OPEX variables default to lognormal
+    unless the rationale explicitly justifies triangular. Anchor on
+    Flyvbjerg's iron law of megaprojects. For
+    `industrial_automation_pilot` and `small_scale_logistics`,
+    triangular stays the default.
+  - For lognormal, `low / high` mean P5 / P95, not hard cutoffs.
+- `monte-carlo` (runner code) — implement lognormal and PERT
+  samplers. Triangular stays default. Update `VALID_DISCIPLINES`.
+- `run-scenarios` — policy decision. Scenarios evaluate at
+  `low / base / high` deterministically; for a lognormal that means
+  P5 / median / P95. Either run-scenarios learns the new disciplines
+  or `generate-bounds` is constrained to triangular for variables
+  that also have a scenario row. Simplest first cut: scenarios stay
+  triangular-only; the LLM may not select lognormal for any variable
+  with a scenario row.
 - `validate-parameters` — extend the discipline-allowed list.
-- `summarize-assessment` — disclose in the slideshow when any variable
-  uses a fat-tail discipline; cite it as a strength, not a footnote.
+- `summarize-assessment` — disclose in the slideshow when any
+  variable uses a fat-tail discipline; cite it as a strength, not a
+  footnote. Also disclose `plan_type` and the discipline default it
+  implies.
 
-### Flaw 5 — Hallucinated Risk-N citations
+### Theme E — Rationale citation verification
 
-**Root cause:** the existing self-audit in `generate-bounds/SKILL.md:30`
-says rationale citations must "substantively support the claim". The
-LLM didn't catch a clean context leak (Risk 5 referenced in a rationale
-text that is about a different topic than the actual Risk 5).
+Covers R1.5. The existing self-audit in `generate-bounds/SKILL.md:30`
+says citations must "substantively support the claim". The LLM didn't
+catch a clean context leak.
 
 **Skills to change:**
 
 - `generate-bounds` — strengthen the self-audit instruction with
   concrete failure examples (context-leak: citation refers to a Risk
-  that exists by number but is about a different topic). Examples beat
-  abstract rules.
+  that exists by number but is about a different topic).
 
 **New skill (or new step in `validate-parameters`):**
 
 - **`verify-bounds-citations`** — deterministic Python, no LLM call.
-  Parse Risk N / Issue N / Decision N tokens from each rationale string
-  in `bounds.json`. For each citation, fetch the corresponding section
-  from the source report (or from `parameters.json` if it stores the
-  cited content). Compare topical keywords from the rationale against
-  the cited section. Fail loud when topical overlap is below threshold.
-  Same fail-loud posture as `SchemaError`. Re-run `generate-bounds`.
+  Parse Risk N / Issue N / Decision N tokens from each rationale
+  string in `bounds.json`. For each citation, fetch the corresponding
+  section from the source report. Compare topical keywords from the
+  rationale against the cited section. Fail loud when topical overlap
+  is below threshold. Same posture as `SchemaError`. Re-run
+  `generate-bounds`. Start with substring / shared-stem matching;
+  tighten if needed.
 
-  Two implementation options for keyword overlap:
-  1. Substring / shared-stem match against a small stopword list.
-     Brittle on morphology (grading / grade) but zero dependencies.
-  2. Lightweight TF-IDF or rapidfuzz overlap against the cited section's
-     tokens. Adds a dep.
+### Theme F — Threshold extraction quality
 
-  I'd start with (1) and tighten if it misses Gemini's class of
-  failure.
+Covers R2.5. The `buildable_area_km2` gate landed as `>= 0`
+(model-defined default) when the plan states 32.2 km² is required for
+9 GW. DREAL forcing the buffer to 20 km² is the actual failure
+scenario; the gate never tests it.
 
-This is the **strongest argument for a new skill** in the inventory.
-It is deterministic, naturally orthogonal to the LLM stages it audits,
-and follows the existing pattern of `validate-parameters` (also
-deterministic, also a structural audit).
+Two upstream failure modes possible:
+
+1. Extract did not declare a margin variable
+   `buildable_area_surplus = actual_buildable_area_km2 - 32.2`. The
+   actual area was bounded; the requirement was lost.
+2. Extract declared the variable but defaulted to `>= 0` because the
+   formula had not subtracted the requirement.
+
+**Skills to change:**
+
+- `extract-parameters-from-full`, `extract-parameters-from-digest` —
+  system prompts must require: when the plan states an explicit
+  requirement for a capacity variable, the gate must be either
+  `>= <requirement>` (explicit-value threshold) OR the variable must
+  be re-expressed as a margin `actual - requirement` with a `>= 0`
+  gate. The model-defined `>= 0` default may apply only when the
+  underlying formula has already subtracted the requirement.
+- `validate-parameters` — add a sanity check: if a `key_value`
+  declares a numeric requirement (e.g., a `*_required` companion
+  variable) and a margin / surplus variable is NOT declared, warn.
+  The existing threshold-friendly naming rule is the hook to extend.
+- `summarize-assessment` — surface `threshold_basis` more
+  prominently. A `model_defined / >= 0` gate next to a value-bearing
+  requirement in the same plan is a yellow flag, not a pass.
+
+### Theme G — Overall verdict aggregation: the megaproject illusion
+
+Covers R2.1, the most consequential new finding. The 9 GW datacenter
+scored 100% Robust because every existential gate (RTE grid, DGSI,
+DREAL) was correctly identified as binary regulatory and correctly
+placed in `unmodelled_gates` — and then the headline verdict ignored
+them entirely. The slideshow disclaimer
+("unmodelled_gates qualify the modelled verdict but never enter the
+simulation") is honest but easily missed, especially on a slide that
+reads "100% pass rate" in large type.
+
+**The fix is a verdict-aggregation change, not a sampling change.**
+The Monte Carlo is producing the right number for the modelled-gates
+question; the headline is asking the wrong question.
+
+**Skills to change:**
+
+- `summarize-assessment` — implement a composite risk band:
+  - Today: `overall_risk_band` = band of the worst declared gate.
+  - Proposed: `overall_risk_band` is capped by `unmodelled_gates`
+    count. Suggested rule (calibratable):
+    - 1–2 unmodelled gates → cap at Robust unchanged.
+    - 3–4 unmodelled gates → cap at Marginal.
+    - 5+ unmodelled gates → cap at Fragile.
+  - The cap is monotonic: more unmodelled binary risks can only make
+    the headline worse, never better.
+  - Add a new manifest field `unmodelled_gate_penalty` naming exactly
+    what was applied and why.
+  - Slideshow text changes: "100% Robust (modelled gates), capped at
+    Marginal due to 4 unmodelled existential gates" — verdict honest
+    about its scope.
+- `extract-parameters-from-full`, `extract-parameters-from-digest` —
+  unchanged; they already populate `unmodelled_gates` correctly. The
+  defect is downstream of extraction.
+- `methology.md` and README — document the cap rule. Load-bearing
+  change to the verdict semantics.
+
+A structurally cleaner alternative is to lift existential gates into
+the simulation as Bernoulli draws (probability of RTE approval ×
+probability of DGSI clearance × …). That requires the LLM to assign
+survival probabilities, which is a new source of error. **The cap
+rule is the safer first cut**; Bernoulli-modelling existential gates
+is a follow-up to pursue if the cap turns out to be too blunt to
+distinguish plans that differ only in unmodelled-gate severity.
 
 ## Skill inventory summary
 
 ### Changed skills
 
-| Skill | Flaw(s) | Type of change |
+| Skill | Findings | Type of change |
 |---|---|---|
-| `extract-parameters-from-full` | 1 | System prompt: aggregates must be calculations |
-| `extract-parameters-from-digest` | 1 | System prompt: aggregates must be calculations |
-| `generate-bounds` | 1, 2, 3, 4, 5 | System prompt + schema (correlations, lognormal); self-audit examples |
+| `extract-parameters-from-full` | R1.1, R2.3, R2.4, R2.5 | System prompt: aggregates / burn rates / FX decomposition / explicit-requirement thresholds |
+| `extract-parameters-from-digest` | R1.1, R2.3, R2.4, R2.5 | Same as above |
+| `generate-bounds` | R1.1, R1.2, R1.3, R1.4, R1.5, R2.2 | System prompt + schema (correlations, lognormal / PERT, plan_type-driven defaults); self-audit examples; strip aggregates |
 | `generate-calculations` | — | No change |
-| `validate-parameters` | 1, 4 | New structural checks (aggregate-not-bounded, expanded discipline enum) |
-| `monte-carlo` (runner) | 1, 3, 4 | Strip aggregate bounds; copula sampler; lognormal/PERT samplers |
-| `run-scenarios` | 4 | Policy decision on lognormal semantics |
-| `summarize-assessment` | 2, 3, 4 | Disclose anchoring, correlation groups, fat-tail discipline in slides |
-| `run-napkin-math-pipeline` | 5 | Orchestrate the new verifier between bounds and calculations |
-| `test-napkin-math` | 1, 3, 4, 5 | Add smoke fixtures exercising lognormal, correlation, aggregate-stripping, citation-failure |
+| `validate-parameters` | R1.1, R1.4, R2.2, R2.5 | New structural checks (aggregate-not-bounded, expanded discipline enum, requirement-margin pairing) |
+| `monte-carlo` (runner) | R1.1, R1.3, R1.4, R2.2 | Strip aggregate bounds; copula sampler; lognormal / PERT samplers |
+| `run-scenarios` | R1.4, R2.2 | Policy decision on lognormal / PERT semantics |
+| `summarize-assessment` | R1.2, R1.3, R1.4, R2.1, R2.2, R2.5 | Disclose anchoring / correlations / discipline / plan_type / threshold-basis; implement composite-risk-band cap |
+| `run-napkin-math-pipeline` | R1.5 | Orchestrate the new verifier between bounds and calculations |
+| `test-napkin-math` | R1.1, R1.3, R1.4, R1.5, R2.1, R2.2, R2.3, R2.4, R2.5 | Smoke fixtures across every theme |
+| `methology.md` / README | R2.1 | Document the composite-band cap rule |
 
 ### New skills
 
-- **`verify-bounds-citations`** — deterministic post-processor. Audits
-  `bounds.json` rationale citations against the source report.
+- **`verify-bounds-citations`** — deterministic post-processor that
+  audits `bounds.json` rationale citations against the source report.
   Fail-loud, re-run-`generate-bounds` posture. Plugs into
   `run-napkin-math-pipeline` between Stage 5 (`generate-bounds`) and
   Stage 6 (`generate-calculations`).
 
-I do **not** recommend a separate `generate-correlations` skill. Folding
-correlations into `generate-bounds` matches how `sampling_discipline`
-and `default_pass_probability` are already declared there. Split later
-only if correlations grow large enough to deserve their own artifact.
+I do **not** recommend separate skills for correlations, burn-rate
+detection, FX decomposition, or composite-band aggregation. These all
+sit inside existing stages with prompt and schema changes only.
 
 ## Sequencing
 
 Rough order of return on effort:
 
-1. **Prompt-only fixes** — Flaw 2 (base anchoring) and Flaw 5
-   (self-audit examples) in `generate-bounds/system-prompt.txt`. Run
-   the Self-Improve optimization loop to detect regressions against
-   the existing 14 plans.
-2. **Deterministic backstops** — add `verify-bounds-citations` (Flaw 5)
-   and the aggregate-not-bounded check in `validate-parameters`
-   (Flaw 1).
-3. **Extraction tightening** — update `extract-parameters-from-full` /
-   `extract-parameters-from-digest` to declare aggregates as
-   calculations (Flaw 1). Validates the backstop above.
-4. **Runner: correlation sampling** — implement copula in
-   `run_monte_carlo.py`; extend `generate-bounds` schema; update
-   slideshow disclosure (Flaw 3).
-5. **Runner: lognormal / PERT** — extend `VALID_DISCIPLINES`; implement
-   samplers; decide `run-scenarios` policy; extend slideshow (Flaw 4).
+1. **Composite-band cap rule (R2.1)** — `summarize-assessment` only.
+   Pure verdict-rendering change. Largest single credibility impact:
+   the 100%-Robust megaproject result is the loudest failure. Apply
+   retroactively against all 14 existing assessments to verify the
+   rule doesn't over-penalize benign plans.
+2. **Prompt-only fixes in `generate-bounds/system-prompt.txt`** —
+   R1.2 (base anchoring), R1.5 (citation self-audit examples), R2.2
+   (plan_type-driven lognormal default). Run Self-Improve against the
+   14-plan baseline before shipping.
+3. **Deterministic backstops** — `verify-bounds-citations` (R1.5);
+   `validate-parameters` extensions for R1.1 (aggregate-not-bounded)
+   and R2.5 (requirement-margin pairing).
+4. **Extraction tightening** — `extract-parameters-from-full` /
+   `extract-parameters-from-digest` prompts for R1.1, R2.3, R2.4,
+   R2.5 (decomposed equations + explicit thresholds).
+5. **Runner: correlation sampling (R1.3)** — copula implementation +
+   `generate-bounds` schema extension. Slideshow disclosure either way.
+6. **Runner: lognormal / PERT (R1.4, R2.2)** — extend
+   `VALID_DISCIPLINES`; decide `run-scenarios` policy; extend
+   slideshow disclosure with `plan_type` context.
 
-Steps 1–3 reach the largest quality gains without touching the runner.
-Steps 4–5 are infrastructure changes that pay off across every plan.
+Step 1 alone closes the most visible methodological gap. Steps 2–4
+reach the bulk of remaining quality gains without touching the
+runner. Steps 5–6 are infrastructure changes that pay off across
+every plan.
 
 ## What does not change
 
 - The runner's posture of "everything semantic comes from upstream
-  stages, nothing is pattern-matched on id strings" stays. Every change
-  above is either a new schema field (declared by an LLM stage) or a
-  deterministic check on existing structure.
-- The slideshow's worst-gate framing stays — none of the flaws
-  contradict it.
-- `summarize-assessment`'s `TRUST_NOT_VALIDATED` list shrinks as flaws
-  land. "Independence or correlation assumptions across inputs" moves
-  from "we don't model it" to "the user (or LLM) declared these groups"
-  once Flaw 3 ships.
+  stages; nothing is pattern-matched on id strings" stays. Every
+  change above is either a new schema field declared by an LLM
+  stage, a deterministic check on existing structure, or a
+  verdict-aggregation rule.
+- The slideshow's worst-gate framing for modelled gates stays; the
+  composite cap adds a *separate* aggregation across
+  modelled + unmodelled, not a rewrite of the modelled-gate logic.
+- `summarize-assessment`'s `TRUST_NOT_VALIDATED` list shrinks as
+  flaws land. "Independence or correlation assumptions across
+  inputs" moves from "we don't model it" to "the user (or LLM)
+  declared these groups" once R1.3 ships.
 
 ## Open questions
 
-- Aggregate stripping in `generate-bounds` — strip silently (like
-  thresholds today) or warn loudly? Threshold-strip warnings are
-  already emitted; aggregates likely deserve the same treatment.
+- Composite-band cap thresholds (1–2 / 3–4 / 5+) are placeholders.
+  Retroactive run across the 14 existing plans is the right way to
+  calibrate. Should the cap also weight by gate severity (a missing
+  permit is heavier than a missing community-engagement plan)?
+- Aggregate stripping — strip silently (like thresholds today) or
+  warn loudly? Aggregates likely deserve a louder warning since the
+  upstream defect is more recoverable.
 - Lognormal in `run-scenarios` — accept the inconsistency (scenarios
-  use base/low/high triangular semantics; Monte Carlo uses lognormal
-  P5/P95), or constrain `generate-bounds` to triangular for any
-  variable that also has a scenario row? Inclines toward the latter,
-  to keep the deterministic and stochastic layers comparable.
-- Citation verifier scope — only Risk N / Issue N / Decision N, or
-  also Premortem / Expert-Criticism passages? Start narrow; widen if
-  the next Gemini critique catches a missed leak.
-- Correlation-group declaration ergonomics — is the LLM expected to
-  emit a full correlation matrix, or pairwise ρ values, or named
-  groups with a single ρ? Named groups with single ρ is the lightest
-  cognitive load; matrices belong in a later iteration.
+  triangular, MC lognormal) or constrain `generate-bounds` to
+  triangular for any variable with a scenario row?
+- Citation verifier scope — Risk / Issue / Decision tokens only, or
+  also Premortem / Expert-Criticism passages? Start narrow.
+- Correlation-group ergonomics — full matrix, pairwise ρ, or named
+  groups with single ρ? Named groups are lightest cognitive load.
+- Burn-rate detection — should the extract emit a dedicated
+  `is_burn` flag on `key_values` so `validate-parameters` can check
+  the `burn × duration` multiplication is wired up downstream?
+  Cleaner than relying on a formula parser.
+- `plan_type` enumeration — current taxonomy is free-form. To make
+  R2.2 work (megaproject lognormal default), the type list needs to
+  be a controlled vocabulary. Where does that vocabulary live, and
+  who maintains it?
+- Bernoulli-modelling existential gates as a follow-up to R2.1 —
+  what does the LLM need to know to assign survival probabilities
+  responsibly? Anchor on the same Premortem / Risk-register passages
+  used for cost bounds, or require a dedicated extraction step?

--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -1,0 +1,263 @@
+# 2026-05-20 — Plan: addressing Gemini's Monte Carlo methodology critique
+
+## Context
+
+Gemini reviewed the napkin_math output for `20251114_paperclip_automation`
+(snapshot 49) and surfaced five flaws on top of the earlier correlation
+comment. Four of the five flaws point at upstream LLM stages
+(extract / bounds), one points at the runner, and one is shared between
+upstream prompts and a deterministic backstop. This document maps each
+flaw to the `.claude/skills` (and the Python infrastructure) that has to
+change, and names the new skill(s) that the gap analysis surfaces.
+
+Source critiques:
+
+- **Independence** — runner samples every variable independently, so
+  inflation can land at p95 in the same trial labor cost lands at p05.
+- **Disconnected aggregates** — `actual_total_project_cost_usd` is drawn
+  as an independent bounded variable instead of computed from its
+  constituents. Run #4,592 can pair sub-component p95s with a total p05.
+- **Base = target fallacy** — `generate-bounds` defaults `base` to the
+  commitment value. With `low = 1.0`, `base = 2.0`, `high = 4.5`, the
+  triangular CDF guarantees ~70% of mass above the threshold; the 29.3%
+  gate-pass figure is a property of the bound shape, not the plan.
+- **Bounded vs. fat-tail** — triangular `high` is a hard ceiling, so 0%
+  of runs see a $700k overrun on a $500k project. Real R&D blowouts are
+  fat-tailed (lognormal).
+- **Hallucinated citation** — a `generate-bounds` rationale cited
+  "Risk-5 grading-protocol variance" in a paperclip-automation plan
+  whose Risk 5 is about machinery supply-chain delays. Context leak,
+  silently shipped.
+
+## Per-flaw mapping
+
+### Flaw 1 — Disconnected aggregates
+
+**Root cause:** the extraction stage emitted `actual_total_project_cost_usd`
+as a `missing_values_to_estimate` entry. The bounds stage then dutifully
+bounded it. The runner has no way to know it should equal the sum of
+sub-costs because no `formula_hint` declares that relationship.
+
+**Skills to change:**
+
+- `extract-parameters-from-full`, `extract-parameters-from-digest` —
+  system prompts must require: when the report names constituents of a
+  total (or any compound aggregate), the total is a
+  `recommended_first_calculations` entry with
+  `formula_hint = A + B + C + ...`, **never** a
+  `missing_values_to_estimate` entry.
+- `validate-parameters` — add a structural check: a variable that is the
+  LHS of a sum-formula in another entry MUST NOT also appear in
+  `missing_values_to_estimate`. Same posture as the existing 16
+  structural rules. Fail-loud.
+- `generate-bounds` — already strips bounds for threshold variables via
+  `strip_threshold_bounds`. Extend the same deterministic backstop to
+  strip bounds for any variable declared as a calculation LHS. Belongs
+  next to the existing strip logic in `run_monte_carlo.py`.
+
+`generate-calculations` does not need to change. If `formula_hint` is
+declared, the existing code generator implements the sum correctly.
+
+### Flaw 2 — Base = target fallacy
+
+**Root cause:** the "actual-vs-commitment default" rule in
+`generate-bounds/system-prompt.txt` was added defensively. Without it,
+the LLM was shifting `base` past the threshold with no anchor,
+producing baseline-fail verdicts that were prompt artifacts. The current
+rule overcorrects in the opposite direction: it forces `base` to the
+commitment regardless of whether the report itself names a likely
+shortfall.
+
+**Skills to change:**
+
+- `generate-bounds` (system-prompt.txt) — rewrite the actual-vs-commitment
+  paragraph as a conditional rule:
+  - If a Premortem / Expert Criticism / Risk-register passage forecasts
+    a gap between commitment and reality, anchor `base` on the
+    plan-internal gap estimate and cite it.
+  - Otherwise, fall back to the commitment value AND tag
+    `source: "assumption"` (today the rule silently emits `data`).
+  - Make the asymmetry visible in the rationale.
+- `summarize-assessment` — surface in the Missing-inputs-ranked-by-impact
+  table whether `base` was anchored on a report passage or on the
+  commitment-default. The reader currently cannot tell.
+
+This is the change most likely to swing gate verdicts on existing plans,
+so run the Self-Improve optimization loop on `generate-bounds` before
+shipping.
+
+### Flaw 3 — Absence of correlation
+
+**Root cause:** runner declares `correlation_groups: []` in
+`DEFAULT_SETTINGS` (line 35), reads it from user settings (line 101),
+and then never references it during sampling. The monte-carlo SKILL.md
+honestly says so at line 70.
+
+**Skills to change:**
+
+- `generate-bounds` — extend output schema with an optional
+  `correlations` block (sibling of the per-variable entries). Declared
+  by the LLM based on plan-internal logic ("if PLC is hostile, OPC UA
+  bid is high AND manual-intervention hours are high").
+- `monte-carlo` (runner code) — implement Gaussian-copula sampling.
+  Build rank-correlated uniforms for variables in a group, feed them
+  through each variable's inverse-triangular (or inverse-lognormal).
+  Inputs not in any group stay independent. ~80 lines.
+- `summarize-assessment` — add a slideshow section disclosing the
+  independence assumption when no correlations are declared; surface
+  declared correlation groups when they are.
+
+**No new skill needed** for correlations. Folding them into
+`generate-bounds` keeps the artifact count down. If correlations grow
+into a multi-page artifact in practice, split out later.
+
+### Flaw 4 — Bounded distributions for unbounded risks
+
+**Root cause:** `sampling_discipline` enumerates `fixed / bernoulli_gate
+/ integer / fraction / continuous` and all continuous draws are
+triangular by default. Triangular has zero mass past `high`, which is
+wrong for R&D / integration cost.
+
+**Skills to change:**
+
+- `generate-bounds` — add `sampling_discipline: "lognormal"` (and
+  possibly `"pert"`) to the enumeration. System prompt must document
+  when to use it: cost or duration variables tied to integration /
+  R&D / legacy-hardware risk, especially when the source report names
+  "scope creep" / "unknown unknowns". For lognormal, `low / high` mean
+  P5 / P95 rather than hard cutoffs.
+- `monte-carlo` (runner code) — implement lognormal and PERT samplers.
+  Keep triangular as default. Update `VALID_DISCIPLINES`.
+- `run-scenarios` — decide policy. Scenarios evaluate at `low / base /
+  high` deterministically; for a lognormal that means P5 / median / P95.
+  Either run-scenarios learns the new disciplines or `generate-bounds`
+  is constrained to triangular for variables that scenarios must
+  evaluate. Simplest first cut: scenarios continue to use triangular
+  semantics (`base` as point estimate, `low` and `high` as the three-
+  point bracket); the LLM may not select lognormal for variables that
+  also need a scenario row.
+- `validate-parameters` — extend the discipline-allowed list.
+- `summarize-assessment` — disclose in the slideshow when any variable
+  uses a fat-tail discipline; cite it as a strength, not a footnote.
+
+### Flaw 5 — Hallucinated Risk-N citations
+
+**Root cause:** the existing self-audit in `generate-bounds/SKILL.md:30`
+says rationale citations must "substantively support the claim". The
+LLM didn't catch a clean context leak (Risk 5 referenced in a rationale
+text that is about a different topic than the actual Risk 5).
+
+**Skills to change:**
+
+- `generate-bounds` — strengthen the self-audit instruction with
+  concrete failure examples (context-leak: citation refers to a Risk
+  that exists by number but is about a different topic). Examples beat
+  abstract rules.
+
+**New skill (or new step in `validate-parameters`):**
+
+- **`verify-bounds-citations`** — deterministic Python, no LLM call.
+  Parse Risk N / Issue N / Decision N tokens from each rationale string
+  in `bounds.json`. For each citation, fetch the corresponding section
+  from the source report (or from `parameters.json` if it stores the
+  cited content). Compare topical keywords from the rationale against
+  the cited section. Fail loud when topical overlap is below threshold.
+  Same fail-loud posture as `SchemaError`. Re-run `generate-bounds`.
+
+  Two implementation options for keyword overlap:
+  1. Substring / shared-stem match against a small stopword list.
+     Brittle on morphology (grading / grade) but zero dependencies.
+  2. Lightweight TF-IDF or rapidfuzz overlap against the cited section's
+     tokens. Adds a dep.
+
+  I'd start with (1) and tighten if it misses Gemini's class of
+  failure.
+
+This is the **strongest argument for a new skill** in the inventory.
+It is deterministic, naturally orthogonal to the LLM stages it audits,
+and follows the existing pattern of `validate-parameters` (also
+deterministic, also a structural audit).
+
+## Skill inventory summary
+
+### Changed skills
+
+| Skill | Flaw(s) | Type of change |
+|---|---|---|
+| `extract-parameters-from-full` | 1 | System prompt: aggregates must be calculations |
+| `extract-parameters-from-digest` | 1 | System prompt: aggregates must be calculations |
+| `generate-bounds` | 1, 2, 3, 4, 5 | System prompt + schema (correlations, lognormal); self-audit examples |
+| `generate-calculations` | — | No change |
+| `validate-parameters` | 1, 4 | New structural checks (aggregate-not-bounded, expanded discipline enum) |
+| `monte-carlo` (runner) | 1, 3, 4 | Strip aggregate bounds; copula sampler; lognormal/PERT samplers |
+| `run-scenarios` | 4 | Policy decision on lognormal semantics |
+| `summarize-assessment` | 2, 3, 4 | Disclose anchoring, correlation groups, fat-tail discipline in slides |
+| `run-napkin-math-pipeline` | 5 | Orchestrate the new verifier between bounds and calculations |
+| `test-napkin-math` | 1, 3, 4, 5 | Add smoke fixtures exercising lognormal, correlation, aggregate-stripping, citation-failure |
+
+### New skills
+
+- **`verify-bounds-citations`** — deterministic post-processor. Audits
+  `bounds.json` rationale citations against the source report.
+  Fail-loud, re-run-`generate-bounds` posture. Plugs into
+  `run-napkin-math-pipeline` between Stage 5 (`generate-bounds`) and
+  Stage 6 (`generate-calculations`).
+
+I do **not** recommend a separate `generate-correlations` skill. Folding
+correlations into `generate-bounds` matches how `sampling_discipline`
+and `default_pass_probability` are already declared there. Split later
+only if correlations grow large enough to deserve their own artifact.
+
+## Sequencing
+
+Rough order of return on effort:
+
+1. **Prompt-only fixes** — Flaw 2 (base anchoring) and Flaw 5
+   (self-audit examples) in `generate-bounds/system-prompt.txt`. Run
+   the Self-Improve optimization loop to detect regressions against
+   the existing 14 plans.
+2. **Deterministic backstops** — add `verify-bounds-citations` (Flaw 5)
+   and the aggregate-not-bounded check in `validate-parameters`
+   (Flaw 1).
+3. **Extraction tightening** — update `extract-parameters-from-full` /
+   `extract-parameters-from-digest` to declare aggregates as
+   calculations (Flaw 1). Validates the backstop above.
+4. **Runner: correlation sampling** — implement copula in
+   `run_monte_carlo.py`; extend `generate-bounds` schema; update
+   slideshow disclosure (Flaw 3).
+5. **Runner: lognormal / PERT** — extend `VALID_DISCIPLINES`; implement
+   samplers; decide `run-scenarios` policy; extend slideshow (Flaw 4).
+
+Steps 1–3 reach the largest quality gains without touching the runner.
+Steps 4–5 are infrastructure changes that pay off across every plan.
+
+## What does not change
+
+- The runner's posture of "everything semantic comes from upstream
+  stages, nothing is pattern-matched on id strings" stays. Every change
+  above is either a new schema field (declared by an LLM stage) or a
+  deterministic check on existing structure.
+- The slideshow's worst-gate framing stays — none of the flaws
+  contradict it.
+- `summarize-assessment`'s `TRUST_NOT_VALIDATED` list shrinks as flaws
+  land. "Independence or correlation assumptions across inputs" moves
+  from "we don't model it" to "the user (or LLM) declared these groups"
+  once Flaw 3 ships.
+
+## Open questions
+
+- Aggregate stripping in `generate-bounds` — strip silently (like
+  thresholds today) or warn loudly? Threshold-strip warnings are
+  already emitted; aggregates likely deserve the same treatment.
+- Lognormal in `run-scenarios` — accept the inconsistency (scenarios
+  use base/low/high triangular semantics; Monte Carlo uses lognormal
+  P5/P95), or constrain `generate-bounds` to triangular for any
+  variable that also has a scenario row? Inclines toward the latter,
+  to keep the deterministic and stochastic layers comparable.
+- Citation verifier scope — only Risk N / Issue N / Decision N, or
+  also Premortem / Expert-Criticism passages? Start narrow; widen if
+  the next Gemini critique catches a missed leak.
+- Correlation-group declaration ergonomics — is the LLM expected to
+  emit a full correlation matrix, or pairwise ρ values, or named
+  groups with a single ρ? Named groups with single ρ is the lightest
+  cognitive load; matrices belong in a later iteration.

--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -375,41 +375,238 @@ I do **not** recommend separate skills for correlations, burn-rate
 detection, FX decomposition, or composite-band aggregation. These all
 sit inside existing stages with prompt and schema changes only.
 
-## Sequencing
+## Implementation order
 
-Rough order of return on effort:
+Upstream-first. Each phase ships a focused set of changes, the
+napkin-math pipeline is re-run end-to-end against the 14-plan
+baseline, and the next phase only starts once the previous phase's
+output looks honest. Build order follows pipeline order (Stage 1 →
+Stage 8) so each downstream stage sees inputs that already encode the
+new structure.
 
-1. **Composite-band cap rule (R2.1)** — `summarize-assessment` only.
-   Pure verdict-rendering change. Largest single credibility impact:
-   the 100%-Robust megaproject result is the loudest failure. Apply
-   retroactively against all 14 existing assessments to verify the
-   rule doesn't over-penalize benign plans.
-2. **Prompt-only fixes in `generate-bounds/system-prompt.txt`** —
-   R1.2 (base anchoring), R1.5 (citation self-audit examples), R2.2
-   (plan_type-driven lognormal default). Run Self-Improve against the
-   14-plan baseline before shipping.
-3. **Compress-stage prompt edits in `compress_report_section.py`** —
-   R2.3 burn-rate preservation in numeric_values + burn/duration
-   pairing in missing_data; R2.5 capacity-requirement detection in
-   gates_and_thresholds. Lower-risk than the bounds prompt because
-   compress is upstream of the LLM judgments that have been
-   benchmarked by Self-Improve; regenerate snapshot fixtures.
-4. **Deterministic backstops** — `verify-bounds-citations` (R1.5);
-   `validate-parameters` extensions for R1.1 (aggregate-not-bounded)
-   and R2.5 (requirement-margin pairing).
-5. **Extraction tightening** — `extract-parameters-from-full` /
-   `extract-parameters-from-digest` prompts for R1.1, R2.3, R2.4,
-   R2.5 (decomposed equations + explicit thresholds).
-6. **Runner: correlation sampling (R1.3)** — copula implementation +
-   `generate-bounds` schema extension. Slideshow disclosure either way.
-7. **Runner: lognormal / PERT (R1.4, R2.2)** — extend
-   `VALID_DISCIPLINES`; decide `run-scenarios` policy; extend
-   slideshow disclosure with `plan_type` context.
+The ROI argument that R2.1 (composite-band cap, the "100% Robust
+datacenter" fix) is the loudest single failure is acknowledged but
+deferred: shipping R2.1 first means calibrating the cap rule against
+still-broken upstream data. Build from the bottom up; the cap rule
+lands at Phase 9 against assessments whose modelled-gate verdicts are
+already correct.
 
-Step 1 alone closes the most visible methodological gap. Steps 2–5
-reach the bulk of remaining quality gains without touching the
-runner. Steps 6–7 are infrastructure changes that pay off across
-every plan.
+### Phase 1 — Compress stage (`compress_report_section.py`)
+
+**Changes**
+
+- `NUMERIC_VALUES_BUCKET_PROMPT`: preserve per-period units (`/yr`,
+  `/mo`, `/km²`, `/FTE`) in the label; require the modelling role to
+  read like "burn rate scaling with <X>". (R2.3)
+- `MISSING_DATA_BUCKET_PROMPT`: extend the denominator-pairing rule
+  with "a per-period burn rate needs the matching duration". (R2.3)
+- `GATES_AND_THRESHOLDS_BUCKET_PROMPT`: capacity requirements count
+  as gates even when the source frames them as capacity calculations.
+  (R2.5)
+
+**Verification gate**
+
+- Re-run the 24 compress calls (4 sections × 6 buckets) against the
+  paperclip and datacenter plans.
+- Spot-check the digests: holding cost surfaces as `€257.6M/yr` (not
+  `€257.6M`); `32.2 km² for 9 GW` surfaces in `gates_and_thresholds`,
+  not buried in capacity prose.
+- Regenerate snapshot fixtures; no compress smoke regressions.
+
+### Phase 2 — Extract stages (`extract-parameters-from-{full,digest}`)
+
+**Changes**
+
+- Aggregates declared as `recommended_first_calculations`, not
+  `missing_values_to_estimate`. (R1.1)
+- Per-period rates trigger `derived = burn_rate * duration`
+  calculations; bound the duration, not the dependent cost. (R2.3)
+- Explicit decomposed assumption blocks (FX Q5 and similar) preserved
+  as calculations rather than collapsed into a flat variable. (R2.4)
+- Capacity-requirement gates use either `>= <requirement>` or a
+  margin variable with `>= 0`. (R2.5)
+
+**Verification gate**
+
+- Re-run extract on paperclip and datacenter using the Phase-1
+  digests.
+- `parameters.json` checks: total cost in `recommended_first_calculations`;
+  holding cost as a calculation, not a missing value; phase-1 CAPEX
+  surplus decomposed into civil_works + remediation + hardware
+  components; buildable-area gate either `>= 32.2` or a margin
+  variable.
+- Run the existing 14-plan baseline. Any plan whose `parameters.json`
+  shifts entries between `missing_values_to_estimate` and
+  `recommended_first_calculations` is expected and reviewed.
+
+### Phase 3 — Validate stage (`validate-parameters`)
+
+**Changes**
+
+- New structural rule: LHS of a sum-formula MUST NOT also appear in
+  `missing_values_to_estimate`. (R1.1)
+- New structural rule: if a `*_required` key value exists, a
+  margin / surplus variable must also exist. (R2.5)
+- Expand `sampling_discipline` enum to include `lognormal` / `pert`
+  (allow, do not require yet). (R1.4, R2.2)
+
+**Verification gate**
+
+- Validation runs cleanly on the Phase-2 `parameters.json` for all 14
+  plans.
+- Deliberately-malformed fixtures (total bounded AND computed;
+  requirement without margin) fail validation with the new rules.
+
+### Phase 4 — Generate-bounds (`generate-bounds`)
+
+**Changes**
+
+- System prompt: base-anchoring rewritten as a conditional rule —
+  anchor on Premortem / Risk-register passages when they forecast a
+  gap; fall back to commitment value with `source: "assumption"`.
+  (R1.2)
+- System prompt: self-audit examples for citation context-leak (Risk
+  N referenced by number but with wrong topical content). (R1.5)
+- System prompt: `plan_type`-driven lognormal default for
+  hyperscale / geopolitical_megaproject. (R2.2)
+- Output schema: optional `correlations` block. (R1.3)
+- Output schema: `sampling_discipline` enum extended to lognormal /
+  pert. (R1.4, R2.2)
+- Code: extend `strip_threshold_bounds` to also strip bounds for any
+  variable declared as a calculation LHS. (R1.1)
+
+**Verification gate**
+
+- Run Self-Improve against the 14-plan baseline. Flag any gate
+  verdict that shifts more than one band for manual review.
+- Paperclip: `actual_manual_intervention_hours_per_week` `base`
+  should move off the 2.0-commitment if Premortem / Risk anchor it
+  higher.
+- Datacenter: CAPEX variables should be lognormal.
+
+### Phase 5 — Verify-bounds-citations (new deterministic step)
+
+**Changes**
+
+- New deterministic Python: parse Risk / Issue / Decision N tokens
+  from `bounds.json` rationale strings; fail loud when topical
+  overlap with the cited section is below threshold. (R1.5)
+- Wire into `run-napkin-math-pipeline` between Stage 5
+  (`generate-bounds`) and Stage 6 (`generate-calculations`).
+
+**Verification gate**
+
+- Re-run on the original paperclip bounds (the one with the Risk-5
+  grading-protocol hallucination). The verifier MUST fail loud.
+- Re-run on the Phase-4 bounds: citation overlap is high enough that
+  the verifier passes.
+
+### Phase 6 — Generate-calculations (`generate-calculations`)
+
+**Changes**
+
+- None required; the existing code generator already handles new
+  `formula_hint` entries from Phase 2.
+
+**Verification gate**
+
+- Regenerate `calculations.py` for paperclip and datacenter; module
+  imports cleanly and includes the new aggregate / burn-rate / FX
+  functions.
+- `test-napkin-math` smoke tests pass.
+
+### Phase 7 — Run-scenarios (`run-scenarios`)
+
+**Changes**
+
+- Policy: scenarios stay triangular-only; `generate-bounds` may NOT
+  select lognormal / pert for any variable that also has a scenario
+  row. Document the constraint in the bounds system prompt. (R1.4,
+  R2.2)
+
+**Verification gate**
+
+- Three-point scenarios resolve for all 14 plans; no NaN /
+  divide-by-zero. Bound widths remain readable.
+
+### Phase 8 — Monte Carlo runner (`run_monte_carlo.py`)
+
+**Changes**
+
+- Strip bounds for calculation-LHS variables (deterministic backstop
+  paralleling `strip_threshold_bounds`). (R1.1)
+- Implement Gaussian-copula sampling; honour `correlations` block
+  from `bounds.json` plus `correlation_groups` from
+  `montecarlo_settings.json`. (R1.3)
+- Implement lognormal and PERT samplers; extend `VALID_DISCIPLINES`.
+  (R1.4, R2.2)
+- Extend `test-napkin-math` smoke fixtures to exercise the new
+  samplers and the new strip rule.
+
+**Verification gate**
+
+- Smoke tests pass.
+- Re-run on the 14-plan baseline; pass-rate diffs from the
+  pre-correlation, pre-lognormal runs are explainable per plan
+  (correlation shrinks pass rate on plans with co-moving cost
+  drivers; lognormal shrinks pass rate on plans with bounded-tail
+  CAPEX bounds).
+
+### Phase 9 — Summarize-assessment (`summarize-assessment`)
+
+**Changes**
+
+- Composite-band cap on `overall_risk_band` based on
+  `unmodelled_gates.length`. Monotonic: more unmodelled gates can
+  only worsen the headline. (R2.1)
+- New manifest field `unmodelled_gate_penalty` naming exactly what
+  was applied. (R2.1)
+- Surface `threshold_basis` more prominently in the gate-verdicts
+  table; flag `model_defined / >= 0` next to a value-bearing
+  requirement. (R2.5)
+- Disclose anchoring source, correlation groups, discipline (and
+  `plan_type` default) in the slideshow. (R1.2, R1.3, R1.4, R2.2)
+
+**Verification gate**
+
+- Re-render all 14 plans' assessments. Calibrate the cap-rule
+  thresholds (placeholder K = 3 / 5) against the actual spread of
+  `unmodelled_gates.length` across the corpus.
+- The datacenter plan no longer reads "100% Robust"; it reads
+  something like "100% Robust (modelled gates), capped at Marginal
+  due to 4 unmodelled existential gates".
+- No benign plan is over-penalized into a worse band than its
+  modelled verdict justifies.
+
+### Phase 10 — Documentation
+
+**Changes**
+
+- Update `methology.md` and the README to describe the composite-band
+  cap rule, the new disciplines, the new verifier step, and the
+  declared correlation surface. (R2.1, R1.3, R1.4, R1.5, R2.2)
+- Update the `run-napkin-math-pipeline` orchestrator skill so the
+  new `verify-bounds-citations` step appears in the documented
+  pipeline.
+
+**Verification gate**
+
+- Slideshow content slides (Slide A / Slide B) match actual pipeline
+  behaviour; no drift between code and prose.
+
+### Cross-phase notes
+
+- Each phase's verification gate runs against the **14-plan
+  baseline**, not just paperclip and datacenter. Single-plan checks
+  exist to catch the specific failure that motivated the change;
+  the 14-plan run catches over-correction.
+- Phases 1, 2, 4, 8, 9 each change LLM-facing prompts or sampling
+  behaviour; expect snapshot diffs in `output/v{N+1}/<plan>/`
+  artifacts. Phases 3, 5, 6, 7, 10 should not move artifact contents
+  except where Phase 1–2 changes propagated.
+- If a phase's verification gate fails, the rollback is to the
+  previous phase's tip (each phase is a small set of commits / a
+  small PR).
 
 ## What does not change
 


### PR DESCRIPTION
## Summary

Adds [experiments/napkin_math/docs/20260520_plan.md](experiments/napkin_math/docs/20260520_plan.md), a planning document that maps Gemini's five-flaw methodology review of snapshot 49's `20251114_paperclip_automation` output (plus the earlier correlation comment) to the `.claude/skills` and runner code that need changes.

## What it identifies

**10 skills to change** — heaviest load on `generate-bounds` (touched by all five flaws). Also: `extract-parameters-from-full`, `extract-parameters-from-digest`, `validate-parameters`, `monte-carlo` (runner), `run-scenarios`, `summarize-assessment`, `run-napkin-math-pipeline`, `test-napkin-math`. `generate-calculations` confirmed no-change.

**1 new skill** — `verify-bounds-citations`, a deterministic post-processor that audits rationale citations (Risk N / Issue N / Decision N) in `bounds.json` against the source report. Backstop for the kind of context-leak Gemini caught (Risk 5 cited as "grading-protocol variance" in a paperclip plan whose Risk 5 is about supply-chain delays).

**Not recommended:** a separate `generate-correlations` skill. Correlations should fold into `generate-bounds` next to the existing `sampling_discipline` and `default_pass_probability` declarations.

## Sequencing rationale

1. Prompt-only fixes (Flaws 2, 5) — base-anchoring rewrite + self-audit examples in `generate-bounds/system-prompt.txt`. Run Self-Improve loop to detect regressions.
2. Deterministic backstops (Flaws 1, 5) — `verify-bounds-citations` + aggregate-not-bounded check in `validate-parameters`.
3. Extraction tightening (Flaw 1) — aggregates declared as `recommended_first_calculations`, not `missing_values_to_estimate`.
4. Runner: correlation sampling (Flaw 3) — Gaussian copula; `correlation_groups` setting is already declared but silently ignored in `run_monte_carlo.py:35,101`.
5. Runner: lognormal / PERT (Flaw 4) — extend `VALID_DISCIPLINES`; decide `run-scenarios` semantics.

## For reviewers

- This is a planning document, not an implementation. No code or skill files change.
- Open questions are flagged at the bottom of the doc (lognormal in `run-scenarios`, citation-verifier scope, correlation-group ergonomics) — none need answers to merge the plan, but they will need answers before the corresponding work starts.
- The runner's "everything semantic comes from upstream stages" posture is preserved across all proposed changes.

## Test plan

- [ ] Skim the doc end-to-end; confirm the per-flaw → skill mapping reads correctly
- [ ] Confirm the sequencing reflects what you'd want to land first

🤖 Generated with [Claude Code](https://claude.com/claude-code)