### PR TITLE
napkin-math(compress): paraphrase-tolerant quote verification

### DIFF
--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -920,7 +920,6 @@ def normalise_for_quote_match(text: str) -> str:
 
 WORD_TOKEN_PATTERN: re.Pattern[str] = re.compile(r"\w+", re.UNICODE)
 
-QUOTE_MATCH_OVERLAP_THRESHOLD: float = 0.9
 QUOTE_MATCH_MIN_TOKENS: int = 3
 
 
@@ -929,8 +928,7 @@ def tokenize_for_quote_match(text: str) -> list[str]:
 
     Language- and domain-neutral: it splits on whatever the Unicode word
     class considers a word character. Numeric tokens like ``$75,000`` split
-    into ``["75", "000"]`` consistently in both quote and source, so digit
-    anchoring still works.
+    into ``["75", "000"]`` consistently in both quote and source.
     """
     return WORD_TOKEN_PATTERN.findall(normalise_for_quote_match(text))
 
@@ -940,12 +938,12 @@ def quote_is_in_source(quote: str, section_markdown: str) -> bool:
 
     Fast path is the existing substring check after normalisation. When the
     LLM paraphrases (drops intermediate words, reorders the noun phrase),
-    that fast path misses even though the quote is faithful to the source.
-    A token-overlap fallback catches those cases without letting hallucinated
-    numbers or substituted content words through: every digit-bearing token
-    in the quote must appear in the source, and at least
-    ``QUOTE_MATCH_OVERLAP_THRESHOLD`` of all quote tokens must appear in the
-    source token set.
+    that fast path misses even though every content token came from the
+    source. The fallback requires every quote token to appear in the source
+    token set, which accepts reordering and elision but rejects any
+    substituted word — including numeric substitutions, since digit-bearing
+    tokens fall under the same all-tokens rule. A short-quote floor avoids
+    trivial overlap on a large source.
     """
     if not quote:
         return False
@@ -959,11 +957,7 @@ def quote_is_in_source(quote: str, section_markdown: str) -> bool:
     if len(quote_tokens) < QUOTE_MATCH_MIN_TOKENS:
         return False
     source_tokens = set(tokenize_for_quote_match(section_markdown))
-    for tok in quote_tokens:
-        if any(ch.isdigit() for ch in tok) and tok not in source_tokens:
-            return False
-    matched = sum(1 for tok in quote_tokens if tok in source_tokens)
-    return matched / len(quote_tokens) >= QUOTE_MATCH_OVERLAP_THRESHOLD
+    return all(tok in source_tokens for tok in quote_tokens)
 
 
 def numeric_density_bonus(text: str) -> float:

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -918,12 +918,52 @@ def normalise_for_quote_match(text: str) -> str:
     return " ".join(text.split())
 
 
+WORD_TOKEN_PATTERN: re.Pattern[str] = re.compile(r"\w+", re.UNICODE)
+
+QUOTE_MATCH_OVERLAP_THRESHOLD: float = 0.9
+QUOTE_MATCH_MIN_TOKENS: int = 3
+
+
+def tokenize_for_quote_match(text: str) -> list[str]:
+    """Tokenize on Unicode word boundaries after the standard normalisation.
+
+    Language- and domain-neutral: it splits on whatever the Unicode word
+    class considers a word character. Numeric tokens like ``$75,000`` split
+    into ``["75", "000"]`` consistently in both quote and source, so digit
+    anchoring still works.
+    """
+    return WORD_TOKEN_PATTERN.findall(normalise_for_quote_match(text))
+
+
 def quote_is_in_source(quote: str, section_markdown: str) -> bool:
+    """Check that the LLM's ``source_quote`` is grounded in the section.
+
+    Fast path is the existing substring check after normalisation. When the
+    LLM paraphrases (drops intermediate words, reorders the noun phrase),
+    that fast path misses even though the quote is faithful to the source.
+    A token-overlap fallback catches those cases without letting hallucinated
+    numbers or substituted content words through: every digit-bearing token
+    in the quote must appear in the source, and at least
+    ``QUOTE_MATCH_OVERLAP_THRESHOLD`` of all quote tokens must appear in the
+    source token set.
+    """
     if not quote:
         return False
     if quote.strip().upper() == "NOT IN SOURCE":
         return False
-    return normalise_for_quote_match(quote) in normalise_for_quote_match(section_markdown)
+    norm_quote = normalise_for_quote_match(quote)
+    norm_source = normalise_for_quote_match(section_markdown)
+    if norm_quote in norm_source:
+        return True
+    quote_tokens = tokenize_for_quote_match(quote)
+    if len(quote_tokens) < QUOTE_MATCH_MIN_TOKENS:
+        return False
+    source_tokens = set(tokenize_for_quote_match(section_markdown))
+    for tok in quote_tokens:
+        if any(ch.isdigit() for ch in tok) and tok not in source_tokens:
+            return False
+    matched = sum(1 for tok in quote_tokens if tok in source_tokens)
+    return matched / len(quote_tokens) >= QUOTE_MATCH_OVERLAP_THRESHOLD
 
 
 def numeric_density_bonus(text: str) -> float:

--- a/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
@@ -510,9 +510,9 @@ def test_quote_is_in_source_rejects_hallucinated_number() -> None:
 
 
 def test_quote_is_in_source_rejects_substituted_content_word() -> None:
-    """Token-overlap threshold (90%) blocks single-word substitutions that
-    invert meaning while keeping most surface tokens. ``highest`` is not in
-    the source, so a six-other-tokens overlap fails."""
+    """All-tokens-in-source rule blocks single-word substitutions that invert
+    meaning while keeping most surface tokens. ``highest`` is not in the
+    source, so even a six-other-tokens overlap fails."""
     from worker_plan_internal.parameter_extraction.compress_report_section import (
         quote_is_in_source,
     )
@@ -522,6 +522,30 @@ def test_quote_is_in_source_rejects_substituted_content_word() -> None:
         "highest qualified middleware bid exceeds $75,000",
         source,
     ) is False
+
+
+def test_quote_is_in_source_rejects_substitution_in_long_quote() -> None:
+    """A longer quote with one substituted content word must still fail —
+    high fractional overlap is not a free pass. The all-tokens rule rejects
+    on the single missing token regardless of quote length, which a
+    fractional threshold like ≥90% would let through."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    source = (
+        "If the lowest qualified bid for OPC UA middleware exceeds $75,000, "
+        "then the project reverts to the current rule-based integration "
+        "vendor and escalates to the steering committee."
+    )
+    # Same 14-token clause; only ``lowest`` swapped for ``highest``. 13/14 of
+    # the tokens still appear in source, but the substituted word inverts
+    # the meaning and must not verify.
+    quote = (
+        "highest qualified bid for OPC UA middleware exceeds $75,000 "
+        "then project reverts to integration vendor"
+    )
+    assert quote_is_in_source(quote, source) is False
 
 
 def test_quote_is_in_source_rejects_short_unrelated_quote() -> None:

--- a/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
@@ -445,3 +445,91 @@ def test_merge_second_pass_items_preserves_emit_order() -> None:
     second = [_si("c", quote="q3"), _si("d", quote="q4"), _si("e", quote="q5")]
     merged, _ = merge_second_pass_items(first, second)
     assert [item.line_english for item in merged] == ["a", "b", "c", "d", "e"]
+
+
+def test_quote_is_in_source_substring_fast_path() -> None:
+    """Verbatim substring match remains the primary signal: a quote copied
+    cleanly from the source should still verify, including across the
+    existing whitespace/dash normalisation."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    source = "If the lowest qualified bid for OPC UA middleware exceeds $75,000, escalate."
+    assert quote_is_in_source("lowest qualified bid for OPC UA middleware", source) is True
+    # Dash variant: em-dash in quote, hyphen in source.
+    assert quote_is_in_source(
+        "qualified bid—for OPC UA middleware",
+        "qualified bid-for OPC UA middleware",
+    ) is True
+
+
+def test_quote_is_in_source_rejects_empty_and_sentinel() -> None:
+    """Empty and the LLM's explicit absence marker are never grounded."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    assert quote_is_in_source("", "anything goes here") is False
+    assert quote_is_in_source("NOT IN SOURCE", "NOT IN SOURCE appears literally here") is False
+
+
+def test_quote_is_in_source_accepts_paraphrase_token_overlap() -> None:
+    """When the LLM reorders or drops intermediate words while still
+    drawing every content token from the source, the token-overlap fallback
+    should accept it. Substring match would miss it because the word order
+    differs."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    source = (
+        "If the lowest qualified bid for OPC UA middleware exceeds $75,000, "
+        "the project re-scopes to a single integration vendor."
+    )
+    # Reordered: "middleware" moved before "bid", "for OPC UA" dropped.
+    assert quote_is_in_source(
+        "lowest qualified middleware bid exceeds $75,000",
+        source,
+    ) is True
+
+
+def test_quote_is_in_source_rejects_hallucinated_number() -> None:
+    """Digit-bearing tokens are anchored exactly. A quote that paraphrases
+    the text but swaps the numeric value is not grounded."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    source = "lowest qualified bid for OPC UA middleware exceeds $75,000"
+    # 80,000 ≠ 75,000 — must fail even though every other token is present.
+    assert quote_is_in_source(
+        "lowest qualified middleware bid exceeds $80,000",
+        source,
+    ) is False
+
+
+def test_quote_is_in_source_rejects_substituted_content_word() -> None:
+    """Token-overlap threshold (90%) blocks single-word substitutions that
+    invert meaning while keeping most surface tokens. ``highest`` is not in
+    the source, so a six-other-tokens overlap fails."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    source = "lowest qualified bid for OPC UA middleware exceeds $75,000"
+    assert quote_is_in_source(
+        "highest qualified middleware bid exceeds $75,000",
+        source,
+    ) is False
+
+
+def test_quote_is_in_source_rejects_short_unrelated_quote() -> None:
+    """Two- or one-token quotes do not get the token-overlap fallback —
+    too easy to satisfy by coincidence on a large source."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        quote_is_in_source,
+    )
+
+    source = "lowest qualified bid for OPC UA middleware exceeds $75,000"
+    assert quote_is_in_source("middleware bid", source) is False


### PR DESCRIPTION
## Summary
- **Problem.** `quote_is_in_source` was a strict substring check after normalisation. When the compress LLM paraphrased (dropped intermediate words, reordered the noun phrase), the check failed even though every content token came from the source. Because `composite_score` adds a +10 verified-quote bonus on a 1-25 `e × r` base, one missed verification can drop a load-bearing tripwire below the `MAX_ITEMS_PER_BUCKET = 6` cutoff. This is the ranking-layer gap PR #743 left open: in v52 inspection, the paperclip `$75,000` OPC UA bid had `qv=False` due to a reordered noun phrase (`"lowest qualified middleware bid"` vs source's `"lowest qualified bid for OPC UA middleware"`) and lost to lower-`e×r` verified explicits.
- **Fix.** Keep the substring check as the fast path. On miss, fall back to token-overlap that requires **every** quote token to appear in the source token set, after a min-3-token gate. Tokenisation is Unicode word boundaries (`\w+`), language- and domain-neutral. The all-tokens rule subsumes any digit-bearing anchor (numbers can't be substituted) and rejects any content-word substitution (`"highest"` for `"lowest"`) regardless of quote length.
- **Out of scope.** The emission-layer gap (LLM not producing a relevant item in either compress pass) is not addressed here; this PR only changes verification of items the LLM does emit.

## Empirical posture
Same-LLM (Gemini Flash Lite) same-session re-runs, so this is a regression check on the deterministic verifier and a behavioural probe — **not** a same-LLM improvement claim.

- **Unit tests**: 28 pass (21 prior + 7 new). New cases cover substring fast-path (regression), `NOT IN SOURCE` and empty, paraphrase via reorder/drop (intended True), hallucinated number (intended False), short-quote substitution (intended False), short unrelated quote (intended False), and a 14-token long-quote `highest`/`lowest` substitution (intended False — locks in the all-tokens rule against any future loosening).
- **Threshold-tightening cost**: simulated 90% vs 100% overlap against the v53 outputs (1366 scored candidates, 8 compress runs across 6 plans): **0 items lose `qv=True`** under tightening. The 90% rule was never functionally looser than the all-tokens rule on observed data; LLM paraphrases either reorder/elide (full token-overlap) or hit the substring fast path.
- **Paperclip acceptance (3× compress)**:
  - v53a: `$75k` bid in public `gates_and_thresholds` top-6 at position 2, `qv=True` ✓
  - v53b: `$75k` bid in public `gates_and_thresholds` top-6 at position 3, `qv=True` ✓
  - v53c: `$75k` bid emitted with `qv=True`, but in the `risks_and_shocks/premortem` bucket (candidate #12, `e=5 r=4 stress_test`, score ~30). Three other score-30 items beat it on tie-break for the last 3 public slots. Net: not in *any* public top-6 in v53c. This is bucket-categorisation variance (LLM placed the gate under "risk") plus tie-break, not emission failure or quote-match failure.
  - Net: **2 of 3 paperclip runs have `$75k` in public top-6** (vs 1 of 3 before); **3 of 3 verified-when-emitted**.
- **Regression sweep across 5 other probes** (euro_adoption, yellowstone, crate, mars_gtld, datacenter_france): **165 fallback flips** (13.7% of 1206 `qv=True`). Random-30 audit shows all legitimate paraphrases (dropped intermediate words, em-dash/hyphen variants, ellipsis-elided clauses) — no hallucinations, no content-word substitutions.

## Test plan
- [x] `pytest worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py` (28 pass)
- [x] Paperclip 3× run with `$75k` bid survival check (2/3 in public top-6 with `qv=True`; 1/3 emitted-and-verified-but-tie-broken in a different bucket)
- [x] 5-other-plan regression sweep with flip audit (165 flips, 30 sampled, all legitimate)
- [x] Threshold-tightening cost simulation (0 lost `qv=True` items under 90% → 100%)
- [x] CI green (tests, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)