### PR TITLE
napkin-math(bounds): Phase 4 runtime + schema readiness

### DIFF
--- a/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/generate-bounds/system-prompt.txt
@@ -187,6 +187,8 @@ sampling_discipline must be one of:
 - "integer"         — countable units (people, households, days, kits, sites, …); downstream samplers round draws to the nearest integer and re-clamp to [low, high]
 - "fraction"        — bounded in [0, 1]; downstream samplers clamp draws to that interval
 - "continuous"      — real-valued; downstream samplers do not round or clamp beyond the [low, high] range
+- "lognormal"       — fat-tailed real-valued draw whose [low, high] mean P5 / P95, not hard cutoffs. **Schema-reserved: the Monte Carlo runner accepts this value at validation time but raises NotImplementedError at sample time until Phase 8 lands the matching sampler.** Do not emit yet unless a follow-up rule (megaproject CAPEX default) explicitly directs you to.
+- "pert"            — three-point modified-beta draw centered on base with low/high as the supports. **Schema-reserved with the same Phase-8 caveat as lognormal.** Do not emit yet.
 
 Choose sampling_discipline by the variable's nature, not by lexical tokens in its id or unit. The downstream Monte Carlo runner does not pattern-match on unit strings; it reads sampling_discipline directly. There must be no fallback path that re-guesses the discipline.
 
@@ -196,11 +198,13 @@ default_pass_probability:
 - For sampling_discipline "bernoulli_gate": must be a number in [0, 1]; this is the assumed pass probability when the caller does not override it
 - For every other sampling_discipline: must be null
 
+A single optional top-level key `correlations` is reserved alongside the per-variable entries for declaring cross-variable correlation groups. **Schema-reserved with the same Phase-8 caveat as lognormal/pert: the runner preserves the key but does not yet apply correlated sampling.** Do not emit a `correlations` block yet; the detailed selection rules will land alongside the copula sampler.
+
 Rules for the output:
 
 - Output only variables selected by the rules above.
 - Do not invent ids.
-- Every top-level key must correspond to a declared id in key_values or missing_values_to_estimate.
+- Every top-level key must correspond to a declared id in key_values or missing_values_to_estimate (except for the reserved `correlations` key described above, which is not yet emitted).
 - Order keys by importance: critical-priority first, then high, then medium, then remaining missing_values_to_estimate not already placed.
 - rationale must be at most 50 words. The cap exists to discourage prose, not to suppress required disclosures: the named-anchor paraphrase required by ACTUAL-VS-COMMITMENT and the base-vs-threshold clause required by SANITY CHECK are exempt from the cap if they push the rationale past 50 words.
 - Split rationale on whitespace for word count; hyphenated and slash-joined tokens count as one word.

--- a/experiments/napkin_math/run_monte_carlo.py
+++ b/experiments/napkin_math/run_monte_carlo.py
@@ -491,11 +491,18 @@ def run(params_path: Path, bounds_path: Path, calc_path: Path,
 
     bounds, stripped_threshold_bounds = strip_threshold_bounds(bounds, params)
     for entry in stripped_threshold_bounds:
-        warnings_text.append(
-            f"stripped threshold variable '{entry['id']}' from bounds "
-            f"(reason: {entry['reason']}); simulation will use the stated value "
-            f"from parameters.json"
-        )
+        if entry["reason"] == "calculation-output":
+            warnings_text.append(
+                f"stripped calculation output '{entry['id']}' from bounds; "
+                f"simulation will compute it from calculations.py instead of "
+                f"sampling it independently"
+            )
+        else:
+            warnings_text.append(
+                f"stripped threshold variable '{entry['id']}' from bounds "
+                f"(reason: {entry['reason']}); simulation will use the stated value "
+                f"from parameters.json"
+            )
 
     input_specs = collect_input_specs(params, bounds)
     plan, plan_warnings = build_calculation_plan(params, module)

--- a/experiments/napkin_math/run_monte_carlo.py
+++ b/experiments/napkin_math/run_monte_carlo.py
@@ -35,7 +35,26 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "correlation_groups": [],
 }
 
-VALID_DISCIPLINES = {"fixed", "bernoulli_gate", "integer", "fraction", "continuous"}
+VALID_DISCIPLINES = {
+    "fixed", "bernoulli_gate", "integer", "fraction", "continuous",
+    # Phase 4 reserved; sampler raises NotImplementedError until Phase 8
+    # implements the matching samplers. Validation passes so that
+    # generate-bounds can begin emitting these for plan_type-driven
+    # megaproject CAPEX without a downstream schema error.
+    "lognormal", "pert",
+}
+
+# Disciplines whose schema is reserved but whose sampler is not yet
+# implemented. ``sample_one`` raises ``NotImplementedError`` loudly so a
+# user trying to run Monte Carlo against bounds that use them gets an
+# explicit failure rather than a silent fall-back to triangular.
+UNIMPLEMENTED_DISCIPLINES = frozenset({"lognormal", "pert"})
+
+# Top-level keys in ``bounds.json`` that are not per-variable bound
+# entries. ``correlations`` carries the optional R1.3 declared-correlation
+# groups; it is preserved as-is through ``strip_threshold_bounds`` and
+# never reaches per-variable validation or sampling.
+RESERVED_TOP_LEVEL_KEYS = frozenset({"correlations"})
 
 THRESHOLD_SUFFIXES = (
     "_threshold", "_target", "_ceiling", "_floor",
@@ -135,10 +154,30 @@ def _collect_formula_threshold_ids(parameters: dict) -> set[str]:
     return threshold_ids
 
 
+def _collect_calculation_output_names(parameters: dict) -> set[str]:
+    """``output_name`` values declared by any calculation in
+    ``recommended_first_calculations`` or ``derived_questions``. These
+    names refer to *computed* quantities — a bound on the output would
+    sample the aggregate independently of its formula's named inputs,
+    so a single Monte Carlo trial can pair sub-component p95s with a
+    total p05 (Gemini R1.1, disconnected aggregates).
+    """
+    out: set[str] = set()
+    for src in ("recommended_first_calculations", "derived_questions"):
+        for entry in parameters.get(src, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("output_name")
+            if isinstance(name, str) and name:
+                out.add(name)
+    return out
+
+
 def strip_threshold_bounds(
     bounds: dict, parameters: dict,
 ) -> tuple[dict, list[dict]]:
-    """Remove bounds entries for threshold/target variables.
+    """Remove bounds entries for threshold/target variables and for
+    variables that are calculation outputs.
 
     Bounds entries on threshold variables silently change what `pass_rate`
     measures from "does actual >= stated_threshold" to
@@ -147,28 +186,41 @@ def strip_threshold_bounds(
     `collect_input_specs` does this automatically when the threshold variable
     is absent from bounds. This function enforces that absence.
 
+    Bounds entries on calculation outputs (variables that appear as a
+    declared ``output_name`` in ``recommended_first_calculations`` or
+    ``derived_questions``) would let a single Monte Carlo trial pair
+    sub-component p95s with a total p05; the output is computed from its
+    inputs, not sampled.
+
     Deterministic backstop for the rule documented in
     `.claude/skills/generate-bounds/system-prompt.txt`. The LLM is asked to
-    skip threshold variables but does not reliably do so when parameter-JSON
-    metadata (medium uncertainty + critical/high priority) signals strongly
-    to include them.
+    skip threshold and aggregate variables but does not reliably do so when
+    parameter-JSON metadata (medium uncertainty + critical/high priority)
+    signals strongly to include them.
 
     Identification:
       1. id suffix match against `THRESHOLD_SUFFIXES`
       2. id appears as the non-`actual_` operand in a binary-subtraction
          margin formula declared in `recommended_first_calculations` or
          `derived_questions`
+      3. id matches the ``output_name`` of any declared calculation
 
-    Variables prefixed `actual_` are never stripped.
+    Variables prefixed `actual_` are never stripped. Reserved top-level
+    keys (currently ``correlations``) pass through unchanged so the
+    optional correlations block survives this pre-processor.
 
     Returns ``(cleaned_bounds, stripped)``. ``stripped`` is an ordered list
-    of ``{"id": str, "reason": "suffix" | "formula-side"}`` records. The
-    input ``bounds`` is not mutated.
+    of ``{"id": str, "reason": "suffix" | "formula-side" | "calculation-output"}``
+    records. The input ``bounds`` is not mutated.
     """
     formula_threshold_ids = _collect_formula_threshold_ids(parameters)
+    calculation_output_names = _collect_calculation_output_names(parameters)
     cleaned: dict = {}
     stripped: list[dict] = []
     for bound_id, bound in bounds.items():
+        if bound_id in RESERVED_TOP_LEVEL_KEYS:
+            cleaned[bound_id] = bound
+            continue
         if bound_id.startswith("actual_"):
             cleaned[bound_id] = bound
             continue
@@ -177,6 +229,9 @@ def strip_threshold_bounds(
             continue
         if bound_id in formula_threshold_ids:
             stripped.append({"id": bound_id, "reason": "formula-side"})
+            continue
+        if bound_id in calculation_output_names:
+            stripped.append({"id": bound_id, "reason": "calculation-output"})
             continue
         cleaned[bound_id] = bound
     return cleaned, stripped
@@ -225,6 +280,15 @@ def sample_one(rng: np.random.Generator, bound: dict, distribution_default: str,
     if discipline == "bernoulli_gate":
         p = gate_probabilities.get(var_id, bound["default_pass_probability"])
         return high if rng.random() < p else low
+
+    if discipline in UNIMPLEMENTED_DISCIPLINES:
+        raise NotImplementedError(
+            f"bound '{var_id}' has sampling_discipline {discipline!r}; "
+            f"the matching sampler is not yet implemented in run_monte_carlo. "
+            f"This value is accepted by the schema (Phase 4) but the sampler "
+            f"lands in Phase 8 — switch to triangular/continuous in bounds.json "
+            f"or wait for Phase 8."
+        )
 
     if low == high:
         val = low

--- a/experiments/napkin_math/tests/test_run_monte_carlo.py
+++ b/experiments/napkin_math/tests/test_run_monte_carlo.py
@@ -219,6 +219,104 @@ class TestSamplingDiscipline(unittest.TestCase):
         self.assertIn("pert", str(ctx.exception))
 
 
+class TestStrippedBoundsWarnings(unittest.TestCase):
+    """Reason-branched warning text for ``strip_threshold_bounds`` results.
+
+    Review feedback on PR #747: the original warning said every stripped
+    item was a "threshold variable" whose value would be read from
+    parameters.json — false for calculation outputs, which are computed
+    from calculations.py instead of read as a stated value.
+    """
+
+    def test_calculation_output_warning_mentions_calculations_py(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            calc = (
+                "def total(a: float, b: float) -> float:\n"
+                "    return a + b\n"
+            )
+            bound_a = make_bound(unit="EUR", low=1, base=2, high=3,
+                                 sampling_discipline="continuous")
+            bound_b = make_bound(unit="EUR", low=4, base=5, high=6,
+                                 sampling_discipline="continuous")
+            bound_total = make_bound(unit="EUR", low=10, base=20, high=30,
+                                     sampling_discipline="continuous")
+            result = run_with_fixture(
+                tmpdir,
+                missing_values=[
+                    {"id": "a", "label": "a", "unit": "EUR",
+                     "why_needed": "x", "suggested_estimation_method": "x"},
+                    {"id": "b", "label": "b", "unit": "EUR",
+                     "why_needed": "x", "suggested_estimation_method": "x"},
+                ],
+                recommended=[{
+                    "id": "c_total", "label": "total",
+                    "formula_hint": "total = a + b",
+                    "output_name": "total", "output_unit": "EUR",
+                    "depends_on": ["a", "b"], "why_first": "x",
+                }],
+                bounds={"a": bound_a, "b": bound_b, "total": bound_total},
+                calc_source=calc,
+                _settings={"n_runs": 100, "seed": 1},
+            )
+
+        stripped = result["bounds_post_processor"]["stripped_threshold_ids"]
+        self.assertEqual(stripped, [{"id": "total", "reason": "calculation-output"}])
+
+        messages = [w["message"] for w in result["warnings"]]
+        calc_warnings = [m for m in messages if "calculation output" in m]
+        self.assertEqual(len(calc_warnings), 1, msg=messages)
+        warning = calc_warnings[0]
+        self.assertIn("'total'", warning)
+        self.assertIn("calculations.py", warning)
+        # The threshold-variable phrasing must NOT appear for a
+        # calculation-output strip — that wording is reserved for
+        # suffix/formula-side strips where the value really does come
+        # from parameters.json.
+        self.assertNotIn("threshold variable", warning)
+        self.assertNotIn("stated value", warning)
+
+    def test_threshold_strip_warning_unchanged(self):
+        """Sibling guard: the original threshold-variable wording is
+        preserved for suffix/formula-side strips."""
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            calc = "def out(x: float) -> float:\n    return x\n"
+            bound_x = make_bound(low=0.1, base=0.2, high=0.3,
+                                 sampling_discipline="fraction")
+            bound_threshold = make_bound(low=0.4, base=0.5, high=0.6,
+                                         sampling_discipline="fraction")
+            result = run_with_fixture(
+                tmpdir,
+                missing_values=[{"id": "x", "label": "x", "unit": "fraction",
+                                 "why_needed": "x", "suggested_estimation_method": "x"}],
+                key_values=[{
+                    "id": "x_threshold", "label": "threshold",
+                    "category": "operational", "value_type": "explicit",
+                    "unit": "fraction", "value": 0.5,
+                    "comment": "x", "formula_hint": None,
+                    "output_name": None, "output_unit": None,
+                    "depends_on": [], "modelling_priority": "high",
+                    "uncertainty": "low", "source_text": "x",
+                }],
+                recommended=[{
+                    "id": "c", "label": "c",
+                    "formula_hint": "out = x",
+                    "output_name": "out", "output_unit": "fraction",
+                    "depends_on": ["x"], "why_first": "x",
+                }],
+                bounds={"x": bound_x, "x_threshold": bound_threshold},
+                calc_source=calc,
+                _settings={"n_runs": 100, "seed": 1},
+            )
+
+        messages = [w["message"] for w in result["warnings"]]
+        threshold_warnings = [m for m in messages if "threshold variable" in m]
+        self.assertEqual(len(threshold_warnings), 1, msg=messages)
+        self.assertIn("'x_threshold'", threshold_warnings[0])
+        self.assertIn("stated value", threshold_warnings[0])
+
+
 class TestSchemaValidation(unittest.TestCase):
     def test_missing_sampling_discipline(self):
         bound = make_bound()

--- a/experiments/napkin_math/tests/test_run_monte_carlo.py
+++ b/experiments/napkin_math/tests/test_run_monte_carlo.py
@@ -186,6 +186,38 @@ class TestSamplingDiscipline(unittest.TestCase):
         self.assertTrue(any(v < 0 for v in out))
         self.assertTrue(all(-10 <= v <= 10 for v in out))
 
+    def test_lognormal_passes_schema_validation(self):
+        """The schema accepts lognormal so that generate-bounds can begin
+        emitting it (Phase 4 readiness for the megaproject CAPEX default
+        that lands in the prompt-side follow-up)."""
+        bound = make_bound(unit="EUR", low=1e6, base=5e6, high=2e7,
+                           sampling_discipline="lognormal")
+        rmc.validate_bound("capex", bound)
+
+    def test_pert_passes_schema_validation(self):
+        bound = make_bound(unit="EUR", low=1e6, base=5e6, high=2e7,
+                           sampling_discipline="pert")
+        rmc.validate_bound("opex", bound)
+
+    def test_lognormal_sampler_raises_not_implemented(self):
+        """Sampling raises loudly until Phase 8 lands the sampler. A silent
+        fall-back to triangular would let the user see "100% Robust" on a
+        megaproject whose CAPEX bounds are actually fat-tailed — exactly
+        the megaproject illusion Phase 4 is laying groundwork to fix."""
+        bound = make_bound(unit="EUR", low=1e6, base=5e6, high=2e7,
+                           sampling_discipline="lognormal")
+        with self.assertRaises(NotImplementedError) as ctx:
+            rmc.sample_one(self.rng, bound, "triangular", {}, "capex")
+        self.assertIn("lognormal", str(ctx.exception))
+        self.assertIn("Phase 8", str(ctx.exception))
+
+    def test_pert_sampler_raises_not_implemented(self):
+        bound = make_bound(unit="EUR", low=1e6, base=5e6, high=2e7,
+                           sampling_discipline="pert")
+        with self.assertRaises(NotImplementedError) as ctx:
+            rmc.sample_one(self.rng, bound, "triangular", {}, "opex")
+        self.assertIn("pert", str(ctx.exception))
+
 
 class TestSchemaValidation(unittest.TestCase):
     def test_missing_sampling_discipline(self):

--- a/experiments/napkin_math/tests/test_strip_threshold_bounds.py
+++ b/experiments/napkin_math/tests/test_strip_threshold_bounds.py
@@ -184,6 +184,103 @@ class StripByFormulaSideTests(unittest.TestCase):
         )
 
 
+class StripByCalculationOutputTests(unittest.TestCase):
+    """A variable that is the declared ``output_name`` of a calculation is
+    a computed quantity, not a primitive input. Bounding it independently
+    lets a single Monte Carlo trial pair sub-component p95s with a total
+    p05 (Gemini R1.1)."""
+
+    def test_strips_calculation_output_in_recommended_first_calculations(self):
+        params = {
+            "recommended_first_calculations": [{
+                "id": "calc_total_cost",
+                "formula_hint": "total_cost = civil_works + remediation + hardware",
+                "output_name": "total_cost",
+                "output_unit": "EUR",
+            }],
+        }
+        bounds = {
+            "civil_works": _bound(),
+            "remediation": _bound(),
+            "hardware": _bound(),
+            "total_cost": _bound(),
+        }
+        cleaned, stripped = rmc.strip_threshold_bounds(bounds, params)
+        self.assertEqual(set(cleaned), {"civil_works", "remediation", "hardware"})
+        self.assertEqual(stripped, [{"id": "total_cost", "reason": "calculation-output"}])
+
+    def test_strips_calculation_output_in_derived_questions(self):
+        params = {
+            "derived_questions": [{
+                "id": "q_holding_cost",
+                "formula_hint": "holding_cost = annual_burn * delay_years",
+                "output_name": "holding_cost",
+                "output_unit": "EUR",
+            }],
+        }
+        bounds = {
+            "annual_burn": _bound(),
+            "delay_years": _bound(),
+            "holding_cost": _bound(),
+        }
+        cleaned, stripped = rmc.strip_threshold_bounds(bounds, params)
+        self.assertEqual(set(cleaned), {"annual_burn", "delay_years"})
+        self.assertEqual(stripped, [{"id": "holding_cost", "reason": "calculation-output"}])
+
+    def test_actual_prefix_overrides_calculation_output(self):
+        """Defensive: ``actual_*`` is preserved even when it collides with a
+        declared output_name. The plan author should never name a primitive
+        actual_X with the same id as a calculation output, but if it
+        happens the actual_ rule wins so the realised input survives."""
+        params = {
+            "recommended_first_calculations": [{
+                "id": "calc",
+                "formula_hint": "x = a + b",
+                "output_name": "actual_total",
+                "output_unit": "EUR",
+            }],
+        }
+        bounds = {"actual_total": _bound()}
+        cleaned, stripped = rmc.strip_threshold_bounds(bounds, params)
+        self.assertEqual(set(cleaned), {"actual_total"})
+        self.assertEqual(stripped, [])
+
+    def test_does_not_strip_variables_that_are_not_outputs(self):
+        params = {
+            "recommended_first_calculations": [{
+                "id": "calc_total",
+                "formula_hint": "total = a + b",
+                "output_name": "total",
+                "output_unit": "EUR",
+            }],
+        }
+        bounds = {"a": _bound(), "b": _bound()}
+        cleaned, stripped = rmc.strip_threshold_bounds(bounds, params)
+        self.assertEqual(set(cleaned), {"a", "b"})
+        self.assertEqual(stripped, [])
+
+
+class ReservedTopLevelKeysTests(unittest.TestCase):
+    """The optional ``correlations`` top-level key carries cross-variable
+    correlation groups. It is preserved through the stripper as-is — it
+    isn't a bound entry, it isn't a threshold, and it must survive into
+    Phase 8 where the copula sampler reads it."""
+
+    def test_correlations_key_passes_through_unchanged(self):
+        correlations_payload = [
+            {"group_id": "capex_cluster", "variables": ["civil_works", "hardware"], "rho": 0.7},
+        ]
+        bounds = {
+            "civil_works": _bound(),
+            "hardware": _bound(),
+            "correlations": correlations_payload,
+        }
+        cleaned, stripped = rmc.strip_threshold_bounds(bounds, {})
+        self.assertEqual(stripped, [])
+        self.assertIs(cleaned["correlations"], correlations_payload)
+        self.assertEqual(set(cleaned), {"civil_works", "hardware", "correlations"})
+
+
 class CombinedTests(unittest.TestCase):
     def test_does_not_mutate_input(self):
         bounds = {"x_threshold": _bound(), "actual_x": _bound()}


### PR DESCRIPTION
## Summary
Phase 4 of `experiments/napkin_math/docs/20260520_plan.md` covers six items spanning code and LLM prompt. This PR ships the **code-side runtime and schema readiness**; the prompt-side behavioural rules ship in a follow-up so the LLM-rule changes can be regression-checked in isolation.

### Shipped here

1. **`strip_threshold_bounds` extension (R1.1).** A variable that is the declared `output_name` of a `recommended_first_calculations` or `derived_questions` entry is a *computed* quantity, not a primitive. Bounding it independently lets a single Monte Carlo trial pair sub-component p95s with a total p05 — Gemini's disconnected-aggregates failure. New strip reason `"calculation-output"` lands alongside the existing `"suffix"` and `"formula-side"` reasons. Variables prefixed `actual_` are still never stripped.
2. **`VALID_DISCIPLINES` reserves `lognormal` and `pert` (R1.4, R2.2).** Schema validation accepts these so generate-bounds can begin emitting them for the megaproject CAPEX default that lands in the prompt-side follow-up. `sample_one` raises `NotImplementedError` loudly when sampling is attempted — **no silent fall-back to triangular**. The matching samplers ship in Phase 8.
3. **`correlations` top-level key reserved (R1.3).** `strip_threshold_bounds` preserves it unchanged so the optional cross-variable correlation block survives the pre-processor; the copula sampler that reads it lands in Phase 8.
4. **System prompt updates the discipline table** with the two reserved disciplines and a mention of the optional `correlations` block, each annotated `schema-reserved; do not emit yet` so the LLM does not start emitting them before the matching sampler is implemented.

### Out of scope (Phase 4 follow-up PR)

- Base-anchoring conditional rule rewrite (R1.2)
- Self-audit citation context-leak examples (R1.5)
- `plan_type`-driven lognormal default for hyperscale / geopolitical_megaproject CAPEX (R2.2)
- Detailed correlations-emission selection rules (R1.3)

These are LLM-rule changes that require same-LLM same-session regression checks against the napkin_math probe set. Shipping them separately keeps the deterministic code review (this PR) clean from the LLM-rule behavioural review.

## Empirical posture

- **Unit tests**: 71 pass in `tests/test_run_monte_carlo.py` and `tests/test_strip_threshold_bounds.py`. 9 new: 4 calculation-output strip cases (recommended, derived, actual-prefix override, non-output-not-stripped), 1 reserved-key preservation (correlations), 4 new-discipline tests (schema accept + sample-time loud failure for lognormal and pert).
- **Smoke suite**: 9/9 checks pass (`run_smoke.py`).
- **Corpus inertness**: the new calculation-output strip rule fires 0 times across the v48 checked-in bounds (paperclip, yellowstone). The LLM already skips calculation outputs; the new rule is a deterministic backstop, not a behavioural change.
- **No silent shims**: trying to sample lognormal/pert raises NotImplementedError naming Phase 8 explicitly. The schema-reserved disciplines do not pretend to work.

## Test plan
- [x] `pytest experiments/napkin_math/tests/test_run_monte_carlo.py experiments/napkin_math/tests/test_strip_threshold_bounds.py` (71 pass)
- [x] `python3 experiments/napkin_math/tests/run_smoke.py` (9/9 pass)
- [x] v48 corpus regression: 0 false-positive calculation-output strips
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)