### PR TITLE
napkin-math(compress): cross-bucket promoter for gate-shaped items misfiled under risks

### DIFF
--- a/experiments/napkin_math/docs/20260520_plan.md
+++ b/experiments/napkin_math/docs/20260520_plan.md
@@ -86,7 +86,8 @@ separated below.
 - **PR #744** (merged) — Compress ranking-layer paraphrase tolerance. `quote_is_in_source` keeps the substring fast path and adds a token-overlap fallback that requires every quote token to appear in the source (min-3-token gate). Closes the case where an LLM paraphrase (reordered noun phrase, dropped intermediate words) flips `quote_verified` to False even though every content token came from the source. Empirical posture: 165 fallback-only verifies across 1206 `qv=True` items (13.7%), 30-sample audit all legitimate paraphrases. Threshold-tightening cost (90% → 100%) is 0 lost `qv=True` items on observed data. Paperclip 3× — 2/3 runs now have `$75k` OPC UA bid in public top-6 (vs 1/3 before); 3/3 verified-when-emitted. Out of scope: bucket-categorisation variance (v53c places the bid in `risks_and_shocks` rather than `gates_and_thresholds`) and the remaining emission-layer miss.
 - **PR #746** (merged) — Phase 3 validate-parameters. Two new deterministic structural checks added to `validate_parameters.py`. `aggregate_not_bounded` (R1.1): when an entry's `formula_hint` is a pure sum of named identifiers and its `output_name` also appears in `missing_values_to_estimate`, the aggregate is sampled independently of its constituents (a single Monte Carlo trial can pair sub-component p95s with a total p05). Detection is syntactic — RHS contains `+`, no other operators, every operand is a snake_case identifier. `requirement_has_margin` (R2.5): when a `key_value`'s id ends in `_required`, at least one calculation must reference it via formula RHS, contain a subtraction or ratio operator, AND emit an `output_name` with a positive-pass margin suffix (`_margin`/`_surplus`/`_buffer`/`_coverage`). All three properties required so a bare reference inside a sum (`combined = actual + required`) no longer satisfies the rule. 19 unit tests, 6 v51 plans still validate clean. Out of scope: the `sampling_discipline` enum expansion (lives in `run_monte_carlo.py`, deferred to Phase 4 to avoid a silent-shim antipattern).
 - **PR #747** (merged) — Phase 4 runtime + schema readiness. Code-side half of Phase 4: (1) `strip_threshold_bounds` extended with a `calculation-output` reason — variables that are the declared `output_name` of any calculation get stripped from bounds (R1.1 backstop); (2) `lognormal` and `pert` reserved in `VALID_DISCIPLINES`, `sample_one` raises `NotImplementedError` loudly when sampling is attempted (no silent fall-back to triangular); (3) the optional `correlations` top-level key reserved and preserved through the stripper; (4) the warning text after `strip_threshold_bounds` is now reason-branched (calculation-output strips say "simulation will compute it from calculations.py", suffix/formula-side strips keep the original threshold wording). 73 unit tests, 9/9 smoke checks, 0 false positives on the v48 corpus. The LLM-rule changes ship in PR #749.
-- **PR #749** (open, CI green, awaiting merge) — Phase 4 prompt-side LLM rules. Completes Phase 4 by shipping the four prompt rules on top of PR #747's runtime: (R1.2) `ACTUAL-VS-COMMITMENT` source-tag asymmetry — `source: "data"` only when the base is shifted on a named plan-internal anchor; `source: "assumption"` when the base is at the commitment default; (R1.5) new `SELF-AUDIT: CITATION CONTEXT-LEAK` section with abstract failure-mode examples (lexical-presence of a citation is not substantive support); (R2.2) new `DISTRIBUTION DEFAULT BY PLAN SCALE` section — megaproject CAPEX defaults to `lognormal` (P5/P95), identified by abstract criteria (multi-billion budget, multi-year horizon, multiple binding regulatory dependencies, first-of-kind execution, Flyvbjerg's iron law), NOT by a `plan_type`-string enum (the actual v51 plan_type strings are corpus literals); (R1.3) new `CORRELATIONS (OPTIONAL TOP-LEVEL BLOCK)` section — schema + selection rules for the correlations key reserved in PR #747. Runner gets a loud warning when bounds declares a correlations block but the Gaussian-copula sampler (Phase 8) is not yet implemented — no silent shim. Worked example flipped to source: "assumption" for default-centered `actual_X` variables (review-feedback fix). Generic source rule in `HOW TO CHOOSE THE RANGE` and `Rules for the output` defers explicitly to the actual_X exception. 75 unit tests, 9/9 smoke checks, no corpus literals in the prompt (grep-verified). Behavioural verification on the napkin_math probe set is a same-LLM same-session regression check, not an improvement claim — a different-LLM run remains a separate follow-up.
+- **PR #749** (merged) — Phase 4 prompt-side LLM rules. Completes Phase 4 by shipping the four prompt rules on top of PR #747's runtime: (R1.2) `ACTUAL-VS-COMMITMENT` source-tag asymmetry — `source: "data"` only when the base is shifted on a named plan-internal anchor; `source: "assumption"` when the base is at the commitment default; (R1.5) new `SELF-AUDIT: CITATION CONTEXT-LEAK` section with abstract failure-mode examples (lexical-presence of a citation is not substantive support); (R2.2) new `DISTRIBUTION DEFAULT BY PLAN SCALE` section — megaproject CAPEX defaults to `lognormal` (P5/P95), identified by abstract criteria (multi-billion budget, multi-year horizon, multiple binding regulatory dependencies, first-of-kind execution, Flyvbjerg's iron law), NOT by a `plan_type`-string enum (the actual v51 plan_type strings are corpus literals); (R1.3) new `CORRELATIONS (OPTIONAL TOP-LEVEL BLOCK)` section — schema + selection rules for the correlations key reserved in PR #747. Runner gets a loud warning when bounds declares a correlations block but the Gaussian-copula sampler (Phase 8) is not yet implemented — no silent shim. Worked example flipped to source: "assumption" for default-centered `actual_X` variables (review-feedback fix). Generic source rule in `HOW TO CHOOSE THE RANGE` and `Rules for the output` defers explicitly to the actual_X exception. 75 unit tests, 9/9 smoke checks, no corpus literals in the prompt (grep-verified). Behavioural verification on the napkin_math probe set is a same-LLM same-session regression check, not an improvement claim — a different-LLM run remains a separate follow-up.
+- **PR #750** (open, CI green, awaiting merge) — Compress bucket-categorisation backstop (cross-bucket promoter). Addresses the residual paperclip v53c failure mode left open by PRs #743/#744: the LLM correctly emits a tripwire with `qv=True` but files it under `risks_and_shocks` instead of `gates_and_thresholds`. The misfiled item then competes against actual risks at top-N and can fall out of the public output. **Process note: shipped after two reverted iterations.** First attempt was a risks-side prompt rule; review correctly flagged the causal model was wrong (gates emits before risks in BUCKET_SPECS, so a risks-side rule cannot move items into gates, and risks creating a worse failure mode where both buckets miss). Second attempt added the cross-bucket promoter but only detected canonical `If <... digit ...> then <...>` form; the actual v53c phrasing was declarative (`<X> exceeds $<N>, <consequence>`), so the promoter as advertised would not have caught the historical failure. Third commit extended the detector to also recognise the declarative comparison form with structural cues only (verb list `exceeds`/`falls below`/`drops below`/`rises above`/`breaches`/`is above|below|greater than|less than|more than`/`reaches`/`surpasses`; causal verbs like `X risks Y` are not recognised). Deterministic if/then rewrite preserves the gates bucket's output contract with acronym casing preserved (`API` stays `API`, not `aPI`). 44 unit tests including positive regression on the literal v53c phrasing, negative regression on a genuine supply-chain risk shape, and acronym-vs-regular-capitalisation tests. Empirical: 0 of 290 risks candidate lines across the v56 sweep matched the extended detector; the v53c shape did not recur in the LLM session. The change is a deterministic backstop — exercised by regression tests on the literal historical line, dormant on the live sweep, same posture as PR #747's `calculation-output` strip rule.
 
 ### PR #737 detail (already on main)
 
@@ -232,7 +233,7 @@ too:
 
 | Phase | Skill / module | Status |
 |---|---|---|
-| 1 | `compress_report_section.py` | **DONE on main via PR #737 + PR #743 + PR #744** (R2.3 numeric_values, R2.3 missing_data, R2.5 gates_and_thresholds, OPTIMIZE_INSTRUCTIONS banner; per-bucket emission-layer second pass for run-to-run variance; paraphrase-tolerant quote verification on the ranking layer). |
+| 1 | `compress_report_section.py` | **DONE on main via PR #737 + PR #743 + PR #744** (R2.3 numeric_values, R2.3 missing_data, R2.5 gates_and_thresholds, OPTIMIZE_INSTRUCTIONS banner; per-bucket emission-layer second pass for run-to-run variance; paraphrase-tolerant quote verification on the ranking layer). **PR #750 (open)** adds the cross-bucket promoter backstop that reroutes gate-shaped tripwires misfiled under `risks_and_shocks`. |
 | 2 | `extract-parameters-from-{full,digest}` | **DONE for prompt-side directives on main via PR #740** — threshold-pairing on `from-digest` shipped in PR #737; source-arithmetic preservation (Patterns 1/2/3 for R1.1, R2.3, R2.4), threshold-pairing parity into `from-full`, aggregate-sum tightening, and source_text truncation discipline shipped in PR #740. Behavioural validation on a different LLM remains a follow-up, not additional prompt-scope work. |
 | 3 | `validate-parameters` | **DONE on main via PR #746** (R1.1 `aggregate_not_bounded` and R2.5 `requirement_has_margin` structural checks). The `sampling_discipline` enum expansion bullet that the original plan tucked here actually lives in `run_monte_carlo.py` and was routed to Phase 4 (PR #747) to avoid a silent shim. |
 | 4 | `generate-bounds` | **Code-side runtime DONE on main via PR #747; prompt-side LLM rules in PR #749 (open, CI green, awaiting merge)** — R1.2 base-anchoring source-tag asymmetry, R1.5 citation context-leak self-audit, R2.2 megaproject CAPEX lognormal default (criterion-based, not plan_type-enum-based), R1.3 correlations selection rules. `pert` discipline remains schema-reserved with no selection rule yet. |
@@ -246,27 +247,19 @@ too:
 ### Next likely move
 
 With PR #746 (validate-parameters structural checks), PR #747
-(generate-bounds runtime + schema readiness), and PR #749
-(generate-bounds prompt-side LLM rules) in flight, the remaining
-work is ordered by what improves napkin_math output quality most
-directly:
+(generate-bounds runtime + schema readiness), PR #749 (generate-bounds
+prompt-side LLM rules), and PR #750 (compress cross-bucket promoter
+backstop for v53c) all in flight, the remaining work is ordered by
+what improves napkin_math output quality most directly:
 
-1. **Bucket-categorisation discipline in compress.** The residual
-   public-output miss in paperclip v53c is the LLM filing a
-   `$X exceeds threshold` tripwire under `risks_and_shocks` instead
-   of `gates_and_thresholds`. The bucket-prompt for
-   `gates_and_thresholds` could be tightened to claim any
-   "If <metric> <comparator> <numeric threshold>, then ..." sentence,
-   even when the source frames it as a downside risk. Verify across
-   the 6-plan probe set; do not overfit to the paperclip OPC UA case.
-2. **Implement proposal 141** (`dropped_signals` schema in extract
+1. **Implement proposal 141** (`dropped_signals` schema in extract
    prompts + `audit_source_preservation.py` deterministic script).
    This is the right guardrail for v49/v51 absences and
    cap-pressure tradeoffs. Now that the upstream variance fixes
-   landed (#743, #744), the audit's classification of preserved /
-   replaced / dropped signals will be measuring against a less
-   leaky pipeline.
-3. **Phase 5 — `verify-bounds-citations`** (new deterministic step,
+   landed (#743, #744, #750), the audit's classification of
+   preserved / replaced / dropped signals will be measuring against
+   a less leaky pipeline.
+2. **Phase 5 — `verify-bounds-citations`** (new deterministic step,
    R1.5 backstop). Parse Risk / Issue / Decision N tokens from each
    rationale string in bounds.json; fetch the corresponding section
    from the source report; compare topical keywords. Fail-loud /
@@ -274,7 +267,7 @@ directly:
    rule that landed in PR #749 reduces the citation context-leak
    surface, but a deterministic post-processor is the right
    guardrail since the LLM is asked to self-audit its own output.
-4. **Different-LLM behavioural validation** of the rules now on
+3. **Different-LLM behavioural validation** of the rules now on
    main. A Self-Improve run with the default napkin_math LLM
    (Gemini Flash Lite) against the same digests would close the
    same-LLM same-session confound. Especially load-bearing for the
@@ -282,7 +275,7 @@ directly:
    and the correlations selection rules each need verification
    against a different-LLM extraction). This should be treated as
    validation of prompt generality, not as the next quality fix.
-5. **Prompt-hygiene pass** for the remaining domain-specific
+4. **Prompt-hygiene pass** for the remaining domain-specific
    examples (e.g. `european_prepper_active_buyers`) in either
    extract prompt. This is worthwhile and small, but not
    load-bearing for the currently observed napkin_math failures.

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -1105,6 +1105,21 @@ DECLARATIVE_GATE_SHAPE_PATTERN: re.Pattern[str] = re.compile(
 )
 
 
+def _lowercase_first_preserving_acronyms(text: str) -> str:
+    """Lowercase the first character of ``text`` only when doing so does
+    not damage an acronym. Heuristic: lowercase only when the first
+    character is an uppercase letter AND the second character is a
+    lowercase letter (a regular capitalized word like ``Middleware``).
+    For tokens like ``API`` / ``OPC UA`` / ``5G`` the next character is
+    not a lowercase letter, so the casing is preserved.
+    """
+    if len(text) < 2:
+        return text
+    if text[0].isupper() and text[1].islower():
+        return text[0].lower() + text[1:]
+    return text
+
+
 def gate_shape_promotion(line: str) -> Optional[str]:
     """Return the if/then form of ``line`` if it has any recognised gate
     structural shape, else ``None``.
@@ -1126,6 +1141,12 @@ def gate_shape_promotion(line: str) -> Optional[str]:
     ``If middleware development bid exceeds $75,000, then consuming
     budget...`` so the downstream consumer reads a uniformly-shaped gate.
 
+    Casing in the rewrite is preserved for acronyms and proper nouns —
+    ``API job queue latency...`` becomes ``If API job queue latency...``,
+    not ``If aPI...``. The case adjustment only fires on regular
+    capitalised words where the first letter being lowercased reads
+    naturally mid-sentence.
+
     Returns ``None`` when the line matches neither shape — the promoter
     must not steal qualitative risks (triggers with a non-numeric source
     side, or risks framed without a comparison verb) into the gates pool.
@@ -1140,14 +1161,10 @@ def gate_shape_promotion(line: str) -> Optional[str]:
     m = DECLARATIVE_GATE_SHAPE_PATTERN.match(s)
     if m is None:
         return None
-    subject = m.group("subject").strip()
+    subject = _lowercase_first_preserving_acronyms(m.group("subject").strip())
     verb = " ".join(m.group("verb").split())
     threshold = m.group("threshold").strip()
-    consequence = m.group("consequence").strip()
-    if subject and subject[0].isupper():
-        subject = subject[0].lower() + subject[1:]
-    if consequence and consequence[0].isupper():
-        consequence = consequence[0].lower() + consequence[1:]
+    consequence = _lowercase_first_preserving_acronyms(m.group("consequence").strip())
     return f"If {subject} {verb} {threshold}, then {consequence}"
 
 

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -765,6 +765,17 @@ rejection. It is NOT the same as a gate/threshold (which is a pass/fail
 condition you actively check). If you have already produced an item in
 gates_and_thresholds, do not restate it here.
 
+Structural priority of gates_and_thresholds: do NOT emit a sentence here
+when its source side has the 'If <metric> <comparator> <numeric
+threshold>, then <consequence>' shape — that shape belongs in
+gates_and_thresholds, even when the consequence is a downside (cost,
+schedule, scope, penalty, vendor switch). A risk is a trigger whose
+source side is NOT a metric-vs-threshold check: the trigger is a
+qualitative event (a rejection, a delay, a disruption, a protocol
+mismatch) coupled with a quantitative impact on the consequence side.
+A sentence whose if-clause names a metric, a comparator, and a numeric
+threshold is a gate even when its then-clause is risk-flavoured.
+
 Skip purely qualitative risks that do not name a number, a date, a capacity,
 or an operationally specific failure mode. If you include a scenario
 shock whose magnitude the source does not state, set source_status to

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -765,17 +765,6 @@ rejection. It is NOT the same as a gate/threshold (which is a pass/fail
 condition you actively check). If you have already produced an item in
 gates_and_thresholds, do not restate it here.
 
-Structural priority of gates_and_thresholds: do NOT emit a sentence here
-when its source side has the 'If <metric> <comparator> <numeric
-threshold>, then <consequence>' shape — that shape belongs in
-gates_and_thresholds, even when the consequence is a downside (cost,
-schedule, scope, penalty, vendor switch). A risk is a trigger whose
-source side is NOT a metric-vs-threshold check: the trigger is a
-qualitative event (a rejection, a delay, a disruption, a protocol
-mismatch) coupled with a quantitative impact on the consequence side.
-A sentence whose if-clause names a metric, a comparator, and a numeric
-threshold is a gate even when its then-clause is risk-flavoured.
-
 Skip purely qualitative risks that do not name a number, a date, a capacity,
 or an operationally specific failure mode. If you include a scenario
 shock whose magnitude the source does not state, set source_status to
@@ -902,6 +891,15 @@ SCORED_LIST_FIELDS: tuple[str, ...] = (
     "gates_and_thresholds",
     "risks_and_shocks",
     "missing_data_to_estimate",
+)
+
+# Buckets whose top-N filter is deferred until both have emitted, so a
+# cross-bucket promoter can move gate-shaped items from risks_and_shocks
+# into the gates_and_thresholds candidate pool before either is filtered
+# down to its public top-N.
+CROSS_BUCKET_PROMOTION_FIELDS: tuple[str, ...] = (
+    "gates_and_thresholds",
+    "risks_and_shocks",
 )
 
 # For buckets where the bucket name already determines the right
@@ -1076,6 +1074,101 @@ SECOND_PASS_USER_PROMPT_TEMPLATE = (
 )
 
 
+GATE_SHAPE_PATTERN: re.Pattern[str] = re.compile(
+    r"\bif\b.*?\d.*?\bthen\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def has_gate_shape(line: str) -> bool:
+    """A line has the gate structural shape when its surface form reads
+    ``If <something with a numeric token> ... then <consequence>``.
+
+    Used by the cross-bucket promoter: a sentence with this shape is a
+    deterministic pass/fail check the downstream model needs to evaluate,
+    regardless of which bucket the LLM filed it under. Detection is
+    syntactic and language-neutral — digits are digits in any locale,
+    and the ``if`` / ``then`` keywords are required by the bucket prompt's
+    own template instructions.
+    """
+    if not isinstance(line, str):
+        return False
+    return bool(GATE_SHAPE_PATTERN.search(line))
+
+
+def promote_gate_shaped_risks(
+    gates_items: list[ScoredItem],
+    risks_items: list[ScoredItem],
+) -> tuple[list[ScoredItem], list[ScoredItem], int]:
+    """Move risks_and_shocks items whose surface form has the if/then
+    numeric-threshold gate shape into the gates_and_thresholds candidate
+    pool, when the same source_quote is not already represented there.
+
+    Background: the gates bucket emits before risks in BUCKET_SPECS, so
+    the LLM occasionally files a tripwire ('If $X exceeds Y, then
+    re-scope') under risks instead of gates — sometimes because the
+    consequence is downside-framed and the LLM keys on the framing
+    rather than the structural shape. The deterministic top-N filter
+    then runs per bucket; the misfiled item competes against actual
+    risks rather than against actual gates, and can fall out of the
+    public output entirely.
+
+    A prompt-side rule on the risks bucket cannot fix this (risks runs
+    after gates, so a risks-side rule can only suppress emission, not
+    cause it elsewhere) and risks creating a worse failure mode where
+    both buckets miss the item. A deterministic post-processor on the
+    combined candidate pools is the right shape: it sees what the LLM
+    actually produced and reroutes by structural shape.
+
+    Rules:
+    - A risk item is promoted when ``has_gate_shape(line_english)`` is
+      true AND its normalised source_quote is NOT already represented in
+      the gates pool.
+    - Promoted items are removed from the risks pool (the slot is
+      reclaimed for an actual risk; the public output should not show
+      the same source claim in both buckets).
+    - A risk item that is gate-shaped but whose quote IS already in
+      gates is left in risks untouched — that within-bucket duplication
+      is a separate concern handled by the existing 'do not restate'
+      rule in the risks prompt and the per-bucket dedupe at top-N time.
+    - The augmented gates pool is returned with the promoted items
+      appended; the per-bucket ``annotate_scored_items`` call then
+      scores them against the rest of the gates field and picks the
+      top-N survivors. A promoted item that scores below the existing
+      gates field is dropped at top-N filter time, same as any other
+      candidate.
+
+    Returns ``(augmented_gates, remaining_risks, promoted_count)``. The
+    input lists are NOT mutated.
+    """
+    existing_gate_quotes: set[str] = {
+        normalise_for_quote_match(g.source_quote)
+        for g in gates_items
+        if isinstance(g, ScoredItem) and g.source_quote
+    }
+    augmented_gates: list[ScoredItem] = list(gates_items)
+    remaining_risks: list[ScoredItem] = []
+    promoted_count = 0
+    for risk_item in risks_items:
+        if not isinstance(risk_item, ScoredItem):
+            remaining_risks.append(risk_item)
+            continue
+        if not has_gate_shape(risk_item.line_english):
+            remaining_risks.append(risk_item)
+            continue
+        if not risk_item.source_quote:
+            remaining_risks.append(risk_item)
+            continue
+        normalised = normalise_for_quote_match(risk_item.source_quote)
+        if normalised in existing_gate_quotes:
+            remaining_risks.append(risk_item)
+            continue
+        augmented_gates.append(risk_item)
+        existing_gate_quotes.add(normalised)
+        promoted_count += 1
+    return augmented_gates, remaining_risks, promoted_count
+
+
 def merge_second_pass_items(
     first_pass: list[ScoredItem],
     second_pass: list[ScoredItem],
@@ -1192,6 +1285,8 @@ class CompressReportSection:
 
         bucket_values: dict[str, Any] = {}
         per_bucket_metadata: dict[str, dict[str, Any]] = {}
+        deferred_cross_bucket_items: dict[str, list[ScoredItem]] = {}
+        deferred_cross_bucket_metadata: dict[str, dict[str, Any]] = {}
         total_start = time.perf_counter()
 
         for turn_index, spec in enumerate(BUCKET_SPECS):
@@ -1349,15 +1444,43 @@ class CompressReportSection:
                     }
                 )
 
-            if spec.field_name in SCORED_LIST_FIELDS:
+            if spec.field_name in CROSS_BUCKET_PROMOTION_FIELDS:
+                # Defer the top-N filter for gates_and_thresholds and
+                # risks_and_shocks; the cross-bucket promoter (below)
+                # needs to see the full merged candidate pools of BOTH
+                # buckets before either is filtered down to top-N. The
+                # promoter runs after the bucket loop finishes.
+                deferred_cross_bucket_items[spec.field_name] = raw_field_value
+                deferred_cross_bucket_metadata[spec.field_name] = bucket_metadata
+            elif spec.field_name in SCORED_LIST_FIELDS:
                 bucket_values[spec.field_name], scored_items = annotate_scored_items(
                     raw_field_value, section_markdown, spec.field_name
                 )
                 bucket_metadata["scored_items"] = scored_items
+                per_bucket_metadata[spec.field_name] = bucket_metadata
             else:
                 bucket_values[spec.field_name] = raw_field_value
+                per_bucket_metadata[spec.field_name] = bucket_metadata
 
-            per_bucket_metadata[spec.field_name] = bucket_metadata
+        gates_raw = deferred_cross_bucket_items.get("gates_and_thresholds", []) or []
+        risks_raw = deferred_cross_bucket_items.get("risks_and_shocks", []) or []
+        augmented_gates, remaining_risks, promoted_count = promote_gate_shaped_risks(
+            gates_raw, risks_raw
+        )
+        for field_name, pool in (
+            ("gates_and_thresholds", augmented_gates),
+            ("risks_and_shocks", remaining_risks),
+        ):
+            if field_name not in deferred_cross_bucket_items:
+                continue
+            kept, scored_items = annotate_scored_items(
+                pool, section_markdown, field_name
+            )
+            bucket_values[field_name] = kept
+            bucket_metadata = deferred_cross_bucket_metadata[field_name]
+            bucket_metadata["scored_items"] = scored_items
+            bucket_metadata["cross_bucket_promoted_count"] = promoted_count
+            per_bucket_metadata[field_name] = bucket_metadata
 
         total_duration = int(ceil(time.perf_counter() - total_start))
 

--- a/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/compress_report_section.py
@@ -1079,21 +1079,84 @@ GATE_SHAPE_PATTERN: re.Pattern[str] = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+# Declarative comparison form the risks bucket sometimes uses for what is
+# structurally a gate. Subject phrase, then a comparison verb naming the
+# direction of the threshold check, then a threshold containing a digit
+# token, then a comma or colon separator, then the consequence. The
+# alternatives below are language-neutral structural cues — digits in any
+# locale, and the comparison verbs are required by the risks bucket
+# prompt's own 'trigger plus impact' template when the trigger itself is
+# numerically gated. Function-word membership (``exceeds`` / ``falls
+# below`` / etc) is the structural cue, not domain vocabulary.
+DECLARATIVE_GATE_COMPARISON_VERBS: str = (
+    r"exceeds?|falls?\s+below|drops?\s+below|rises?\s+above|breaches?|"
+    r"is\s+(?:above|below|greater\s+than|less\s+than|more\s+than)|"
+    r"reaches?|surpass(?:es)?"
+)
+DECLARATIVE_GATE_SHAPE_PATTERN: re.Pattern[str] = re.compile(
+    r"^(?P<subject>.+?)\s+"
+    rf"(?P<verb>{DECLARATIVE_GATE_COMPARISON_VERBS})\s+"
+    # Threshold must contain a digit token; commas/colons INSIDE a number
+    # (e.g. ``$75,000``) are accepted by requiring the separator comma to
+    # be followed by whitespace and NOT preceded by a digit.
+    r"(?P<threshold>.*?\d.*?)\s*(?:[,:](?!\d))\s+"
+    r"(?P<consequence>.+)$",
+    re.IGNORECASE | re.DOTALL,
+)
 
-def has_gate_shape(line: str) -> bool:
-    """A line has the gate structural shape when its surface form reads
-    ``If <something with a numeric token> ... then <consequence>``.
 
-    Used by the cross-bucket promoter: a sentence with this shape is a
-    deterministic pass/fail check the downstream model needs to evaluate,
-    regardless of which bucket the LLM filed it under. Detection is
-    syntactic and language-neutral — digits are digits in any locale,
-    and the ``if`` / ``then`` keywords are required by the bucket prompt's
-    own template instructions.
+def gate_shape_promotion(line: str) -> Optional[str]:
+    """Return the if/then form of ``line`` if it has any recognised gate
+    structural shape, else ``None``.
+
+    Two shapes are recognised:
+
+    1. **Canonical if/then numeric** (``If <... digit ...> then <...>``) —
+       the line is returned unchanged.
+    2. **Declarative comparison numeric** (``<subject> exceeds <threshold>,
+       <consequence>`` and variants) — the line is rewritten as ``If
+       <subject> <verb> <threshold>, then <consequence>``.
+
+    The rewrite preserves the gates_and_thresholds bucket's output contract
+    (every gate is in if/then form). The declarative shape is exactly what
+    the risks bucket sometimes produces for what is structurally a gate —
+    see the v53c paperclip case, where the LLM filed
+    ``Middleware development bid exceeds $75,000, consuming budget...``
+    under risks instead of gates. The promoter rewrites this into
+    ``If middleware development bid exceeds $75,000, then consuming
+    budget...`` so the downstream consumer reads a uniformly-shaped gate.
+
+    Returns ``None`` when the line matches neither shape — the promoter
+    must not steal qualitative risks (triggers with a non-numeric source
+    side, or risks framed without a comparison verb) into the gates pool.
     """
     if not isinstance(line, str):
-        return False
-    return bool(GATE_SHAPE_PATTERN.search(line))
+        return None
+    s = line.strip()
+    if not s:
+        return None
+    if GATE_SHAPE_PATTERN.search(s):
+        return s
+    m = DECLARATIVE_GATE_SHAPE_PATTERN.match(s)
+    if m is None:
+        return None
+    subject = m.group("subject").strip()
+    verb = " ".join(m.group("verb").split())
+    threshold = m.group("threshold").strip()
+    consequence = m.group("consequence").strip()
+    if subject and subject[0].isupper():
+        subject = subject[0].lower() + subject[1:]
+    if consequence and consequence[0].isupper():
+        consequence = consequence[0].lower() + consequence[1:]
+    return f"If {subject} {verb} {threshold}, then {consequence}"
+
+
+def has_gate_shape(line: str) -> bool:
+    """True when ``line`` has a gate structural shape — either canonical
+    if/then numeric, or declarative comparison-verb numeric that the
+    promoter can deterministically rewrite into if/then form.
+    """
+    return gate_shape_promotion(line) is not None
 
 
 def promote_gate_shaped_risks(
@@ -1153,7 +1216,8 @@ def promote_gate_shaped_risks(
         if not isinstance(risk_item, ScoredItem):
             remaining_risks.append(risk_item)
             continue
-        if not has_gate_shape(risk_item.line_english):
+        rewritten_line = gate_shape_promotion(risk_item.line_english)
+        if rewritten_line is None:
             remaining_risks.append(risk_item)
             continue
         if not risk_item.source_quote:
@@ -1163,7 +1227,13 @@ def promote_gate_shaped_risks(
         if normalised in existing_gate_quotes:
             remaining_risks.append(risk_item)
             continue
-        augmented_gates.append(risk_item)
+        # Promote with the if/then-form line. ``line_original`` is kept as
+        # the source's native phrasing — the rewrite is a structural
+        # adapter for the gates bucket output contract only, not a
+        # claim about the source language. Scores, status, and quote
+        # carry over unchanged.
+        promoted_item = risk_item.model_copy(update={"line_english": rewritten_line})
+        augmented_gates.append(promoted_item)
         existing_gate_quotes.add(normalised)
         promoted_count += 1
     return augmented_gates, remaining_risks, promoted_count

--- a/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
@@ -662,6 +662,40 @@ def test_gate_shape_promotion_passes_through_canonical_if_then() -> None:
     assert gate_shape_promotion(line) == line
 
 
+def test_gate_shape_promotion_preserves_acronyms_in_subject() -> None:
+    """Subject acronyms like ``API`` / ``OPC UA`` must NOT be lowercased
+    by the rewrite — that would damage the readable form. The case
+    adjustment only fires on regular capitalised words (uppercase
+    followed by lowercase), not on acronyms (uppercase followed by
+    uppercase)."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        gate_shape_promotion,
+    )
+
+    line = (
+        "API job queue latency exceeds 100ms, "
+        "requiring control board upgrades to meet the responsiveness target."
+    )
+    rewritten = gate_shape_promotion(line)
+    assert rewritten is not None
+    assert rewritten.startswith("If API "), rewritten
+    assert "aPI" not in rewritten
+
+
+def test_gate_shape_promotion_lowercases_regular_capitalised_subject() -> None:
+    """Counterpart to the acronym test: a regular capitalised subject
+    SHOULD be lowercased mid-sentence so the rewritten if/then reads
+    naturally. ``Middleware`` → ``middleware`` is the canonical case."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        gate_shape_promotion,
+    )
+
+    line = "Middleware development bid exceeds $75,000, scope is cut."
+    rewritten = gate_shape_promotion(line)
+    assert rewritten is not None
+    assert rewritten.startswith("If middleware development bid "), rewritten
+
+
 def test_promote_gate_shaped_risks_moves_misfiled_gate() -> None:
     """Focal v53c scenario: gates emitted some items but missed a tripwire;
     risks emitted the tripwire with if/then numeric shape. Promotion

--- a/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
@@ -598,6 +598,70 @@ def test_has_gate_shape_rejects_non_string() -> None:
     assert has_gate_shape("") is False
 
 
+def test_has_gate_shape_accepts_declarative_v53c_form() -> None:
+    """Regression test for the actual v53c failure: the LLM filed
+    ``Middleware development bid exceeds $75,000, consuming budget...``
+    under risks_and_shocks. The historical phrasing is declarative
+    (subject + comparison verb + threshold + consequence), not if/then.
+    The promoter must recognise this shape so the v53c miscategorisation
+    can be rerouted to gates."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        has_gate_shape,
+    )
+
+    line = (
+        "Middleware development bid exceeds $75,000, "
+        "consuming budget planned for the physical handoff accumulation system."
+    )
+    assert has_gate_shape(line) is True
+
+
+def test_has_gate_shape_rejects_genuine_risk_with_colon_delay() -> None:
+    """Negative regression: a genuine risk like 'Supply chain disruption:
+    4 to 6 weeks delay and $15,000 cost increase.' has no comparison
+    verb between subject and digit, so it must NOT be classified as a
+    gate. The promoter must not steal genuine risks into the gates pool."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        has_gate_shape,
+    )
+
+    line = "Supply chain disruption: 4 to 6 weeks delay and $15,000 cost increase."
+    assert has_gate_shape(line) is False
+
+
+def test_gate_shape_promotion_rewrites_declarative_to_if_then() -> None:
+    """The declarative v53c form is rewritten into if/then so the
+    gates bucket's output contract (every gate is in if/then form)
+    is preserved."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        gate_shape_promotion,
+    )
+
+    line = (
+        "Middleware development bid exceeds $75,000, "
+        "consuming budget planned for the physical handoff accumulation system."
+    )
+    rewritten = gate_shape_promotion(line)
+    assert rewritten is not None
+    assert rewritten.startswith("If "), rewritten
+    assert ", then " in rewritten
+    assert "middleware development bid" in rewritten
+    assert "exceeds" in rewritten
+    assert "$75,000" in rewritten
+    assert "budget planned" in rewritten
+
+
+def test_gate_shape_promotion_passes_through_canonical_if_then() -> None:
+    """A canonical if/then numeric line should be returned unchanged —
+    the rewrite only triggers on the declarative shape."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        gate_shape_promotion,
+    )
+
+    line = "If manual work exceeds 2 hours per week, then the goal fails."
+    assert gate_shape_promotion(line) == line
+
+
 def test_promote_gate_shaped_risks_moves_misfiled_gate() -> None:
     """Focal v53c scenario: gates emitted some items but missed a tripwire;
     risks emitted the tripwire with if/then numeric shape. Promotion
@@ -628,6 +692,46 @@ def test_promote_gate_shaped_risks_moves_misfiled_gate() -> None:
     assert promoted == 1
     assert len(augmented) == 2
     assert augmented[-1].source_quote == "lowest qualified bid exceeds $75,000"
+    assert remaining == []
+
+
+def test_promote_gate_shaped_risks_rewrites_declarative_v53c_form() -> None:
+    """End-to-end on the exact v53c risk-bucket phrasing: the promoter
+    must (a) recognise the declarative shape, (b) rewrite line_english
+    to if/then form, (c) preserve source_quote, scores, status, and (d)
+    remove the item from the risks pool."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        ScoredItem,
+        promote_gate_shaped_risks,
+    )
+
+    risk = ScoredItem(
+        line_english=(
+            "Middleware development bid exceeds $75,000, "
+            "consuming budget planned for the physical handoff accumulation system."
+        ),
+        line_original=(
+            "Middleware development bid exceeds $75,000, "
+            "consuming budget planned for the physical handoff accumulation system."
+        ),
+        modelling_relevance=4,
+        source_evidence=5,
+        source_status="stress_test",
+        source_quote="lowest qualified bid for middleware development exceeds $75,000",
+    )
+    augmented, remaining, promoted = promote_gate_shaped_risks([], [risk])
+    assert promoted == 1
+    assert len(augmented) == 1
+    promoted_item = augmented[0]
+    assert promoted_item.line_english.startswith("If ")
+    assert ", then " in promoted_item.line_english
+    assert promoted_item.source_quote == risk.source_quote
+    assert promoted_item.source_status == risk.source_status
+    assert promoted_item.source_evidence == risk.source_evidence
+    assert promoted_item.modelling_relevance == risk.modelling_relevance
+    # line_original is intentionally NOT rewritten — it preserves the
+    # source's native phrasing for downstream consumers that need it.
+    assert promoted_item.line_original == risk.line_original
     assert remaining == []
 
 

--- a/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
+++ b/worker_plan/worker_plan_internal/parameter_extraction/tests/test_compress_report_section.py
@@ -557,3 +557,172 @@ def test_quote_is_in_source_rejects_short_unrelated_quote() -> None:
 
     source = "lowest qualified bid for OPC UA middleware exceeds $75,000"
     assert quote_is_in_source("middleware bid", source) is False
+
+
+def test_has_gate_shape_accepts_canonical_if_then_numeric() -> None:
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        has_gate_shape,
+    )
+
+    assert has_gate_shape("If the cost exceeds $75,000, then the project re-scopes.") is True
+    assert has_gate_shape("If manual work exceeds 2 hours per week, then the goal fails.") is True
+
+
+def test_has_gate_shape_rejects_qualitative_if_then() -> None:
+    """No numeric token between if and then → not a gate shape. Such
+    sentences may still be legitimate gates (categorical / approval
+    gates) but the cross-bucket promoter only fires on the numeric
+    pattern to avoid stealing genuine risks."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        has_gate_shape,
+    )
+
+    assert has_gate_shape("If the regulator rejects the application, then the timeline slips.") is False
+
+
+def test_has_gate_shape_rejects_no_then() -> None:
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        has_gate_shape,
+    )
+
+    assert has_gate_shape("Costs above $75,000 force a scope cut.") is False
+
+
+def test_has_gate_shape_rejects_non_string() -> None:
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        has_gate_shape,
+    )
+
+    assert has_gate_shape(None) is False
+    assert has_gate_shape(123) is False
+    assert has_gate_shape("") is False
+
+
+def test_promote_gate_shaped_risks_moves_misfiled_gate() -> None:
+    """Focal v53c scenario: gates emitted some items but missed a tripwire;
+    risks emitted the tripwire with if/then numeric shape. Promotion
+    should move the misfiled item into the gates pool and remove it
+    from risks (the slot is reclaimed)."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        ScoredItem,
+        promote_gate_shaped_risks,
+    )
+
+    existing_gate = ScoredItem(
+        line_english="If manual work exceeds 2 hours per week, then the goal fails.",
+        line_original="If manual work exceeds 2 hours per week, then the goal fails.",
+        modelling_relevance=5,
+        source_evidence=4,
+        source_status="explicit",
+        source_quote="manual work exceeds 2 hours per week",
+    )
+    misfiled = ScoredItem(
+        line_english="If the lowest qualified bid exceeds $75,000, then the project re-scopes.",
+        line_original="If the lowest qualified bid exceeds $75,000, then the project re-scopes.",
+        modelling_relevance=5,
+        source_evidence=3,
+        source_status="stress_test",
+        source_quote="lowest qualified bid exceeds $75,000",
+    )
+    augmented, remaining, promoted = promote_gate_shaped_risks([existing_gate], [misfiled])
+    assert promoted == 1
+    assert len(augmented) == 2
+    assert augmented[-1].source_quote == "lowest qualified bid exceeds $75,000"
+    assert remaining == []
+
+
+def test_promote_gate_shaped_risks_skips_qualitative_risks() -> None:
+    """A risks item whose surface form does not match the if/then
+    numeric-threshold shape is left in risks untouched — the promoter
+    must not steal genuine risks (triggers with a qualitative source side
+    and quantitative consequence) into the gates pool."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        ScoredItem,
+        promote_gate_shaped_risks,
+    )
+
+    qualitative_risk = ScoredItem(
+        line_english="Supply chain disruption: 4 to 6 weeks development delay and $15,000 cost increase.",
+        line_original="Supply chain disruption: 4 to 6 weeks development delay and $15,000 cost increase.",
+        modelling_relevance=4,
+        source_evidence=4,
+        source_status="stress_test",
+        source_quote="supply chain delays cause weeks of delay",
+    )
+    augmented, remaining, promoted = promote_gate_shaped_risks([], [qualitative_risk])
+    assert promoted == 0
+    assert augmented == []
+    assert remaining == [qualitative_risk]
+
+
+def test_promote_gate_shaped_risks_skips_duplicate_quote_in_gates() -> None:
+    """If the same source_quote is already represented in gates (LLM
+    violated do-not-restate), the risks item is left in risks rather
+    than added to gates again. Within-bucket dedupe is a separate
+    concern handled at top-N time."""
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        ScoredItem,
+        promote_gate_shaped_risks,
+    )
+
+    quote = "lowest qualified bid exceeds $75,000"
+    in_gates = ScoredItem(
+        line_english="If the lowest qualified bid exceeds $75,000, then the project re-scopes.",
+        line_original="If the lowest qualified bid exceeds $75,000, then the project re-scopes.",
+        modelling_relevance=5,
+        source_evidence=4,
+        source_status="stress_test",
+        source_quote=quote,
+    )
+    same_in_risks = ScoredItem(
+        line_english="If the middleware bid exceeds $75,000, then the architecture is re-scoped.",
+        line_original="If the middleware bid exceeds $75,000, then the architecture is re-scoped.",
+        modelling_relevance=4,
+        source_evidence=3,
+        source_status="stress_test",
+        source_quote=quote,
+    )
+    augmented, remaining, promoted = promote_gate_shaped_risks([in_gates], [same_in_risks])
+    assert promoted == 0
+    assert len(augmented) == 1
+    assert remaining == [same_in_risks]
+
+
+def test_promote_gate_shaped_risks_handles_empty_inputs() -> None:
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        promote_gate_shaped_risks,
+    )
+
+    augmented, remaining, promoted = promote_gate_shaped_risks([], [])
+    assert promoted == 0
+    assert augmented == []
+    assert remaining == []
+
+
+def test_promote_gate_shaped_risks_does_not_mutate_inputs() -> None:
+    from worker_plan_internal.parameter_extraction.compress_report_section import (
+        ScoredItem,
+        promote_gate_shaped_risks,
+    )
+
+    gates = [
+        ScoredItem(
+            line_english="If A exceeds 100, then B.",
+            line_original="If A exceeds 100, then B.",
+            modelling_relevance=5, source_evidence=5,
+            source_status="explicit", source_quote="A exceeds 100",
+        ),
+    ]
+    risks = [
+        ScoredItem(
+            line_english="If C exceeds 50, then D.",
+            line_original="If C exceeds 50, then D.",
+            modelling_relevance=4, source_evidence=4,
+            source_status="stress_test", source_quote="C exceeds 50",
+        ),
+    ]
+    promote_gate_shaped_risks(gates, risks)
+    assert len(gates) == 1
+    assert len(risks) == 1
+    assert gates[0].source_quote == "A exceeds 100"
+    assert risks[0].source_quote == "C exceeds 50"


### PR DESCRIPTION
## Summary

Addresses the residual paperclip v53c failure mode: the LLM sometimes files a tripwire (`If $X exceeds threshold, then <downside>`, OR the declarative `<X> exceeds threshold, <consequence>`) under `risks_and_shocks` instead of `gates_and_thresholds`. The misfiled item then competes against actual risks at top-N selection and can fall out of the public output entirely.

### Approach

**A deterministic post-processor over the LLM emissions**, not a prompt rule. The first iteration of this PR tried a risks-side prompt rule — review correctly flagged the causal model was wrong (gates emits before risks, so a risks-side prompt rule cannot move items into gates, and risks creating a worse failure mode where both buckets miss). That commit has been reverted on this branch; the gates and risks prompts are now back to their pre-PR state.

### Code change

1. **`has_gate_shape(line)`** — true when the surface form matches either:
   - **Canonical if/then numeric**: `If <... digit token ...> then <consequence>`
   - **Declarative comparison numeric**: `<subject> + comparison verb + <threshold with digit> + comma/colon + <consequence>` — the actual v53c phrasing. Recognised comparison verbs: `exceeds`, `falls below`, `drops below`, `rises above`, `breaches`, `is above/below/greater than/less than/more than`, `reaches`, `surpasses`. Causal verbs (`X risks Y`, `X causes Y`, `Failure of X leads to Y`) are **not** recognised — those stay in risks.

   Numeric guard: separator comma/colon must not be followed by another digit, so commas inside numbers like `$75,000` don't split the match. Qualitative if-then sentences without a numeric token between `if` and `then` are intentionally excluded so the promoter doesn't steal categorical/approval/deadline gates that the LLM already categorises correctly.
2. **`gate_shape_promotion(line)`** — returns the if/then form of `line` if it has any recognised gate shape, else `None`. For declarative inputs it produces a deterministic if/then rewrite preserving the gates bucket's output contract. Acronym casing is preserved (`API job queue latency...` rewrites to `If API ...`, NOT `If aPI ...`) — the case adjustment only fires on regular capitalised words (uppercase followed by lowercase). `line_original` is intentionally NOT rewritten; it preserves the source's native phrasing.
3. **`promote_gate_shaped_risks(gates, risks)`** — scans risks for gate-shaped items whose normalised `source_quote` is NOT already in the gates pool. Promoted items are MOVED to the gates candidate pool (not copied) so the risks slot is reclaimed. Items already in gates by quote are left in risks untouched (within-bucket dedupe is the existing 'do not restate' prompt rule's job).
4. **Wiring** — defers `annotate_scored_items` for `gates_and_thresholds` and `risks_and_shocks` until both have completed first+second-pass merging. After the bucket loop, the promoter runs on both merged pools, then `annotate_scored_items` fires on the augmented gates pool and the remaining risks pool. The promoter's count is exposed in `per_bucket.gates_and_thresholds.cross_bucket_promoted_count` for downstream auditing.

## Empirical posture

- **Unit tests**: 44 pass in `test_compress_report_section.py`. New cases include: `has_gate_shape` true/false for both if/then and declarative shapes; positive regression on the literal v53c phrasing `Middleware development bid exceeds $75,000, consuming budget...`; negative regression on the genuine risk `Supply chain disruption: 4 to 6 weeks delay and $15,000 cost increase.`; end-to-end promoter test that asserts the v53c-shaped risk is moved with `line_english` rewritten to if/then form and `source_quote` / scores / status / `line_original` preserved; acronym preservation (`API` stays `API`); regular capitalisation lowering (`Middleware` → `middleware`).
- **v56 regression sweep** (paperclip 3× + 5 other probes, 290 risks candidate lines, 32 plan×section cells): **0 promotions fired**. The v53c shape did NOT recur in this same-LLM same-session sweep; the v56 risks emissions are dominated by causal forms (`X risks Y`, `X causes Y`, `Failure of X leads to Y`) which the detector intentionally rejects. The change is a deterministic backstop for a rare LLM failure mode, analogous to PR #747's `calculation-output` strip rule which also fired 0 times on its v48 regression corpus.
- The 8-run regression otherwise shows typical same-LLM variance (mostly ±1-3 items per cell, no systematic over-narrowing). One section had a 0-candidate emission failure (paperclip v56c expert_criticism gates), unrelated to this change — the gates LLM call itself is unchanged; the promoter only acts post-LLM.

## What this PR explicitly does NOT claim

- **Does not claim** to "fix the v53c failure" by changing live LLM behaviour in the v56 session — the v53c-shaped failure didn't recur, so the promoter is uncalled.
- **Does not claim** to improve any bucket count metric — the v56 vs v53 count deltas are within typical same-LLM variance.
- **Does claim** to provide a deterministic backstop for the structural failure mode that PRs #743/#744 left open: the LLM correctly emits the item with `qv=True` somewhere, but in the wrong bucket. When that recurs, the promoter routes it to gates with a clean if/then rewrite that preserves the gates bucket's output contract and acronym casing.

## Test plan
- [x] `pytest worker_plan/.../tests/test_compress_report_section.py` (44 pass)
- [x] v56 paperclip 3× + 5 regression probes — no systematic over-narrowing, 0 false-positive promotions
- [x] Reverted the wrong risks-side prompt rule from this PR's first commit
- [x] Detector covers both if/then numeric AND declarative comparison forms (the actual v53c phrasing)
- [x] Acronym casing preserved by the if/then rewrite
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)