### PR TITLE
napkin-math(validate): add aggregate_not_bounded and requirement_has_margin (Phase 3)

### DIFF
--- a/experiments/napkin_math/tests/run_smoke.py
+++ b/experiments/napkin_math/tests/run_smoke.py
@@ -223,7 +223,7 @@ def check_summarize_assessment_end_to_end(tmpdir: Path) -> None:
 
 def check_validate_parameters_end_to_end(tmpdir: Path) -> None:
     """Run validate_parameters.py against the smoke fixture and verify it
-    produces a clean validation.json (exit 0, valid: true, 16 checks listed).
+    produces a clean validation.json (exit 0, valid: true, 18 checks listed).
     """
     out = tmpdir / "validation.json"
     validator = NAPKIN_DIR / "validate_parameters.py"

--- a/experiments/napkin_math/tests/run_smoke.py
+++ b/experiments/napkin_math/tests/run_smoke.py
@@ -241,8 +241,8 @@ def check_validate_parameters_end_to_end(tmpdir: Path) -> None:
     body = json.loads(out.read_text())
     _check("validation.json valid: true", body.get("valid") is True)
     _check("validation.json error_count == 0", body.get("error_count") == 0)
-    _check("validation.json lists 16 checks_performed",
-           len(body.get("summary", {}).get("checks_performed", [])) == 16)
+    _check("validation.json lists 18 checks_performed",
+           len(body.get("summary", {}).get("checks_performed", [])) == 18)
 
 
 def check_prepare_extract_input_imports() -> None:

--- a/experiments/napkin_math/tests/test_validate_parameters.py
+++ b/experiments/napkin_math/tests/test_validate_parameters.py
@@ -310,6 +310,161 @@ def test_requirement_has_margin_silent_when_referenced_in_formula_rhs_only() -> 
     assert _violations_for(report, "requirement_has_margin") == []
 
 
+def test_requirement_has_margin_fires_when_reference_is_inside_a_sum() -> None:
+    """Regression for review feedback on PR #746: a reference inside a
+    pure sum (``combined_area = actual_area + buildable_area_required``)
+    consumes the value but does not test the realised-vs-required margin.
+    Pre-tightening this validated clean; the rule must now fire."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "buildable_area_required",
+                "label": "Buildable area required",
+                "category": "capacity",
+                "value_type": "explicit",
+                "unit": "km2",
+                "value": 32.2,
+                "comment": "Stated requirement",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "critical",
+                "uncertainty": "low",
+                "source_text": "Requires 32.2 km2 to support 9 GW.",
+            },
+        ],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "actual_area",
+                "label": "Realised area",
+                "unit": "km2",
+                "why_needed": "addend",
+                "suggested_estimation_method": "site survey",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_combined_area",
+                "label": "Combined area",
+                "formula_hint": "combined_area = actual_area + buildable_area_required",
+                "output_name": "combined_area",
+                "output_unit": "km2",
+                "depends_on": ["actual_area", "buildable_area_required"],
+                "why_first": "headline",
+            },
+        ],
+    }
+    report = validate(params)
+    fired = _violations_for(report, "requirement_has_margin")
+    assert len(fired) == 1
+    assert "buildable_area_required" in fired[0]["message"]
+
+
+def test_requirement_has_margin_fires_when_subtraction_but_no_margin_suffix() -> None:
+    """A real subtraction without a positive-pass output suffix reads
+    ambiguously when a downstream gate tests it against >= 0. The
+    threshold-friendly naming rule warns on `_gap/_deficit/_shortfall`;
+    here we require the converse — a clear margin-shape suffix."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "buildable_area_required",
+                "label": "Buildable area required",
+                "category": "capacity",
+                "value_type": "explicit",
+                "unit": "km2",
+                "value": 32.2,
+                "comment": "Stated requirement",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "critical",
+                "uncertainty": "low",
+                "source_text": "Requires 32.2 km2 to support 9 GW.",
+            },
+        ],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "actual_area",
+                "label": "Realised area",
+                "unit": "km2",
+                "why_needed": "subtrahend",
+                "suggested_estimation_method": "site survey",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_area_delta",
+                "label": "Area delta",
+                "formula_hint": "area_delta = actual_area - buildable_area_required",
+                "output_name": "area_delta",
+                "output_unit": "km2",
+                "depends_on": ["actual_area", "buildable_area_required"],
+                "why_first": "delta",
+            },
+        ],
+    }
+    report = validate(params)
+    fired = _violations_for(report, "requirement_has_margin")
+    assert len(fired) == 1
+
+
+def test_requirement_has_margin_silent_for_ratio_coverage() -> None:
+    """A coverage ratio (``actual / required``) with an ``_coverage``
+    output_name is an acceptable margin-shape: positive_pass = coverage
+    meets/exceeds the required threshold (typically >= 1.0)."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "buildable_area_required",
+                "label": "Buildable area required",
+                "category": "capacity",
+                "value_type": "explicit",
+                "unit": "km2",
+                "value": 32.2,
+                "comment": "Stated requirement",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "critical",
+                "uncertainty": "low",
+                "source_text": "Requires 32.2 km2 to support 9 GW.",
+            },
+        ],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "actual_area",
+                "label": "Realised area",
+                "unit": "km2",
+                "why_needed": "numerator",
+                "suggested_estimation_method": "site survey",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_area_coverage",
+                "label": "Area coverage ratio",
+                "formula_hint": "buildable_area_coverage = actual_area / buildable_area_required",
+                "output_name": "buildable_area_coverage",
+                "output_unit": "fraction",
+                "depends_on": ["actual_area", "buildable_area_required"],
+                "why_first": "coverage",
+            },
+        ],
+    }
+    report = validate(params)
+    assert _violations_for(report, "requirement_has_margin") == []
+
+
 def test_requirement_has_margin_silent_when_no_required_key_value() -> None:
     """No `_required` key_value at all → rule is silent. Avoids false
     positives on plans that don't state hard requirements."""

--- a/experiments/napkin_math/tests/test_validate_parameters.py
+++ b/experiments/napkin_math/tests/test_validate_parameters.py
@@ -1,0 +1,360 @@
+"""Focused unit tests for the structural rules added in Phase 3.
+
+End-to-end behaviour of the validator is covered by the smoke test
+(``check_validate_parameters_end_to_end`` in ``run_smoke.py``); these
+tests target the two new rules in isolation by passing minimal in-memory
+parameters dicts to ``validate``.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+NAPKIN_DIR = Path(__file__).resolve().parent.parent
+VALIDATOR_PATH = NAPKIN_DIR / "validate_parameters.py"
+
+spec = importlib.util.spec_from_file_location("validate_parameters", VALIDATOR_PATH)
+validate_parameters = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(validate_parameters)
+
+validate = validate_parameters.validate
+is_pure_sum_formula = validate_parameters.is_pure_sum_formula
+
+
+PLAN_SUMMARY = {
+    "plan_name": "test",
+    "plan_type": "test",
+    "primary_goal": "test",
+    "modelling_frame": "test",
+}
+
+
+def _violations_for(report: dict, rule_id: str) -> list[dict]:
+    return [v for v in report["violations"] if v["rule_id"] == rule_id]
+
+
+# ─── is_pure_sum_formula ──────────────────────────────────────────────────
+
+def test_is_pure_sum_formula_accepts_two_term_sum() -> None:
+    assert is_pure_sum_formula("total = a + b") is True
+
+
+def test_is_pure_sum_formula_accepts_three_term_sum() -> None:
+    assert is_pure_sum_formula("total = a + b + c") is True
+
+
+def test_is_pure_sum_formula_accepts_when_no_lhs() -> None:
+    assert is_pure_sum_formula("a + b + c") is True
+
+
+def test_is_pure_sum_formula_rejects_product() -> None:
+    assert is_pure_sum_formula("derived = rate * duration") is False
+
+
+def test_is_pure_sum_formula_rejects_mixed_operators() -> None:
+    # Mixed-operator expressions are out of scope; the unambiguous
+    # "aggregate of named parts" pattern only fires on pure sums.
+    assert is_pure_sum_formula("net = a + b - c") is False
+    assert is_pure_sum_formula("scaled = a * b + c") is False
+
+
+def test_is_pure_sum_formula_rejects_single_term() -> None:
+    assert is_pure_sum_formula("just_a = alpha") is False
+
+
+def test_is_pure_sum_formula_rejects_constants_in_terms() -> None:
+    # 30 is not a snake_case identifier; the rule only fires when every
+    # operand is a named variable the rest of the schema can reference.
+    assert is_pure_sum_formula("total = a + 30") is False
+
+
+def test_is_pure_sum_formula_handles_non_string() -> None:
+    assert is_pure_sum_formula(None) is False
+    assert is_pure_sum_formula(123) is False
+    assert is_pure_sum_formula("") is False
+
+
+# ─── aggregate_not_bounded ─────────────────────────────────────────────────
+
+def test_aggregate_not_bounded_fires_when_sum_lhs_is_also_missing() -> None:
+    """The disconnected-aggregates failure: a total computed as a sum of
+    named constituents AND also listed in missing_values_to_estimate."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "total_cost",
+                "label": "Total cost",
+                "unit": "USD",
+                "why_needed": "Headline total",
+                "suggested_estimation_method": "sum of constituents",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_total_cost",
+                "label": "Total cost from constituents",
+                "formula_hint": "total_cost = civil_works + remediation + hardware",
+                "output_name": "total_cost",
+                "output_unit": "USD",
+                "depends_on": ["civil_works", "remediation", "hardware"],
+                "why_first": "headline gate",
+            },
+        ],
+    }
+    report = validate(params)
+    fired = _violations_for(report, "aggregate_not_bounded")
+    assert len(fired) == 1
+    assert fired[0]["severity"] == "ERROR"
+    assert "total_cost" in fired[0]["message"]
+
+
+def test_aggregate_not_bounded_silent_when_no_missing_collision() -> None:
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "civil_works",
+                "label": "Civil works",
+                "unit": "USD",
+                "why_needed": "Constituent of total",
+                "suggested_estimation_method": "vendor quote",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_total_cost",
+                "label": "Total cost from constituents",
+                "formula_hint": "total_cost = civil_works + remediation + hardware",
+                "output_name": "total_cost",
+                "output_unit": "USD",
+                "depends_on": ["civil_works", "remediation", "hardware"],
+                "why_first": "headline gate",
+            },
+        ],
+    }
+    report = validate(params)
+    assert _violations_for(report, "aggregate_not_bounded") == []
+
+
+def test_aggregate_not_bounded_silent_when_formula_is_not_pure_sum() -> None:
+    """A burn-rate × duration product whose LHS is also a missing value
+    is a different (and rarer) failure mode; this check intentionally
+    fires only on pure sums to avoid false positives on multiplicative
+    decompositions."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "holding_cost",
+                "label": "Holding cost",
+                "unit": "EUR",
+                "why_needed": "operational",
+                "suggested_estimation_method": "burn × delay",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_holding_cost",
+                "label": "Holding cost",
+                "formula_hint": "holding_cost = annual_burn_rate * delay_years",
+                "output_name": "holding_cost",
+                "output_unit": "EUR",
+                "depends_on": ["annual_burn_rate", "delay_years"],
+                "why_first": "operational",
+            },
+        ],
+    }
+    report = validate(params)
+    assert _violations_for(report, "aggregate_not_bounded") == []
+
+
+# ─── requirement_has_margin ───────────────────────────────────────────────
+
+def test_requirement_has_margin_fires_when_required_kv_has_no_referencing_calc() -> None:
+    """A `_required` key value with no calculation consuming it leaves
+    the realised-vs-required margin variable undeclared."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "buildable_area_required",
+                "label": "Buildable area required",
+                "category": "capacity",
+                "value_type": "explicit",
+                "unit": "km2",
+                "value": 32.2,
+                "comment": "Stated requirement",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "critical",
+                "uncertainty": "low",
+                "source_text": "Requires 32.2 km2 to support 9 GW.",
+            },
+        ],
+        "derived_questions": [],
+        "missing_values_to_estimate": [],
+        "recommended_first_calculations": [],
+    }
+    report = validate(params)
+    fired = _violations_for(report, "requirement_has_margin")
+    assert len(fired) == 1
+    assert "buildable_area_required" in fired[0]["message"]
+
+
+def test_requirement_has_margin_silent_when_referenced_in_depends_on() -> None:
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "buildable_area_required",
+                "label": "Buildable area required",
+                "category": "capacity",
+                "value_type": "explicit",
+                "unit": "km2",
+                "value": 32.2,
+                "comment": "Stated requirement",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "critical",
+                "uncertainty": "low",
+                "source_text": "Requires 32.2 km2 to support 9 GW.",
+            },
+        ],
+        "derived_questions": [],
+        "missing_values_to_estimate": [
+            {
+                "id": "buildable_area_actual",
+                "label": "Realised buildable area",
+                "unit": "km2",
+                "why_needed": "test against requirement",
+                "suggested_estimation_method": "site survey",
+            },
+        ],
+        "recommended_first_calculations": [
+            {
+                "id": "calc_buildable_surplus",
+                "label": "Buildable area surplus",
+                "formula_hint": "buildable_area_surplus = buildable_area_actual - buildable_area_required",
+                "output_name": "buildable_area_surplus",
+                "output_unit": "km2",
+                "depends_on": ["buildable_area_actual", "buildable_area_required"],
+                "why_first": "primary capacity gate",
+            },
+        ],
+    }
+    report = validate(params)
+    assert _violations_for(report, "requirement_has_margin") == []
+
+
+def test_requirement_has_margin_silent_when_referenced_in_formula_rhs_only() -> None:
+    """If the requirement is consumed by a formula but not listed in
+    depends_on, the validator's depends_on_declared rule will catch the
+    omission separately; for requirement_has_margin, formula-RHS
+    membership is enough to satisfy 'is referenced by a calculation'."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "throughput_per_week_required",
+                "label": "Throughput required",
+                "category": "operational",
+                "value_type": "explicit",
+                "unit": "units_per_week",
+                "value": 100,
+                "comment": "Stated floor",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "high",
+                "uncertainty": "low",
+                "source_text": "At least 100 units per week.",
+            },
+        ],
+        "derived_questions": [
+            {
+                "id": "q_margin",
+                "question": "What is the throughput surplus?",
+                "why_it_matters": "tests the floor",
+                "formula_hint": "throughput_surplus = throughput_actual - throughput_per_week_required",
+                "output_name": "throughput_surplus",
+                "output_unit": "units_per_week",
+                "depends_on": ["throughput_actual"],
+            },
+        ],
+        "missing_values_to_estimate": [
+            {
+                "id": "throughput_actual",
+                "label": "Realised throughput",
+                "unit": "units_per_week",
+                "why_needed": "tests the floor",
+                "suggested_estimation_method": "logged runs",
+            },
+        ],
+        "recommended_first_calculations": [],
+    }
+    report = validate(params)
+    assert _violations_for(report, "requirement_has_margin") == []
+
+
+def test_requirement_has_margin_silent_when_no_required_key_value() -> None:
+    """No `_required` key_value at all → rule is silent. Avoids false
+    positives on plans that don't state hard requirements."""
+    params = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [
+            {
+                "id": "throughput_target",
+                "label": "Throughput target",
+                "category": "operational",
+                "value_type": "explicit",
+                "unit": "units_per_week",
+                "value": 100,
+                "comment": "Aspirational target, not a hard floor",
+                "formula_hint": None,
+                "output_name": None,
+                "output_unit": None,
+                "depends_on": [],
+                "modelling_priority": "high",
+                "uncertainty": "medium",
+                "source_text": "Aim for 100 units per week.",
+            },
+        ],
+        "derived_questions": [],
+        "missing_values_to_estimate": [],
+        "recommended_first_calculations": [],
+    }
+    report = validate(params)
+    assert _violations_for(report, "requirement_has_margin") == []
+
+
+# ─── checks_performed enumeration ─────────────────────────────────────────
+
+def test_validate_lists_all_18_checks() -> None:
+    """The validator must report all 18 checks_performed, including the
+    two new structural rules. Downstream consumers (summarize_assessment)
+    use this list to render the validation card."""
+    report = validate({
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [],
+        "derived_questions": [],
+        "missing_values_to_estimate": [],
+        "recommended_first_calculations": [],
+    })
+    checks = report["summary"]["checks_performed"]
+    assert len(checks) == 18
+    assert "aggregate_not_bounded" in checks
+    assert "requirement_has_margin" in checks

--- a/experiments/napkin_math/validate_parameters.py
+++ b/experiments/napkin_math/validate_parameters.py
@@ -107,6 +107,10 @@ FORMULA_BUILTINS = {"min", "max", "abs", "sum", "round", "int", "float"}
 # elsewhere.
 THRESHOLD_UNFRIENDLY_PATTERN = re.compile(r"_(gap|deficit|shortfall)(_[a-z0-9_]+)?$")
 
+# Output-name suffixes recognised as a realised-vs-required margin shape.
+# Matched as a token at the end or just before a unit/qualifier suffix.
+MARGIN_SUFFIX_PATTERN = re.compile(r"_(margin|surplus|buffer|coverage)(_[a-z0-9_]+)?$")
+
 
 def violation(rule_id: str, severity: str, path: str,
               message: str, suggested_fix: str) -> dict:
@@ -528,15 +532,24 @@ def check_aggregate_not_bounded(params: dict, violations: list) -> None:
 
 def check_requirement_has_margin(params: dict, violations: list) -> None:
     """A key_value whose id ends in ``_required`` names a stated
-    requirement floor. At least one calculation in derived_questions or
-    recommended_first_calculations must reference it (formula RHS or
-    depends_on), so that the realised-vs-required margin variable is
-    declared.
+    requirement floor. At least one calculation must declare a real
+    realised-vs-required margin against it. Three properties together
+    constitute a margin:
 
-    Without this pairing the simulation defaults to ``>= 0`` against an
-    absolute quantity that has not been compared to its requirement —
-    the threshold then passes for any non-negative realisation, even
-    when the realised value falls below the requirement.
+    1. The requirement id appears on the formula RHS (the calculation
+       actually consumes the required value).
+    2. The formula contains a subtraction or ratio operator (the
+       calculation compares the realised quantity to the requirement,
+       rather than adding the requirement into an aggregate).
+    3. The output_name carries a positive-pass margin suffix
+       (``_margin``/``_surplus``/``_buffer``/``_coverage``), so a
+       downstream ``>= 0`` threshold reads correctly.
+
+    A bare reference inside a sum (e.g. ``combined = actual + required``)
+    consumes the value but does not test whether the realised quantity
+    meets the requirement. Without a real margin, the gate defaults to
+    ``>= 0`` against an absolute quantity and passes for any non-negative
+    realisation regardless of whether it meets the requirement.
     """
     required_kv: list[tuple[int, str]] = []
     for i, entry in enumerate(params.get("key_values", []) or []):
@@ -547,28 +560,43 @@ def check_requirement_has_margin(params: dict, violations: list) -> None:
             required_kv.append((i, eid))
     if not required_kv:
         return
-    referenced: set[str] = set()
-    for section in ("derived_questions", "recommended_first_calculations"):
-        for entry in params.get(section, []) or []:
-            if not isinstance(entry, dict):
-                continue
-            for d in entry.get("depends_on", []) or []:
-                if isinstance(d, str):
-                    referenced.add(d)
-            formula = entry.get("formula_hint")
-            if formula:
-                referenced |= parse_rhs_vars(formula)
     for i, rid in required_kv:
-        if rid in referenced:
+        satisfied = False
+        for section in ("derived_questions", "recommended_first_calculations"):
+            for entry in params.get(section, []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                formula = entry.get("formula_hint")
+                if not isinstance(formula, str) or not formula:
+                    continue
+                if rid not in parse_rhs_vars(formula):
+                    continue
+                rhs = formula.split("=", 1)[1] if "=" in formula else formula
+                if "-" not in rhs and "/" not in rhs:
+                    continue
+                output_name = entry.get("output_name")
+                if not isinstance(output_name, str):
+                    continue
+                if not MARGIN_SUFFIX_PATTERN.search(output_name):
+                    continue
+                satisfied = True
+                break
+            if satisfied:
+                break
+        if satisfied:
             continue
         violations.append(violation(
             "requirement_has_margin", "ERROR",
             f"$.key_values[{i}].id",
-            f"key_value `{rid}` names a requirement but no calculation references it; the "
-            f"realised-vs-required margin variable is missing",
-            f"add a derived_question or recommended_first_calculation that consumes `{rid}` "
-            f"(e.g. compute a `*_surplus`/`*_margin` of realised minus required), or rename "
-            f"the key_value if it isn't actually a requirement",
+            f"key_value `{rid}` names a requirement but no calculation declares a "
+            f"realised-vs-required margin against it; expected a derived_question or "
+            f"recommended_first_calculation whose formula references `{rid}` with a "
+            f"subtraction or ratio operator AND whose output_name ends in "
+            f"_margin/_surplus/_buffer/_coverage",
+            f"add a calculation like `<base>_margin = <actual> - {rid}` (or "
+            f"`<base>_coverage = <actual> / {rid}`) so a >= 0 / >= 1 threshold tests the "
+            f"realised value against the requirement; or rename the key_value if it "
+            f"isn't actually a requirement",
         ))
 
 

--- a/experiments/napkin_math/validate_parameters.py
+++ b/experiments/napkin_math/validate_parameters.py
@@ -7,7 +7,7 @@ Replaces the LLM-driven `validate-parameters` skill. Reads a
 the shape that `summarize_assessment.py` consumes (named `checks_performed`
 list + per-violation rule_id/severity/path/message/suggested_fix).
 
-16 structural checks are run:
+18 structural checks are run:
 
     json_parse                                # implicit (file already parsed)
     top_level_structure                       # plan_summary + four arrays
@@ -25,6 +25,8 @@ list + per-violation rule_id/severity/path/message/suggested_fix).
     no_dead_end_variables                     # every kv/mv consumed by a calc
     threshold_friendly_naming                 # WARN on _gap/_deficit/_shortfall outputs
     shared_pool_legitimacy                    # no-op; enforced upstream in the prompt
+    aggregate_not_bounded                     # sum-formula LHS not in missing_values
+    requirement_has_margin                    # *_required key_value referenced by a calc
 
 `valid` is true iff `error_count == 0`. WARN-level findings do not
 invalidate the file. Exit code 0 on valid, 1 on invalid, 2 on JSON parse
@@ -46,6 +48,7 @@ CHECKS_PERFORMED = [
     "source_text_word_caps", "output_name_present_when_formula_hint",
     "output_unit_present_when_formula_hint", "no_dead_end_variables",
     "threshold_friendly_naming", "shared_pool_legitimacy",
+    "aggregate_not_bounded", "requirement_has_margin",
 ]
 
 CAPS = {
@@ -461,6 +464,114 @@ def check_shared_pool_legitimacy(params: dict, violations: list) -> None:
     return
 
 
+def is_pure_sum_formula(formula: object) -> bool:
+    """A formula is a pure sum aggregate when its RHS is a chain of
+    snake_case identifiers joined by ``+`` and nothing else. Constants,
+    multiplication, division, subtraction, function calls, and unary
+    minus all disqualify it. The intent is to flag only the unambiguous
+    ``total = A + B + C`` shape — a flat bounded variable for the LHS
+    would conflict with the constituent decomposition. Mixed expressions
+    like ``A*B + C`` are out of scope here because their semantics are
+    not unambiguously "aggregate of the named parts".
+    """
+    if not isinstance(formula, str) or not formula:
+        return False
+    rhs = formula.split("=", 1)[1] if "=" in formula else formula
+    rhs = rhs.strip()
+    while rhs.startswith("(") and rhs.endswith(")"):
+        rhs = rhs[1:-1].strip()
+    if not rhs or "+" not in rhs:
+        return False
+    if any(op in rhs for op in ("*", "/", "-")):
+        return False
+    parts = [p.strip() for p in rhs.split("+")]
+    if len(parts) < 2:
+        return False
+    return all(SNAKE_CASE_RE.match(p) for p in parts)
+
+
+def check_aggregate_not_bounded(params: dict, violations: list) -> None:
+    """A variable computed as a pure sum of named constituents MUST NOT
+    also appear in ``missing_values_to_estimate``.
+
+    When a total is sampled independently of its named sub-components, a
+    single Monte Carlo trial can pair sub-component p95s with a total
+    p05 (or vice versa). The total is a calculation over the
+    constituents, not a primitive input that needs estimation.
+    """
+    missing_ids: set[str] = set()
+    for entry in params.get("missing_values_to_estimate", []) or []:
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str):
+            missing_ids.add(entry["id"])
+    if not missing_ids:
+        return
+    for section in ("key_values", "derived_questions", "recommended_first_calculations"):
+        for i, entry in enumerate(params.get(section, []) or []):
+            if not isinstance(entry, dict):
+                continue
+            if not is_pure_sum_formula(entry.get("formula_hint")):
+                continue
+            output_name = entry.get("output_name")
+            if not isinstance(output_name, str):
+                continue
+            if output_name not in missing_ids:
+                continue
+            violations.append(violation(
+                "aggregate_not_bounded", "ERROR",
+                f"$.{section}[{i}].output_name",
+                f"`{output_name}` is computed as a sum of named constituents AND also appears in "
+                f"missing_values_to_estimate; bounding the aggregate flat lets a single Monte Carlo "
+                f"trial pair sub-component p95s with a total p05",
+                f"drop `{output_name}` from missing_values_to_estimate (the named constituents are the primitives)",
+            ))
+
+
+def check_requirement_has_margin(params: dict, violations: list) -> None:
+    """A key_value whose id ends in ``_required`` names a stated
+    requirement floor. At least one calculation in derived_questions or
+    recommended_first_calculations must reference it (formula RHS or
+    depends_on), so that the realised-vs-required margin variable is
+    declared.
+
+    Without this pairing the simulation defaults to ``>= 0`` against an
+    absolute quantity that has not been compared to its requirement —
+    the threshold then passes for any non-negative realisation, even
+    when the realised value falls below the requirement.
+    """
+    required_kv: list[tuple[int, str]] = []
+    for i, entry in enumerate(params.get("key_values", []) or []):
+        if not isinstance(entry, dict):
+            continue
+        eid = entry.get("id")
+        if isinstance(eid, str) and eid.endswith("_required"):
+            required_kv.append((i, eid))
+    if not required_kv:
+        return
+    referenced: set[str] = set()
+    for section in ("derived_questions", "recommended_first_calculations"):
+        for entry in params.get(section, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            for d in entry.get("depends_on", []) or []:
+                if isinstance(d, str):
+                    referenced.add(d)
+            formula = entry.get("formula_hint")
+            if formula:
+                referenced |= parse_rhs_vars(formula)
+    for i, rid in required_kv:
+        if rid in referenced:
+            continue
+        violations.append(violation(
+            "requirement_has_margin", "ERROR",
+            f"$.key_values[{i}].id",
+            f"key_value `{rid}` names a requirement but no calculation references it; the "
+            f"realised-vs-required margin variable is missing",
+            f"add a derived_question or recommended_first_calculation that consumes `{rid}` "
+            f"(e.g. compute a `*_surplus`/`*_margin` of realised minus required), or rename "
+            f"the key_value if it isn't actually a requirement",
+        ))
+
+
 CHECK_FUNCTIONS = {
     "json_parse": None,  # implicit; failure handled in main()
     "top_level_structure": check_top_level_structure,
@@ -478,6 +589,8 @@ CHECK_FUNCTIONS = {
     "no_dead_end_variables": check_no_dead_end_variables,
     "threshold_friendly_naming": check_threshold_friendly_naming,
     "shared_pool_legitimacy": check_shared_pool_legitimacy,
+    "aggregate_not_bounded": check_aggregate_not_bounded,
+    "requirement_has_margin": check_requirement_has_margin,
 }
 
 


### PR DESCRIPTION
## Summary
Phase 3 of `experiments/napkin_math/docs/20260520_plan.md`. Adds two new deterministic structural checks to `validate_parameters.py`, targeting Gemini's R1.1 (disconnected aggregates) and R2.5 (threshold trivialization).

### New rules

1. **`aggregate_not_bounded`** (ERROR) — when an entry's `formula_hint` is a pure sum of named identifiers (`total = A + B + C`) and its `output_name` also appears in `missing_values_to_estimate`, the aggregate is sampled independently of its constituents. A single Monte Carlo trial can then pair sub-component p95s with a total p05. The total is a calculation over the parts, not a primitive input to estimate. Detection is deterministic and syntactic — RHS contains `+`, no other operators, every operand is a snake_case identifier. Mixed-operator expressions (`a + b - c`, `a * b + c`) are intentionally out of scope to avoid false positives on multiplicative or netted decompositions.
2. **`requirement_has_margin`** (ERROR) — when a `key_value`'s id ends in `_required`, at least one calculation in `derived_questions` or `recommended_first_calculations` must declare a real realised-vs-required margin. Three properties together constitute a margin:
   1. The requirement id appears on the formula RHS (the calculation actually consumes the required value).
   2. The formula contains a subtraction or ratio operator (the calculation compares the realised quantity to the requirement, rather than adding the requirement into an aggregate).
   3. The output_name carries a positive-pass margin suffix (`_margin`/`_surplus`/`_buffer`/`_coverage`), so a downstream `>= 0` (or `>= 1` for coverage) threshold reads correctly.

   A bare reference inside a sum (e.g. `combined = actual + required`) consumes the value but does not test whether the realised quantity meets the requirement, and was the false-pass case flagged in the first review round.

### Out of scope

The Phase 3 `sampling_discipline` enum expansion (`lognormal`, `pert`) is **not** in this PR. `VALID_DISCIPLINES` lives in `run_monte_carlo.py`, not `validate_parameters.py`. Expanding the allowed set without the matching sampler implementation (Phase 8) would create a silent shim where validation passes but sampling uses the wrong (triangular) distribution — exactly the "shim that pretends to work" antipattern. That bullet belongs alongside Phase 4 (bounds prompt emits the new disciplines) or Phase 8 (samplers implement them).

## Empirical posture

- **Unit tests**: 19 focused tests in `tests/test_validate_parameters.py`. Coverage includes the sum-formula classifier alone, the `aggregate_not_bounded` fire and silent paths, the `requirement_has_margin` fire/silent paths with the three property combinations (false-pass sum, subtraction without margin suffix, ratio coverage as legitimate margin), and the `checks_performed` enumeration. All pass.
- **Smoke-test fixture**: validates clean against the updated validator (18 checks_performed, 0 errors, 0 warnings). Smoke-test assertion and docstring updated from 16 → 18 checks.
- **6 existing v51 parameters.json files** (paperclip, euro_adoption, yellowstone, crate, mars_gtld, datacenter_france): all still `valid=True, errors=0, warns=0` with zero new-rule violations. The corpus does not currently emit `_required` ids, so the tightened margin rule is correctly dormant — it will engage once Phase 2 extract prompts start producing requirement-floor key_values.

## Test plan
- [x] `pytest experiments/napkin_math/tests/test_validate_parameters.py` (19 pass)
- [x] Smoke fixture validates clean (18 checks_performed, 0 errors, 0 warns)
- [x] All 6 v51 plans still validate clean (0 false positives from new rules)
- [x] Regression test for the false-pass sum case (`combined = actual + required`) — rule now fires
- [x] CI green on this branch (tests, lint, typecheck after the original commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)