### PR TITLE
docs(napkin-math): proposal 141 — source-preservation audit

### DIFF
--- a/docs/proposals/141-source-preservation-audit.md
+++ b/docs/proposals/141-source-preservation-audit.md
@@ -1,138 +1,248 @@
-# 141 — Source-preservation audit for the napkin_math pipeline
+---
+title: "Source-Preservation Audit for the Napkin Math Pipeline"
+date: 2026-05-21
+status: Proposal
+author: PlanExe Team
+---
+
+# Source-Preservation Audit for the Napkin Math Pipeline
+
+**Author:** PlanExe Team
+**Date:** 2026-05-21
+**Status:** Proposal
+**Tags:** `napkin-math`, `validation`, `audit`, `parameters`, `llm-output`
+
+---
+
+## Pitch
+
+Add a deterministic source-preservation audit between parameter extraction and validation so load-bearing source signals cannot silently disappear. Every threshold-like source claim or prior-baseline signal must either be carried forward into the current `parameters.json` or be recorded in `dropped_signals` with a mechanically checkable structural reason.
 
 ## Problem
 
-The current extraction-stage discipline (no-dead-end-variables, threshold-pairing) verifies that every declared `key_value` connects to a downstream calculation. It does NOT verify that every signal stated in the source or carried forward from the prior baseline survives into the current output. Silent drops pass the audit because the absent variable was never declared in the first place.
+The current extraction-stage discipline verifies that every declared `key_value` connects to a downstream calculation. It does not verify that every signal stated in the source or carried forward from the prior baseline survives into the current output. Silent drops pass the audit because the absent variable was never declared in the first place.
 
-Two failure modes observed during the v50 prompt-cleanup work:
+Two failure modes motivated this proposal:
 
-1. **Source-stated threshold absent from output.** The plan names a floor / cap / target the extractor recognises but does not surface in `key_values` or `missing_values_to_estimate`, and does not record the drop. Downstream stages cannot test the gate; the user has no signal that the gate was even considered.
-2. **Prior-baseline signal absent from current version.** A variable / calculation / unmodelled-gate present in v49 disappears in v50 without explanation. The change may be a structural improvement (replaced by a better-named or better-decomposed equivalent) or a silent regression. The depends-on audit cannot tell the difference.
+1. **Source-stated threshold absent from output** — the source names a floor, cap, target, deadline, or pass/fail condition, but the extractor does not surface it in `key_values`, `missing_values_to_estimate`, a formula input, or `unmodelled_gates`.
+2. **Prior-baseline signal absent from current output** — a variable, calculation, or unmodelled gate present in a prior artifact disappears without an explicit replacement or rationale.
 
-Both modes are invisible to the existing audit and to chat-level reporting that focuses only on what the current artifact contains.
+Both modes are invisible to the existing no-dead-end-variable audit and to reporting that only describes what the current artifact contains.
 
-## Goal
+## Feasibility
 
-Every signal the source or prior baseline names as load-bearing must be **either** carried forward into the current output **or** explicitly recorded in a `dropped_signals` field with a structural rationale (`replaced_by:<id>`, `cap_pressure`, `out_of_scope`, `unmodelled_external`, `redundant_with:<id>`, …). The audit fails when an unjustified drop is detected.
+The audit is feasible as an advisory deterministic script because `parameters.json` already has stable IDs, labels, formulas, dependencies, and source anchors. The source-side scan is less precise: it must infer threshold-like claims from compressed digest text, so it will produce false positives and miss unusual phrasing. That is acceptable for an advisory first phase, but strict CI gating should wait until the matching fields and false-positive rate are proven on the full napkin_math corpus.
 
-The rule is corpus-agnostic. It applies to any plan in any domain.
+The implementation should avoid adding plan-specific literals to prompts. Regression plans are probes only; tests should use synthetic fixtures for unit coverage and optionally run real corpus probes as non-normative integration checks.
 
-## Two forks of the audit
+## Proposal
 
-### Fork A — Source / digest → current artifact
+Build two orthogonal audit forks that share one `dropped_signals` schema.
 
-Reads the source digest (`extract_parameters_input.md` or the equivalent raw report). Identifies threshold-like claims by structural pattern (numeric values paired with comparison words: "at least", "no more than", "minimum", "maximum", "must clear", "if X exceeds Y", etc.). For each claim, checks whether the current artifact references it via a `key_value`, `missing_values_to_estimate`, formula RHS, or `unmodelled_gates` entry, or records it in `dropped_signals`.
+### Fork A: Source Digest To Current Artifact
 
-### Fork B — Prior baseline → current artifact
+Reads `extract_parameters_input.md` or the equivalent raw report input. It identifies threshold-like claims by structural pattern: numeric value plus language such as minimum, maximum, floor, ceiling, cap, target, deadline, must be at least, must not exceed, falls below, exceeds, or equivalent pass/fail phrasing.
 
-Reads the prior-version artifact (e.g. v49 `parameters.json`) and the current-version artifact. Computes the full prior signal set: every `id` across `key_values`, `missing_values_to_estimate`, `derived_questions`, `recommended_first_calculations`, `unmodelled_gates`. For each prior id, checks whether the current artifact carries an equivalent (same id, or referenced via `dropped_signals` with `replaced_by:<current_id>`).
+For each detected source claim, the audit computes a deterministic `source_claim_id`:
 
-Both forks share the same `dropped_signals` schema. They are orthogonal sources of evidence about completeness: Fork A protects against silent omissions of source-named claims; Fork B protects against silent regressions on the verification corpus.
+```text
+source_claim_id = "claim_" + sha1(normalized_source_anchor + "\n" + normalized_claim_text)[:12]
+```
 
-## Schema extension
+A source claim is considered preserved when at least one of these is true:
 
-The extract-stage artifact schemas (currently the JSON shape at the end of `extract-parameters-from-digest/system-prompt.txt` and the parallel `extract-parameters-from-full`) gain an optional top-level field:
+1. A current artifact entry declares that claim in `source_claim_ids`.
+2. A current artifact entry has sufficient deterministic text overlap with the claim, using source anchor, numeric token, comparison token, and noun-token overlap.
+3. A `dropped_signals` entry records the same `source_claim_id` with an allowed structural reason.
+
+The explicit `source_claim_ids` field is the preferred long-term mechanism. Text overlap is a compatibility fallback for older outputs and should be reported as lower-confidence.
+
+### Fork B: Prior Baseline To Current Artifact
+
+Reads a prior `parameters.json` and the current `parameters.json`. It computes the prior signal set from every `id` and `output_name` across:
+
+- `key_values`
+- `missing_values_to_estimate`
+- `recommended_first_calculations`
+- `derived_questions`
+- `unmodelled_gates`
+
+A prior signal is considered preserved when at least one of these is true:
+
+1. The same `id` or `output_name` appears in the current artifact.
+2. A current formula depends on the prior signal name and the producer still exists under a compatible output name.
+3. A `dropped_signals` entry records the prior signal with `reason: "replaced_by"` or `reason: "redundant_with"` and points to an existing current ID.
+4. A `dropped_signals` entry records another allowed structural reason.
+
+Fork A protects against omissions that the prior baseline also missed. Fork B protects against regressions relative to a known earlier artifact.
+
+## Schema
+
+The extract-stage schemas gain two optional additions.
+
+First, any emitted entry may carry source-claim references:
+
+```jsonc
+"source_claim_ids": ["claim_ab12cd34ef56"]
+```
+
+Second, the top-level artifact may include `dropped_signals`:
 
 ```jsonc
 "dropped_signals": [
   {
-    "id": "<snake_case id of the dropped signal>",
-    "source_anchor": "<source section or 'prior_baseline'>",
-    "dropped_from": "<key_values | missing_values_to_estimate | recommended_first_calculations | derived_questions | unmodelled_gates>",
-    "reason": "<one of: replaced_by:<new_id> | cap_pressure | out_of_scope | unmodelled_external | redundant_with:<other_id>>",
-    "rationale": "<one-sentence structural justification (≤25 words)>"
+    "id": "prior_or_claim_id",
+    "origin": "source_digest",
+    "source_claim_id": "claim_ab12cd34ef56",
+    "source_anchor": "review_plan",
+    "expected_section": "key_values",
+    "dropped_from": null,
+    "reason": "replaced_by",
+    "replacement_id": "current_signal_id",
+    "redundant_with_id": null,
+    "cap_kind": null,
+    "rationale": "Equivalent threshold is represented by a clearer current margin input."
   }
 ]
 ```
 
-Hard limit: at most 8 entries. If more than 8 source/prior signals must be dropped, that itself is a structural problem to surface, not a list to inflate.
+Field semantics:
 
-Allowed `reason` values are a closed enumeration so the audit script can mechanically classify each drop. The `rationale` field is for human readers and must restate the reason in plan-neutral terms.
+- `id` is the prior signal ID for Fork B, or the `source_claim_id` for Fork A.
+- `origin` is one of `source_digest` or `prior_baseline`.
+- `source_claim_id` is required when `origin == "source_digest"`.
+- `source_anchor` names the source section when known; otherwise use `prior_baseline`.
+- `expected_section` is the section where the signal would normally land.
+- `dropped_from` is required only when `origin == "prior_baseline"` and names the prior section.
+- `reason` is one of `replaced_by`, `cap_pressure`, `out_of_scope`, `moved_to_unmodelled_gate`, or `redundant_with`.
+- `replacement_id` is required for `replaced_by` and must reference an existing current ID or output name.
+- `redundant_with_id` is required for `redundant_with` and must reference an existing current ID or output name.
+- `cap_kind` is required for `cap_pressure` and must name the capped array.
+- `rationale` is a one-sentence structural justification, capped at 25 words.
 
-## System-prompt rule additions
+Hard limit: at most 8 `dropped_signals`. If more than 8 signals must be dropped, the audit should surface an overflow finding instead of encouraging a long confession list.
 
-Inserted into the extract skill's `system-prompt.txt` between the existing "Threshold pairing rule" and "Combined viability gate preservation" sections:
+## Validation Rules
+
+The audit validates `dropped_signals` before trusting it:
+
+1. `reason` must be in the closed enum.
+2. `replacement_id` and `redundant_with_id` must reference existing current IDs or output names.
+3. `cap_pressure` must name a capped array in `cap_kind`, and that array must actually be at its cap in the current artifact.
+4. `moved_to_unmodelled_gate` must reference an existing `unmodelled_gates` entry through `replacement_id`.
+5. `source_claim_id` values must match the deterministic `claim_<12 hex>` shape.
+6. `rationale` must be non-empty, plan-neutral, and at most 25 words.
+
+Malformed `dropped_signals` entries are audit failures. They should not be accepted as explanations.
+
+## Prompt Rule
+
+The extract prompts should gain a corpus-agnostic source-preservation rule:
 
 ```text
 Source preservation rule:
 
-Every threshold-like claim the source states (a floor, cap, ceiling,
-minimum, maximum, target, deadline, or stated pass/fail condition)
-must either appear in the current artifact (as a key_value,
-missing_values_to_estimate, formula input, or unmodelled_gates
-entry) OR be recorded in dropped_signals with a structural rationale.
+Every threshold-like source claim must either appear in the current
+artifact, be represented by a declared source_claim_id on a current
+entry, or be recorded in dropped_signals with a structural reason.
 Silent omission is not allowed.
 
-The same rule applies to prior-baseline signals when the extract is
-being run as part of an evaluation iteration. Every id present in
-the prior baseline must either carry forward (same id, or replaced
-by a new id explicitly named via reason='replaced_by:<new_id>') or
-be recorded in dropped_signals.
+When running an evaluation iteration with a prior baseline, every
+prior-baseline signal must either carry forward, be replaced by a
+current signal named in dropped_signals, or be recorded with another
+allowed structural reason.
 
-Allowed reasons for a drop:
-- replaced_by:<id>     — superseded by a structurally equivalent
-                         current entry with a different id
-- cap_pressure         — the hard limit on key_values, missing,
-                         calcs, or derived_questions forced this
-                         drop; the dropped signal is the
-                         least-load-bearing per a stated criterion
-- out_of_scope         — the signal exists in the source but the
-                         current modelling frame does not cover it;
-                         must say what scope decision excluded it
-- unmodelled_external  — the signal is binary and depends on an
-                         external actor; belongs in unmodelled_gates
-                         but cannot be simulated
-- redundant_with:<id>  — the signal is structurally equivalent to
-                         another already-declared current entry
-
-Do not use dropped_signals as a confession of laziness. Every drop
-must have a structural reason a future reader can defend.
+Do not use dropped_signals to excuse weak extraction. Each entry must
+name a defensible structural reason and point to the current signal
+when the signal was replaced, made redundant, or moved to unmodelled
+gates.
 ```
 
-## Deterministic audit script
+The prompt must not mention corpus plan names, literal values, expected output IDs, or domain-specific probe details.
 
-A new Python script, `experiments/napkin_math/audit_source_preservation.py`. No LLM call. Inputs:
+## Audit Script
+
+Add `experiments/napkin_math/audit_source_preservation.py`. No LLM call.
+
+Inputs:
 
 - `--digest` — path to `extract_parameters_input.md`
 - `--parameters` — path to the current `parameters.json`
-- `--prior` — optional path to the prior baseline `parameters.json` (for Fork B)
-- `--strict` — if set, exits non-zero on any unjustified drop
+- `--prior` — optional path to the prior baseline `parameters.json`
+- `--report-json` — optional output path for a machine-readable report
+- `--strict` — exit non-zero on unjustified drops
 
 Behaviour:
 
-1. **Fork A scan.** Regex over the digest's compressed-section bullets for threshold patterns (numeric value with one of: "minimum", "maximum", "floor", "ceiling", "cap", "must be at least", "must not exceed", "if X exceeds", "if X falls below"). For each detected claim, compute a stable claim-hash and look it up against the current artifact's id pool and `dropped_signals` array. Unreferenced claims are flagged.
-2. **Fork B comparison.** Diff the prior artifact's id set against the current artifact's id set. Each prior-only id must appear in the current `dropped_signals` (matched by `id`) or be flagged as a silent regression.
-3. **Report.** Plain-text output listing unjustified drops with section anchors. Exit code 0 if clean (or `--strict` not set), 1 otherwise.
+1. Parse and validate the current artifact shape.
+2. Scan the digest for threshold-like claims and compute `source_claim_id` values.
+3. Build the current signal index from IDs, output names, labels, source text, formulas, dependencies, unmodelled gates, and `source_claim_ids`.
+4. Run Fork A preservation checks.
+5. If `--prior` is present, build the prior signal set and run Fork B checks.
+6. Validate every `dropped_signals` explanation.
+7. Emit a human-readable report and, when requested, a JSON report.
 
-The regex over threshold patterns is intentionally lossy — it will miss claims phrased in unusual ways and will sometimes false-positive. The goal is not perfect coverage; it is to surface silent drops that any reasonable extractor would have spotted. False positives are cheaper than silent regressions.
+Exit code is 0 when clean, 1 when strict mode finds unjustified drops, and 2 for malformed input JSON.
 
-## Pipeline integration
+## Integration
 
-The audit runs after `extract-parameters-from-digest` (or `extract-parameters-from-full`) and before `validate-parameters`. It is advisory — failures emit a report but do not block the downstream pipeline unless `--strict` is passed.
+The audit runs after `extract-parameters-from-digest` or `extract-parameters-from-full` and before `validate-parameters`.
 
-`run-napkin-math-pipeline` documentation gains a note that the audit step exists. The orchestrator skill is not modified in this PR; the audit is invoked manually until the orchestrator is updated separately.
+Initial integration should be advisory:
 
-## What this proposal does NOT do
+1. Manual invocation during prompt-development work.
+2. Optional step documented in `run-napkin-math-pipeline`.
+3. Later orchestrator integration that writes `audit_source_preservation.json` next to `parameters.json`.
+4. Strict mode only after false positives are measured and reduced across the corpus.
 
-- Does not add Fork A coverage at the compress stage. The compress LLM legitimately drops content from the source by design (compression). Auditing compress preservation is a separate problem with different shape.
-- Does not add Fork A coverage at downstream stages (`generate-bounds`, `monte-carlo`, etc.). Most of those stages are deterministic Python; preservation there is a code property, not an LLM-output property.
-- Does not address compress-LLM run-to-run variance. That is a separate orchestration problem.
-- Does not enforce strict mode in CI. The audit lands as advisory only; making it gating is a follow-up policy decision.
-- Does not retro-edit existing v50 `parameters.json` outputs. Those are gitignored. Re-running the extract under the new prompt rule will produce compliant outputs naturally.
+The existing `validate_parameters.py` should stay focused on internal structural consistency. Source preservation is a separate audit because it needs external artifacts: the digest and optional prior baseline.
 
-## Acceptance for this proposal
+## What This Proposal Does Not Do
 
-- [ ] `dropped_signals` schema field documented in the extract system prompts
-- [ ] Source-preservation rule added to both extract skill system prompts
-- [ ] `audit_source_preservation.py` lands under `experiments/napkin_math/` with a small test suite covering the threshold-pattern regex and the prior-baseline diff logic
-- [ ] One regression run against an existing v50 output that demonstrates the audit catches a previously-silent drop (the Mars `registration_volume_buffer_fraction` drop is the natural fixture)
-- [ ] Discipline change reflected in `OPTIMIZE_INSTRUCTIONS` blocks if the rule has implications for the compress prompts (most likely not, but check)
-- [ ] No corpus literals introduced in the prompt edits or the proposal text
+- It does not audit raw-source to compressed-digest preservation. Compression intentionally drops content, so that needs a separate design.
+- It does not solve compress-LLM run-to-run variance.
+- It does not make source preservation a CI gate in the first implementation.
+- It does not retro-edit existing gitignored outputs.
+- It does not require plan-specific prompt text or probe-specific rules.
 
-## Open questions
+## Implementation Phases
 
-- Should the audit emit a machine-readable report (`audit_source_preservation.json`) alongside the human-readable one, for use by downstream Self-Improve runs? Probably yes, defer to implementation.
-- Should `cap_pressure` drops require naming the cap (`cap_pressure:key_values` vs `cap_pressure:missing_values_to_estimate`)? Yes, but the closed-enumeration mechanism above doesn't naturally express that. Either widen the enumeration or add a `cap_kind` subfield.
-- The threshold-pattern regex needs a multilingual variant for non-English plans. Punt to a follow-up; the napkin_math baseline is currently English-only.
-- When Fork B's prior baseline is missing (no v49 exists for this plan), Fork B is skipped. The audit reports "Fork B skipped: no prior baseline" rather than erroring.
-- Should `dropped_signals` itself be capped lower than 8 to discourage drift? Maybe 5. Defer to implementation feedback.
+1. **Schema and docs** — document `source_claim_ids` and `dropped_signals` in both extract prompts and the napkin_math README.
+2. **Advisory script** — implement the audit with synthetic unit fixtures for Fork A, Fork B, and malformed `dropped_signals`.
+3. **Corpus probe run** — run against a subset of existing outputs and record false positives, false negatives, and useful catches.
+4. **Pipeline note** — document manual invocation in the orchestrator skill without changing orchestration behaviour.
+5. **Orchestrator integration** — write `audit_source_preservation.json` as a normal intermediate artifact.
+6. **Strict policy decision** — decide whether any subset of findings should become blocking.
+
+## Success Metrics
+
+- Synthetic tests catch an omitted source threshold, a dropped prior missing value, a dropped prior derived question, and a malformed replacement reference.
+- On corpus probes, every reported finding is classified as true positive, false positive, or accepted tradeoff.
+- The audit catches at least one silent drop that the current no-dead-end-variable audit misses.
+- False positives are low enough that reviewers can inspect them during prompt work without ignoring the report.
+- No corpus literals are introduced into extract prompts.
+
+## Risks
+
+- **False positives from regex scanning** — mitigate with advisory rollout, source anchors, numeric-token checks, and `source_claim_ids`.
+- **LLM overuses `dropped_signals`** — mitigate with hard caps, validation rules, and strict replacement references.
+- **Prior baseline was wrong or incomplete** — mitigate by treating Fork B as regression evidence, not ground truth.
+- **Schema bloat** — keep fields optional and local to napkin_math artifacts until the audit proves useful.
+- **Multilingual blind spots** — start with English structural patterns and add multilingual phrase tables only after measuring misses.
+
+## Acceptance
+
+- [ ] Proposal follows `docs/proposals/AGENTS.md` formatting rules.
+- [ ] `source_claim_ids` and `dropped_signals` are documented in both extract system prompts.
+- [ ] `experiments/napkin_math/README.md` documents the new optional fields and audit workflow.
+- [ ] `audit_source_preservation.py` lands under `experiments/napkin_math/`.
+- [ ] Unit tests cover source-claim detection, prior-baseline diffing, malformed `dropped_signals`, cap-pressure validation, and replacement-ID validation.
+- [ ] A synthetic regression fixture demonstrates a previously silent drop is caught.
+- [ ] A corpus probe report is produced without adding corpus literals to prompts.
+
+## Open Questions
+
+- Should `source_claim_ids` be required on new extract outputs once the field is introduced, or remain optional until the matching fallback has enough data?
+- Should strict mode ever apply to Fork A regex findings, or only to Fork B and explicit `source_claim_ids`?
+- Should `dropped_signals` be capped at 8 or 5?
+- Should the JSON report be consumed by Self-Improve as a prompt-optimization signal?

--- a/docs/proposals/141-source-preservation-audit.md
+++ b/docs/proposals/141-source-preservation-audit.md
@@ -1,0 +1,138 @@
+# 141 — Source-preservation audit for the napkin_math pipeline
+
+## Problem
+
+The current extraction-stage discipline (no-dead-end-variables, threshold-pairing) verifies that every declared `key_value` connects to a downstream calculation. It does NOT verify that every signal stated in the source or carried forward from the prior baseline survives into the current output. Silent drops pass the audit because the absent variable was never declared in the first place.
+
+Two failure modes observed during the v50 prompt-cleanup work:
+
+1. **Source-stated threshold absent from output.** The plan names a floor / cap / target the extractor recognises but does not surface in `key_values` or `missing_values_to_estimate`, and does not record the drop. Downstream stages cannot test the gate; the user has no signal that the gate was even considered.
+2. **Prior-baseline signal absent from current version.** A variable / calculation / unmodelled-gate present in v49 disappears in v50 without explanation. The change may be a structural improvement (replaced by a better-named or better-decomposed equivalent) or a silent regression. The depends-on audit cannot tell the difference.
+
+Both modes are invisible to the existing audit and to chat-level reporting that focuses only on what the current artifact contains.
+
+## Goal
+
+Every signal the source or prior baseline names as load-bearing must be **either** carried forward into the current output **or** explicitly recorded in a `dropped_signals` field with a structural rationale (`replaced_by:<id>`, `cap_pressure`, `out_of_scope`, `unmodelled_external`, `redundant_with:<id>`, …). The audit fails when an unjustified drop is detected.
+
+The rule is corpus-agnostic. It applies to any plan in any domain.
+
+## Two forks of the audit
+
+### Fork A — Source / digest → current artifact
+
+Reads the source digest (`extract_parameters_input.md` or the equivalent raw report). Identifies threshold-like claims by structural pattern (numeric values paired with comparison words: "at least", "no more than", "minimum", "maximum", "must clear", "if X exceeds Y", etc.). For each claim, checks whether the current artifact references it via a `key_value`, `missing_values_to_estimate`, formula RHS, or `unmodelled_gates` entry, or records it in `dropped_signals`.
+
+### Fork B — Prior baseline → current artifact
+
+Reads the prior-version artifact (e.g. v49 `parameters.json`) and the current-version artifact. Computes the full prior signal set: every `id` across `key_values`, `missing_values_to_estimate`, `derived_questions`, `recommended_first_calculations`, `unmodelled_gates`. For each prior id, checks whether the current artifact carries an equivalent (same id, or referenced via `dropped_signals` with `replaced_by:<current_id>`).
+
+Both forks share the same `dropped_signals` schema. They are orthogonal sources of evidence about completeness: Fork A protects against silent omissions of source-named claims; Fork B protects against silent regressions on the verification corpus.
+
+## Schema extension
+
+The extract-stage artifact schemas (currently the JSON shape at the end of `extract-parameters-from-digest/system-prompt.txt` and the parallel `extract-parameters-from-full`) gain an optional top-level field:
+
+```jsonc
+"dropped_signals": [
+  {
+    "id": "<snake_case id of the dropped signal>",
+    "source_anchor": "<source section or 'prior_baseline'>",
+    "dropped_from": "<key_values | missing_values_to_estimate | recommended_first_calculations | derived_questions | unmodelled_gates>",
+    "reason": "<one of: replaced_by:<new_id> | cap_pressure | out_of_scope | unmodelled_external | redundant_with:<other_id>>",
+    "rationale": "<one-sentence structural justification (≤25 words)>"
+  }
+]
+```
+
+Hard limit: at most 8 entries. If more than 8 source/prior signals must be dropped, that itself is a structural problem to surface, not a list to inflate.
+
+Allowed `reason` values are a closed enumeration so the audit script can mechanically classify each drop. The `rationale` field is for human readers and must restate the reason in plan-neutral terms.
+
+## System-prompt rule additions
+
+Inserted into the extract skill's `system-prompt.txt` between the existing "Threshold pairing rule" and "Combined viability gate preservation" sections:
+
+```text
+Source preservation rule:
+
+Every threshold-like claim the source states (a floor, cap, ceiling,
+minimum, maximum, target, deadline, or stated pass/fail condition)
+must either appear in the current artifact (as a key_value,
+missing_values_to_estimate, formula input, or unmodelled_gates
+entry) OR be recorded in dropped_signals with a structural rationale.
+Silent omission is not allowed.
+
+The same rule applies to prior-baseline signals when the extract is
+being run as part of an evaluation iteration. Every id present in
+the prior baseline must either carry forward (same id, or replaced
+by a new id explicitly named via reason='replaced_by:<new_id>') or
+be recorded in dropped_signals.
+
+Allowed reasons for a drop:
+- replaced_by:<id>     — superseded by a structurally equivalent
+                         current entry with a different id
+- cap_pressure         — the hard limit on key_values, missing,
+                         calcs, or derived_questions forced this
+                         drop; the dropped signal is the
+                         least-load-bearing per a stated criterion
+- out_of_scope         — the signal exists in the source but the
+                         current modelling frame does not cover it;
+                         must say what scope decision excluded it
+- unmodelled_external  — the signal is binary and depends on an
+                         external actor; belongs in unmodelled_gates
+                         but cannot be simulated
+- redundant_with:<id>  — the signal is structurally equivalent to
+                         another already-declared current entry
+
+Do not use dropped_signals as a confession of laziness. Every drop
+must have a structural reason a future reader can defend.
+```
+
+## Deterministic audit script
+
+A new Python script, `experiments/napkin_math/audit_source_preservation.py`. No LLM call. Inputs:
+
+- `--digest` — path to `extract_parameters_input.md`
+- `--parameters` — path to the current `parameters.json`
+- `--prior` — optional path to the prior baseline `parameters.json` (for Fork B)
+- `--strict` — if set, exits non-zero on any unjustified drop
+
+Behaviour:
+
+1. **Fork A scan.** Regex over the digest's compressed-section bullets for threshold patterns (numeric value with one of: "minimum", "maximum", "floor", "ceiling", "cap", "must be at least", "must not exceed", "if X exceeds", "if X falls below"). For each detected claim, compute a stable claim-hash and look it up against the current artifact's id pool and `dropped_signals` array. Unreferenced claims are flagged.
+2. **Fork B comparison.** Diff the prior artifact's id set against the current artifact's id set. Each prior-only id must appear in the current `dropped_signals` (matched by `id`) or be flagged as a silent regression.
+3. **Report.** Plain-text output listing unjustified drops with section anchors. Exit code 0 if clean (or `--strict` not set), 1 otherwise.
+
+The regex over threshold patterns is intentionally lossy — it will miss claims phrased in unusual ways and will sometimes false-positive. The goal is not perfect coverage; it is to surface silent drops that any reasonable extractor would have spotted. False positives are cheaper than silent regressions.
+
+## Pipeline integration
+
+The audit runs after `extract-parameters-from-digest` (or `extract-parameters-from-full`) and before `validate-parameters`. It is advisory — failures emit a report but do not block the downstream pipeline unless `--strict` is passed.
+
+`run-napkin-math-pipeline` documentation gains a note that the audit step exists. The orchestrator skill is not modified in this PR; the audit is invoked manually until the orchestrator is updated separately.
+
+## What this proposal does NOT do
+
+- Does not add Fork A coverage at the compress stage. The compress LLM legitimately drops content from the source by design (compression). Auditing compress preservation is a separate problem with different shape.
+- Does not add Fork A coverage at downstream stages (`generate-bounds`, `monte-carlo`, etc.). Most of those stages are deterministic Python; preservation there is a code property, not an LLM-output property.
+- Does not address compress-LLM run-to-run variance. That is a separate orchestration problem.
+- Does not enforce strict mode in CI. The audit lands as advisory only; making it gating is a follow-up policy decision.
+- Does not retro-edit existing v50 `parameters.json` outputs. Those are gitignored. Re-running the extract under the new prompt rule will produce compliant outputs naturally.
+
+## Acceptance for this proposal
+
+- [ ] `dropped_signals` schema field documented in the extract system prompts
+- [ ] Source-preservation rule added to both extract skill system prompts
+- [ ] `audit_source_preservation.py` lands under `experiments/napkin_math/` with a small test suite covering the threshold-pattern regex and the prior-baseline diff logic
+- [ ] One regression run against an existing v50 output that demonstrates the audit catches a previously-silent drop (the Mars `registration_volume_buffer_fraction` drop is the natural fixture)
+- [ ] Discipline change reflected in `OPTIMIZE_INSTRUCTIONS` blocks if the rule has implications for the compress prompts (most likely not, but check)
+- [ ] No corpus literals introduced in the prompt edits or the proposal text
+
+## Open questions
+
+- Should the audit emit a machine-readable report (`audit_source_preservation.json`) alongside the human-readable one, for use by downstream Self-Improve runs? Probably yes, defer to implementation.
+- Should `cap_pressure` drops require naming the cap (`cap_pressure:key_values` vs `cap_pressure:missing_values_to_estimate`)? Yes, but the closed-enumeration mechanism above doesn't naturally express that. Either widen the enumeration or add a `cap_kind` subfield.
+- The threshold-pattern regex needs a multilingual variant for non-English plans. Punt to a follow-up; the napkin_math baseline is currently English-only.
+- When Fork B's prior baseline is missing (no v49 exists for this plan), Fork B is skipped. The audit reports "Fork B skipped: no prior baseline" rather than erroring.
+- Should `dropped_signals` itself be capped lower than 8 to discourage drift? Maybe 5. Defer to implementation feedback.


### PR DESCRIPTION
## Summary

Adds proposal 141 to `docs/proposals/` covering a deterministic source-preservation audit for the napkin_math pipeline. Doc-only PR — no code or prompt changes.

## What the proposal specifies

- Two orthogonal audit forks sharing one schema:
  - **Fork A** — source/digest threshold-like claims vs. current `parameters.json`
  - **Fork B** — prior-baseline signals vs. current `parameters.json`
- New optional schema fields on extract artifacts: `source_claim_ids` (per entry) and `dropped_signals` (top-level array)
- Deterministic `source_claim_id` hashes for mechanical claim-to-declaration matching
- Closed enum for `reason` (`replaced_by`, `cap_pressure`, `out_of_scope`, `moved_to_unmodelled_gate`, `redundant_with`) with dedicated reference fields per reason
- Validation rules on `dropped_signals` itself (e.g. `cap_pressure` must actually match a capped array at cap)
- A new advisory `experiments/napkin_math/audit_source_preservation.py` script (no LLM call)
- Phased rollout: schema docs → advisory script → corpus probe → orchestrator integration → strict policy

## Why now

Two failure modes the existing depends-on audit cannot catch:
1. Source-stated threshold absent from output (extractor recognises but omits)
2. Prior-baseline signal absent from current version (silent regression vs. structural improvement looks identical)

Both predate this proposal and were surfaced during the PR #737 v50 prompt-cleanup work. The proposal commits to a design before implementation lands.

## What this PR does NOT do

- Does not implement the schema field or the audit script — that is the Phase 1-4 follow-up work in the proposal itself.
- Does not modify any prompt or code file.
- Does not introduce corpus literals anywhere.

## Commit chain

- `aaceee55` — Initial proposal draft
- `3c47a3ab` — ChatGPT-led restructuring (added Pitch, Feasibility, Implementation Phases, Success Metrics, Risks, Acceptance, Open Questions; deterministic `source_claim_id` hash; closed-enum `reason` with dedicated reference fields; validation rules on `dropped_signals`)

## Test plan

- [ ] Proposal follows `docs/proposals/AGENTS.md` formatting
- [ ] No corpus literals (`grep -nE "€[0-9]|km²|GW|GVA|RTE|DGSI|DREAL|OPC UA|paperclip|hyperscale|yellowstone|mars_gtld|euro_adoption|crate_recovery|datacenter" docs/proposals/141-source-preservation-audit.md` returns nothing)
- [ ] Phase 1-4 implementation tracked in a follow-up PR