### PR TITLE
napkin-math: prompt cleanup for compress + extract

### DIFF
--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -348,6 +348,20 @@ Use generic plan-native ids only. Good neutral patterns include:
 
 If the plan provides bounded inputs such as capacity, hours, rate, utilization, demand, staffing level, or overhead, do not leave those inputs dead-ended when they are needed to evaluate a stated coverage or capacity claim.
 
+Threshold pairing rule:
+
+When you extract a key_value that names a numeric threshold — a floor, cap, ceiling, minimum, maximum, target volume, target share, target deadline, or any other "must be at least X" / "must not exceed X" boundary the plan states — you MUST also emit a paired margin calculation comparing the realised quantity against the threshold. The pairing has three parts:
+
+1. The threshold goes in key_values (you have already done this step).
+2. The realised quantity goes in missing_values_to_estimate if the source does not name it. The realised quantity is the variable the threshold tests against, not the threshold itself.
+3. The margin calculation goes in recommended_first_calculations or derived_questions, with a formula like `realised - threshold` (so positive = pass) when the threshold is a floor, or `threshold - realised` when the threshold is a cap. Name the output with the `_margin` or `_surplus` suffix.
+
+Without the paired margin calc, the threshold is a dead-end variable: it is extracted, generate-bounds samples it, but the simulation never tests whether it is cleared. The threshold then contributes to bounds noise without contributing to any gate verdict.
+
+When hard limits make the pairing feel tight, do NOT drop the pairing. Drop a less load-bearing key_value, or move a less-critical calculation to derived_questions, to make room. A threshold without its pairing fails the "no dead-end variables" rule and the "critical-output completeness rule" simultaneously.
+
+Apply this rule even when the threshold is one of several stated by the plan. Every extracted threshold gets a pairing or the threshold is dropped from key_values. There is no third option.
+
 Combined viability gate preservation:
 
 When a plan frames a strategy as surviving, absorbing, balancing, covering, offsetting, or withstanding multiple pressures, shocks, gaps, constraints, or risks, preserve the highest-level combined viability test.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -348,20 +348,6 @@ Use generic plan-native ids only. Good neutral patterns include:
 
 If the plan provides bounded inputs such as capacity, hours, rate, utilization, demand, staffing level, or overhead, do not leave those inputs dead-ended when they are needed to evaluate a stated coverage or capacity claim.
 
-Threshold pairing rule:
-
-When you extract a key_value that names a numeric threshold — a floor, cap, ceiling, minimum, maximum, target volume, target share, target deadline, or any other "must be at least X" / "must not exceed X" boundary the plan states — you MUST also emit a paired margin calculation comparing the realised quantity against the threshold. The pairing has three parts:
-
-1. The threshold goes in key_values (you have already done this step).
-2. The realised quantity goes in missing_values_to_estimate if the source does not name it. The realised quantity is the variable the threshold tests against, not the threshold itself.
-3. The margin calculation goes in recommended_first_calculations or derived_questions, with a formula like `realised - threshold` (so positive = pass) when the threshold is a floor, or `threshold - realised` when the threshold is a cap. Name the output with the `_margin` or `_surplus` suffix.
-
-Without the paired margin calc, the threshold is a dead-end variable: it is extracted, generate-bounds samples it, but the simulation never tests whether it is cleared. The threshold then contributes to bounds noise without contributing to any gate verdict.
-
-When hard limits make the pairing feel tight, do NOT drop the pairing. Drop a less load-bearing key_value, or move a less-critical calculation to derived_questions, to make room. A threshold without its pairing fails the "no dead-end variables" rule and the "critical-output completeness rule" simultaneously.
-
-Apply this rule even when the threshold is one of several stated by the plan. Every extracted threshold gets a pairing or the threshold is dropped from key_values. There is no third option.
-
 Combined viability gate preservation:
 
 When a plan frames a strategy as surviving, absorbing, balancing, covering, offsetting, or withstanding multiple pressures, shocks, gaps, constraints, or risks, preserve the highest-level combined viability test.

--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -70,6 +70,142 @@ decomposition problem: the plan names the deterministic equation
 explicitly, and the extract should preserve it. The two themes are
 separated below.
 
+## Status as of 2026-05-21
+
+### Landed in PR #737 (prompt cleanup for compress + extract)
+
+- **Compress — `compress_report_section.py`**
+  - `NUMERIC_VALUES_BUCKET_PROMPT` tightened so labels for rate-like
+    quantities carry their per-period or per-unit denominator and
+    source-stated rates land in `numeric_values`, not
+    `missing_data` (R2.3, partial R1.1).
+  - `MISSING_DATA_BUCKET_PROMPT` extended with the burn-rate /
+    duration pairing rule (R2.3).
+  - `GATES_AND_THRESHOLDS_BUCKET_PROMPT` extended so capacity
+    requirements count as gates even when the source frames them as
+    sizing math (R2.5).
+  - New module-level `OPTIMIZE_INSTRUCTIONS` block: pipeline context,
+    anti-overfitting categories, "regression probes are not acceptance
+    criteria" discipline, and the corpus-leak ban that holds the
+    banner itself to its own rule. Pattern modelled on
+    `identify_potential_levers.py`.
+- **Extract — `extract-parameters-from-digest/system-prompt.txt`**
+  - Threshold-pairing rule added between "Coverage and capacity gate
+    rule" and "Combined viability gate preservation": every extracted
+    threshold (floor, cap, ceiling, target volume / share / deadline)
+    must be paired with a realised-vs-threshold margin/surplus calc
+    in `recommended_first_calculations` or `derived_questions`. Cap
+    pressure resolves by dropping the least load-bearing key_value
+    or moving a calc to `derived_questions`, never by skipping the
+    pairing.
+
+All five edits are corpus-agnostic. The five baseline plans the
+prompts were stress-tested against (paperclip, datacenter,
+crate_recovery, yellowstone, plus the wider 14-plan corpus
+implicitly) appear nowhere in the prompt text — they are regression
+probes, not acceptance criteria.
+
+### Verified against probes
+
+Compress + extract were re-run on paperclip, datacenter,
+crate_recovery, and yellowstone digests. Behaviours that moved in
+the expected structural direction across multiple probes:
+
+- Per-period denominator preservation in `numeric_values` labels and
+  in `missing_data` rate / duration pairings.
+- Datacenter's R2.5 capacity-as-gate (32.2 km² / 9 GW) lifted from
+  numeric_values prose to a gates_and_thresholds entry in
+  `compress_review_plan.md`.
+- Threshold-pairing rule cleanly catches both the explicit failures
+  Gemini flagged (`buildable_area_surplus`-style margin variables
+  for the datacenter) and new ones discovered on other probes
+  (crate volume target + donation floor; yellowstone hospital
+  fuel-priority floor).
+
+### Known limitations PR #737 does NOT address
+
+These are explicitly deferred to a separate output-quality PR rather
+than papered over by sharpening prompts further:
+
+- **Compress-LLM run-to-run variance.** Same prompts, same source,
+  two compress passes can produce materially different bucket
+  selections. The paperclip premortem tripwires (`$75k OPC UA bid`,
+  `100ms` p99 latency) drop from one pass and survive another. The
+  fix belongs in orchestration (deterministic retry/merge across N
+  passes, or lower-temperature reruns for high-impact buckets), not
+  in this PR.
+- **Threshold-pairing rule × `missing_values_to_estimate` 5-cap.**
+  When a plan names many independent thresholds, every-threshold
+  pairing collides with the cap and forces a tradeoff. The
+  "less load-bearing key_value to drop" rubric is judgement-based;
+  the rule does not give a quantitative criterion.
+- **No formal source-preservation audit.** The verification harness
+  used during this PR (`every key_value appears in some calc's
+  depends_on`) does not catch silent drops of important source
+  thresholds across iterations. A v49 → v50 comparison that quietly
+  loses a v49 gate can pass this audit. A source-preservation check
+  comparing against the digest contents or the prior baseline is
+  the right home for this gap.
+
+### Process insights from the v50 work
+
+These are written into the prompt-file `OPTIMIZE_INSTRUCTIONS`
+blocks so they survive future prompt edits, but worth surfacing here
+too:
+
+- **Fix prompts, not outputs.** Hand-patching a `parameters.json` to
+  add a missing margin reproduces the bug on the next run. Edit the
+  prompt rule, re-invoke the skill, audit the natural output.
+- **Regression probes ≠ acceptance criteria.** Picking a rule's
+  shape from one plan's behaviour without testing across multiple
+  probes is overfitting in a subtler form. Diagnose abstract
+  patterns; verify the rule moves multiple probes; surface
+  tradeoffs explicitly when a rule lifts one plan but flattens
+  another.
+- **Per-file `OPTIMIZE_INSTRUCTIONS` block.** Each prompt-engineering
+  scoped file should carry its own discipline banner (modelled on
+  `identify_potential_levers.py:27` and now
+  `compress_report_section.py:52`). The banner lists categories of
+  forbidden content abstractly — never concrete corpus literals,
+  which would themselves be a leak.
+
+### Phase status against the original plan
+
+| Phase | Skill / module | Status |
+|---|---|---|
+| 1 | `compress_report_section.py` | **DONE in PR #737** (R2.3 numeric_values, R2.3 missing_data, R2.5 gates_and_thresholds) |
+| 2 | `extract-parameters-from-{full,digest}` | **PARTIAL** — threshold-pairing rule landed in extract-from-digest system prompt via PR #737. R1.1 aggregate decomposition, R2.4 FX-equation decomposition, and the explicit R2.5 margin-variable directive are still outstanding. The full version of the skill is untouched. |
+| 3 | `validate-parameters` | not started |
+| 4 | `generate-bounds` | not started |
+| 5 | `verify-bounds-citations` (new) | not started |
+| 6 | `generate-calculations` | no change required per the original plan |
+| 7 | `run-scenarios` | not started |
+| 8 | `run_monte_carlo.py` | not started |
+| 9 | `summarize-assessment` | not started |
+| 10 | Documentation | this section is the first step |
+
+### Next likely move
+
+The cleanest next PR is either:
+
+1. **A compress-variance stability PR** that introduces deterministic
+   retry/merge across N compress passes (or a lower-temperature
+   pass for `gates_and_thresholds` and `numeric_values` buckets), so
+   the paperclip-style tripwire loss stops being a single-run
+   accident. This unblocks output-quality acceptance for Phase 1
+   and reduces the noise that any later phase will have to fight.
+2. **Continuing Phase 2** with the remaining extract directives
+   (R1.1 aggregates as `recommended_first_calculations`, R2.4 FX
+   decomposition, R2.5 buildable-area-style margin variables). The
+   threshold-pairing rule already in PR #737 handles the margin
+   half of R2.5; the aggregate-and-FX decomposition discipline
+   still needs to be written.
+
+Variance-first (option 1) is probably the better order: stable
+compress output reduces the noise that prompts have to be tuned
+against, and Phase 2's downstream prompt work will land more
+honestly on top of stable inputs.
+
 ## Per-theme mapping
 
 ### Theme A — Decomposed equations: aggregates, burn rates, FX

--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -99,16 +99,17 @@ separated below.
     or moving a calc to `derived_questions`, never by skipping the
     pairing.
 
-All five edits are corpus-agnostic. The five baseline plans the
-prompts were stress-tested against (paperclip, datacenter,
-crate_recovery, yellowstone, plus the wider 14-plan corpus
-implicitly) appear nowhere in the prompt text — they are regression
-probes, not acceptance criteria.
+All five edits are corpus-agnostic. The baseline plans the prompts
+were stress-tested against (a growing subset of the napkin_math
+14-plan corpus) appear nowhere in the prompt text — they are
+regression probes, not acceptance criteria.
 
 ### Verified against probes
 
-Compress + extract were re-run on paperclip, datacenter,
-crate_recovery, and yellowstone digests. Behaviours that moved in
+Compress + extract were re-run on a subset of the baseline including
+paperclip, datacenter, crate_recovery, yellowstone, mars_gtld, and
+euro_adoption digests. Probe coverage is expected to grow; exact
+counts in this section are not normative. Behaviours that moved in
 the expected structural direction across multiple probes:
 
 - Per-period denominator preservation in `numeric_values` labels and

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -74,28 +74,27 @@ baseline before merging, not just unit tests.
 
 Anti-overfitting: NEVER bake corpus content into the prompts
 -------------------------------------------------------------
-The 14-plan napkin_math baseline (paperclip pilot, datacenter, and the
-twelve other reports used by Self-Improve and the smoke fixtures) is
-the evaluation set for these prompts. Specific phrases from any of
-those plans MUST NOT appear in the prompt text. That includes — but is
-not limited to:
+These prompts are evaluated against the napkin_math plan baseline used
+by Self-Improve and the smoke fixtures. Specific phrases from any
+baseline plan MUST NOT appear in the prompt text. That includes — but
+is not limited to:
 
-- Concrete numeric values from a baseline plan ('€257.6M/yr',
-  '32.2 km²', '9 GW', '11 GVA', '128.8 km²'). If the prompt example
-  paraphrases a value the test plan also contains, the model is being
-  told the answer, not taught the pattern.
-- Named entities or acronyms from a baseline plan ('RTE', 'DGSI',
-  'DREAL', 'OPC UA', 'Risk-5', 'Assumption Q5', 'Phase 1 CAPEX
-  surplus'). These leak the structure of the test inputs even when
+- Concrete numeric values from any baseline plan (a currency amount,
+  an area figure, a capacity figure, a deadline). If the prompt
+  example paraphrases a value the test plan also contains, the model
+  is being told the answer, not taught the pattern.
+- Named entities or acronyms from any baseline plan (the name of a
+  regulator, a protocol, a project phase, an industry-specific
+  artefact). These leak the structure of the test inputs even when
   the numbers are abstracted.
-- Variable names that match what extract is expected to emit
-  ('holding_cost', 'buildable_area_surplus', 'phase1_capex_surplus').
-  Putting the desired output name in the prompt collapses the test
-  from "did the extract pick the right decomposition?" to "did it
-  copy the suggested name?"
+- Variable names that match what the downstream extract is expected
+  to emit (the specific snake_case ids the calculations stage will
+  call by name). Putting the desired output name in the prompt
+  collapses the test from "did the extract pick the right
+  decomposition?" to "did it copy the suggested name?"
 - Domain-specific framings that fit only one or two corpus plans
-  ('hyperscale grid headroom', 'cleanroom throughput', 'paperclip
-  R&D cell'). Even if no number leaks, the framing tells the model
+  (the jargon of a single industry, the failure mode of a single
+  project). Even if no number leaks, the framing tells the model
   which corpus member the prompt is targeting.
 
 Use abstract placeholder shapes only: '<rate>', '<denominator>',
@@ -105,6 +104,12 @@ energy plan, a renovation project, a public-benefit policy, or a
 language no one on the team reads. PlanExe inputs are multilingual
 and span domains; English-only or commercially-biased examples in a
 prompt are themselves a form of overfitting.
+
+This banner itself is held to the same rule: it lists categories of
+forbidden content but does NOT cite concrete examples from the
+evaluation corpus. A list of literal corpus terms here would rot the
+moment the baseline shifts and would itself be a corpus leak in the
+source file — exactly the failure mode the rule forbids.
 
 If a concrete example feels necessary to anchor a rule, pick a domain
 that demonstrably does NOT appear in the napkin_math baseline AND

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -49,6 +49,110 @@ from pydantic import BaseModel, Field, ValidationError
 logger = logging.getLogger(__name__)
 
 
+OPTIMIZE_INSTRUCTIONS = """\
+Goal: produce digests that preserve the modelling signal a downstream
+parameter-extraction LLM needs, without leaking the contents of the
+evaluation corpus into the prompts themselves.
+
+Pipeline context
+----------------
+This module is Stage 1 of the napkin_math pipeline:
+
+  1. compress_report_section          ← you are here (4 sections × 6 buckets)
+  2. extract-parameters-from-digest   — reads the compressed digest
+  3. validate-parameters              — deterministic structural checks
+  4. generate-bounds                  — low/base/high per variable
+  5. generate-calculations            — Python module of formulas
+  6. run-scenarios                    — deterministic three-point
+  7. monte-carlo                      — sampled distributions
+  8. summarize-assessment             — gate verdicts, slideshow
+
+Each downstream stage assumes the bucket schema and field semantics
+encoded here. A change to a bucket prompt is a change to the contract
+the whole pipeline relies on — re-run the napkin_math 14-plan
+baseline before merging, not just unit tests.
+
+Anti-overfitting: NEVER bake corpus content into the prompts
+-------------------------------------------------------------
+The 14-plan napkin_math baseline (paperclip pilot, datacenter, and the
+twelve other reports used by Self-Improve and the smoke fixtures) is
+the evaluation set for these prompts. Specific phrases from any of
+those plans MUST NOT appear in the prompt text. That includes — but is
+not limited to:
+
+- Concrete numeric values from a baseline plan ('€257.6M/yr',
+  '32.2 km²', '9 GW', '11 GVA', '128.8 km²'). If the prompt example
+  paraphrases a value the test plan also contains, the model is being
+  told the answer, not taught the pattern.
+- Named entities or acronyms from a baseline plan ('RTE', 'DGSI',
+  'DREAL', 'OPC UA', 'Risk-5', 'Assumption Q5', 'Phase 1 CAPEX
+  surplus'). These leak the structure of the test inputs even when
+  the numbers are abstracted.
+- Variable names that match what extract is expected to emit
+  ('holding_cost', 'buildable_area_surplus', 'phase1_capex_surplus').
+  Putting the desired output name in the prompt collapses the test
+  from "did the extract pick the right decomposition?" to "did it
+  copy the suggested name?"
+- Domain-specific framings that fit only one or two corpus plans
+  ('hyperscale grid headroom', 'cleanroom throughput', 'paperclip
+  R&D cell'). Even if no number leaks, the framing tells the model
+  which corpus member the prompt is targeting.
+
+Use abstract placeholder shapes only: '<rate>', '<denominator>',
+'<requirement>', '<consequence>', '<period>'. The structural rule
+must read identically whether the model is summarising a renewable-
+energy plan, a renovation project, a public-benefit policy, or a
+language no one on the team reads. PlanExe inputs are multilingual
+and span domains; English-only or commercially-biased examples in a
+prompt are themselves a form of overfitting.
+
+If a concrete example feels necessary to anchor a rule, pick a domain
+that demonstrably does NOT appear in the napkin_math baseline AND
+flag it as illustrative. The safer default is to skip the example
+and let the abstract template do the work.
+
+Known failure patterns to guard against
+---------------------------------------
+- Flattened per-period rates. The source states 'X per period', the
+  numeric_values line records the bare amount, the denominator is
+  lost, and downstream extract emits a flat bounded variable instead
+  of the rate × duration decomposition. Fix: require the denominator
+  in the label or unit field of any rate entry.
+- Capacity requirements lost as gates. The source frames a minimum
+  needed for a target capacity as a sizing calculation rather than a
+  pass/fail. The gates_and_thresholds bucket skips it, the extract
+  defaults the threshold to '>= 0', and the gate stops testing the
+  real failure scenario. Fix: capacity requirements are gates,
+  rewritten into if/then form by the compress stage.
+- Burn rate / duration separation across sections. The rate lives in
+  one PlanExe section, the matching duration in another. Compress
+  sees one section at a time. Each section's missing_data bucket
+  must therefore surface the *other half* of any rate × duration
+  pair the section names, so extract sees both pieces in the digest.
+- Per-period unit substitution. Models sometimes translate '/yr' to
+  'annual' (or vice versa) in the label, silently. The verbatim rule
+  for the value field already protects the unit field; the label
+  must mirror the same discipline.
+- Hardcoded English keywords in prompts. PlanExe receives reports in
+  many languages; prompts that depend on English-only stems ('cost',
+  'fee', 'overhead', 'budget') reject perfectly valid digests in
+  other languages. Prefer structural cues ('a value divided by a
+  period') over keyword lists.
+- Numeric-example drift. Whenever a prompt mentions a number, ask:
+  does this number appear in any baseline report? If yes — even
+  approximately — replace it with a placeholder. Numbers that
+  resemble corpus content are the most reliable signal of a
+  prompt-eval leak.
+
+When in doubt
+-------------
+Read the prompt edit and ask: "would a reader who has seen the
+baseline plans guess which plan I had in mind when writing this?"
+If yes, abstract harder. The prompt is for the model, not for a
+human reviewing the baseline.
+"""
+
+
 class LenientJsonModel(BaseModel):
     """BaseModel whose `model_validate_json` tolerates trailing characters.
 
@@ -509,11 +613,23 @@ The 'line' field for this bucket MUST follow the form
 Bare values are invalid: a percent on its own, an amount in any currency on
 its own, or a date on its own.
 
+Per-period and per-unit rates (important): when the source expresses a
+quantity as a rate (a value divided by some period or some other unit),
+the label MUST carry the denominator so the rate stays visible
+downstream. Write the label as '<quantity> per <denominator>' or
+include the denominator in the unit field (e.g. '<unit>/<denominator>').
+A flat label that drops the denominator is invalid when the source
+states one — the downstream extract can no longer reconstruct the
+multiplication. For these rate entries the modelling role should
+describe the multiplication structure rather than just naming the cost,
+so a downstream stage can identify the matching scaling input.
+
 Template shape (substitute values from the source — DO NOT copy these
 placeholders or any unit from them):
 - '<what the number is>: <amount> <currency-from-source> — <modelling role>.'
 - '<what the number is>: <percent>% — <modelling role>.'
 - '<what the number is>: <date-from-source> — <modelling role>.'
+- '<what the rate is> per <denominator>: <amount> <unit-from-source>/<denominator> — <modelling role describing what it scales with>.'
 
 If the source contains conflicting values for the same quantity, list each
 with a disambiguating label (e.g. 'minimum', 'aspirational') rather than
@@ -561,6 +677,15 @@ deficit. If something is a qualitative trade-off without a pass/fail edge,
 leave it out. If a condition is named but no numeric threshold is given in
 the source, put the missing threshold in missing_data_to_estimate rather
 than emitting a vague gate like 'must meet a threshold'.
+
+Capacity requirements count as gates. When the source states a numeric
+minimum needed to physically support a declared capacity, output, or
+service level, the requirement IS the gate — even when the source
+frames it as a sizing calculation rather than an explicit pass/fail
+condition. Write it in the if/then form: 'If <quantity> falls below
+<required value>, then <the supported capacity cannot be achieved>.'
+Do not skip such requirements just because the source phrases them as
+sizing math instead of a gate.
 
 At most 8 items.
 """.strip() + "\n\n" + SCORING_DISCIPLINE
@@ -619,6 +744,11 @@ missing counterpart here. Patterns to look for:
   needs the per-week or per-day revenue exposure the failure interrupts.
 - An overhead coverage threshold ('cover 75% of X') needs the absolute
   X amount per period.
+- A per-period burn rate (any cost or output expressed as a value per
+  unit of time) needs the matching duration the rate will be
+  multiplied by — the count of those time units the burn applies for.
+  Without the duration, the rate cannot be turned into a total and the
+  multiplication is lost downstream.
 Do not invent a value; just name the missing primitive and how it
 would be estimated. Skip this pairing only when the section already
 supplies the denominator elsewhere.

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -624,6 +624,24 @@ multiplication. For these rate entries the modelling role should
 describe the multiplication structure rather than just naming the cost,
 so a downstream stage can identify the matching scaling input.
 
+Source-stated rates belong in this bucket, not in missing_data. If the
+source names a per-period or per-unit rate at all — explicitly,
+inferred, as a recommended range, or as a stress_test magnitude — emit
+it as a numeric_value with the denominator preserved. Setting
+source_status to 'inferred' or 'stress_test' is fine when the source's
+framing fits; do NOT route a rate-like quantity to missing_data merely
+because the source gives it as a range, a recommendation, or an
+expert's estimate rather than as a single committed value.
+missing_data_to_estimate is reserved for primitives the source does NOT
+name. A rate the source mentions, even imprecisely, has been named and
+must surface here with its denominator intact.
+
+A total cost that the source ALSO frames as a per-period burn must
+appear here in BOTH forms when the source supplies both: one entry for
+the total (with its absolute label) and one entry for the rate (with
+the per-period denominator). Listing only the total flattens the burn
+structure; listing only the rate hides the source's own committed total.
+
 Template shape (substitute values from the source — DO NOT copy these
 placeholders or any unit from them):
 - '<what the number is>: <amount> <currency-from-source> — <modelling role>.'

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -116,6 +116,46 @@ that demonstrably does NOT appear in the napkin_math baseline AND
 flag it as illustrative. The safer default is to skip the example
 and let the abstract template do the work.
 
+Regression probes are not acceptance criteria
+---------------------------------------------
+The baseline plans exist to surface failure patterns, NOT to define
+what these prompts should target. A prompt edit that "fixes plan X" by
+encoding plan X's specifics is overfitting in another form: even if
+plan X's literals never enter the prompt verbatim, picking the rule
+shape from one plan's behaviour without testing against many will fit
+one and miss the others.
+
+When a baseline plan reveals a failure mode:
+1. Diagnose the abstract pattern, not the plan-specific symptom. Ask
+   "what category of source content is being mishandled?" rather than
+   "what does plan X need this bucket to do?"
+2. Write the rule in corpus-agnostic language: structural categories
+   (rate, denominator, threshold, gate, capacity, sum, decomposition),
+   not domain nouns. Multilingual, multi-domain, multi-scale.
+3. Verify the rule moves behaviour across MULTIPLE probe plans, not
+   just the one that originally failed. A rule that lifts plan X but
+   flattens plan Y is a tradeoff, not progress, and needs an explicit
+   structural justification.
+
+Report a prompt edit's effect in terms of:
+- Which structural rule changed.
+- Which corpus-agnostic behaviour it should improve.
+- Which regression probes improved or worsened (across multiple
+  plans, not one).
+- Whether any baseline signal was dropped, and the structural reason
+  the drop is acceptable.
+
+Do not claim success because a single probe plan got a desired
+variable. Claim success only when the general rule improves multiple
+probes without adding corpus leakage and without silently losing
+source-level signal elsewhere in the baseline.
+
+Compress-LLM run-to-run variance is its own structural problem; do
+NOT try to "fix" it by sharpening a bucket prompt to nudge the model
+toward a specific selection it sometimes makes. Variance handling
+belongs in orchestration (deterministic retry/merge across passes,
+lower-temperature reruns for high-impact buckets), not in this file.
+
 Known failure patterns to guard against
 ---------------------------------------
 - Flattened per-period rates. The source states 'X per period', the


### PR DESCRIPTION
## Scope

**Prompt cleanup PR — both compress (`compress_report_section.py`) and extract (`extract-parameters-from-digest/system-prompt.txt`) prompts.** Kept as a single PR per request so the combined effect of the prompt changes can be evaluated together against the napkin_math regression probes.

The PR is **not** a quality-acceptance claim that v50 outputs beat v49 across the baseline. Compress is stochastic; one before/after pass cannot honestly attribute output movement to a specific prompt edit. Output-quality acceptance, plus the unrelated compress-LLM run-to-run variance problem, are explicitly deferred.

## What changes (net effective diff vs. main)

### Compress stage — `compress_report_section.py`

1. **`NUMERIC_VALUES_BUCKET_PROMPT`** — labels for rate-like quantities must carry their per-period or per-unit denominator; source-stated rates (explicit / inferred / recommended-range / stress_test) belong in this bucket, not in `missing_data`; modelling role describes the multiplication structure.
2. **`MISSING_DATA_BUCKET_PROMPT`** — denominator-pairing rule extended: a per-period burn rate needs the matching duration it will be multiplied by.
3. **`GATES_AND_THRESHOLDS_BUCKET_PROMPT`** — capacity requirements count as gates even when the source frames them as sizing math, rewritten into if/then form.
4. **`OPTIMIZE_INSTRUCTIONS`** (new module-level block) — anti-overfitting documentation for future authors. Lists the four categories of forbidden prompt content as abstract structural descriptions only; the banner is held to its own rule.

### Extract stage — `system-prompt.txt`

5. **Threshold pairing rule** (new section between "Coverage and capacity gate rule" and "Combined viability gate preservation") — when the extract emits a `key_value` whose role is a numeric threshold (floor, cap, ceiling, minimum, maximum, target volume, target share, target deadline), it must also emit a paired margin/surplus calculation comparing the realised quantity against the threshold. The realised goes in `missing_values_to_estimate` if absent from the source; the margin goes in `recommended_first_calculations` or `derived_questions`; under cap pressure, drop a less-load-bearing `key_value` or move a less-critical calc rather than skip the pairing.

All five edits are corpus-agnostic: no plan names, no literals from any baseline plan, no expected downstream output ids, no domain-specific framings. The `OPTIMIZE_INSTRUCTIONS` block names only abstract categories of forbidden content; the threshold-pairing rule names only structural threshold categories (floor, cap, target, deadline).

## Discipline this PR enforces

Each edit is written so it would apply identically to any plan in any domain or language. The baseline plans (`paperclip`, `datacenter`, `crate_recovery`, `yellowstone`, plus the other ten Self-Improve / smoke-fixture plans) are used as **regression probes**, not as the spec — when a probe surfaces a failure pattern, the prompt edit captures the abstract pattern in corpus-agnostic language.

## Where the discipline still falls short

Honest list of known limitations these prompt edits do NOT fix:

- **Compress LLM run-to-run variance.** The same source, same prompts, two compress passes can produce materially different bucket selections. A high-impact tripwire stated by the source can be dropped by one run and present in the next. A follow-up that introduces a deterministic retry/merge across N compress passes, or a lower-temperature pass for high-impact buckets, is the right home for this.
- **Threshold-pairing rule × 5-cap on `missing_values_to_estimate`.** When a plan names many independent thresholds, the rule's requirement to pair each one collides with the 5-cap and forces tradeoffs — a less-load-bearing existing pair may be dropped to make room for a new pairing. The "less-load-bearing" criterion is judgement-based; two reasonable extractors will disagree. A follow-up that re-examines hard limits, or that defines a quantitative criterion for "load-bearing", is the right home.
- **No formal source-preservation check.** The audit script used during verification (`every key_value appears in some calc's depends_on`) does not verify that important source thresholds were preserved across iterations. A v49 → v50 comparison that silently drops a v49 gate can still pass this audit. A follow-up should add a source-preservation check that compares against either the source text or the prior baseline.

## Verification

- 17/17 unit tests pass.
- Compress + extract re-runs on `paperclip`, `datacenter`, `crate_recovery`, and `yellowstone_evacuation` recorded under `experiments/napkin_math/output/v50/` (gitignored). Used as regression probes only.
- `grep` confirms no baseline-plan literals (`€[0-9]`, `km²`, `GW`, `GVA`, `RTE`, `DGSI`, `DREAL`, `OPC UA`, `paperclip`, `hyperscale`) appear in either prompt file outside the legitimate section-name enum.

## Acceptance checks for any follow-up quality-improvement PR

When the next PR claims a structural improvement over the baseline, it should:

- [ ] Demonstrate an abstract rule moves behaviour across multiple regression-probe plans, not one.
- [ ] Show that no important source threshold is silently dropped — every drop has an explicit structural rationale (cap pressure, scope, or the threshold being unmodelled).
- [ ] Avoid prompt content that names any baseline plan, its acronyms, its numeric values, its expected output ids, or its domain-specific jargon.
- [ ] Treat compress-LLM variance as its own structural problem, addressed at the orchestration/sampling layer rather than by prompt rewording.

## Commit chain

- `bd6faf4a` — Phase 1 compress prompt edits + initial OPTIMIZE_INSTRUCTIONS guard
- `74030f8d` — Tighten numeric_values to route source-stated rates into the right bucket
- `19dd780e` — Strip eval-corpus literals from OPTIMIZE_INSTRUCTIONS (keep categories, drop concrete examples)
- `6a7468b8` — Add threshold-pairing rule to extract-parameters-from-digest
- `2f9bb77a` — Revert of the threshold-pairing rule (during a brief PR split)
- `2d1088d2` — Restore the threshold-pairing rule (consolidating back into a single PR for unified review)

The pair of revert commits records the brief split-and-reconsolidate. Net diff vs `main` is the five substantive prompt changes.

## Test plan

- [ ] CI green
- [ ] Hand-spot the new bucket-prompt paragraphs and the threshold-pairing rule are corpus-agnostic
- [ ] OPTIMIZE_INSTRUCTIONS contains no concrete corpus identifiers
- [ ] Compress + extract regression probes do not reveal corpus-leaking content in either prompt file