### PR TITLE
napkin-math: advisory source-preservation audit (Fork B, proposal 141 PR 1)

### DIFF
--- a/experiments/napkin_math/audit_source_preservation.py
+++ b/experiments/napkin_math/audit_source_preservation.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Advisory audit: classify every prior-baseline signal by what happened
+to it in the current parameters.json.
+
+Implements Fork B of proposal 141 (source-preservation audit). Reads a
+prior ``parameters.json`` and a current ``parameters.json``, builds the
+prior signal set, and classifies each prior id as one of:
+
+    preserved_by_id                — same id is in current
+    preserved_by_output_name       — prior id appears as an output_name
+    preserved_as_formula_dependency — prior id is on a current formula RHS
+                                      or in a current depends_on list
+    likely_renamed                 — prior id has high snake_case token
+                                      overlap with one or more current ids
+    absent_unexplained             — no preservation evidence found
+
+Advisory only. Exit 0 unless the input is malformed (exit 2). No strict
+mode, no CI gating, no schema changes to extract prompts — those land in
+later proposal 141 PRs after this audit's findings (false-positive rate,
+useful catches) are measured on the corpus.
+
+Out of scope for this PR (deferred to later proposal 141 PRs):
+  - Fork A (source-digest regex scan against the current artifact).
+  - The optional ``dropped_signals`` schema in extract prompts.
+  - LLM rationale parsing of ``dropped_signals`` entries.
+  - Strict-mode exit-non-zero policy.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SECTIONS_WITH_IDS: tuple[str, ...] = (
+    "key_values",
+    "missing_values_to_estimate",
+    "derived_questions",
+    "recommended_first_calculations",
+    "unmodelled_gates",
+)
+
+# Sections whose entries can declare an ``output_name`` distinct from
+# their ``id``. The audit treats matching output_names as a preservation
+# signal because downstream consumers (calculations.py, monte-carlo) bind
+# by output_name, not by id.
+SECTIONS_WITH_OUTPUT_NAMES: tuple[str, ...] = (
+    "key_values",
+    "derived_questions",
+    "recommended_first_calculations",
+)
+
+# Builtins stripped from formula_hint RHS token extraction. Matches the
+# set in validate_parameters.py for consistency.
+FORMULA_BUILTINS: frozenset[str] = frozenset(
+    {"min", "max", "abs", "sum", "round", "int", "float"}
+)
+
+# Jaccard-overlap threshold for the "likely_renamed" classification.
+# A snake_case prior id and a candidate current id are considered a
+# plausible rename when |intersection|/|union| >= this value.
+# Calibrated empirically: ``actual_X_rate`` vs ``X_realised_rate``
+# overlaps at 0.5; ``unrelated_thing`` vs ``different_id`` overlaps at 0.
+# Lower values produce more candidates (advisory); 0.4 is permissive
+# enough to surface most renames without flooding the report.
+RENAME_JACCARD_THRESHOLD: float = 0.4
+
+# Maximum candidate suggestions per likely_renamed prior id. The audit
+# is advisory — the reviewer wants the top few, not an exhaustive list.
+MAX_RENAME_CANDIDATES: int = 3
+
+
+def parse_rhs_tokens(formula: str) -> set[str]:
+    """Extract snake_case identifier tokens from the RHS of a
+    ``lhs = rhs`` formula (or the whole expression when no ``=``).
+    Function-name builtins are filtered out so they cannot collide with
+    prior ids. Numeric literals fall out naturally because they are not
+    snake_case identifiers.
+    """
+    if not isinstance(formula, str) or not formula:
+        return set()
+    rhs = formula.split("=", 1)[1] if "=" in formula else formula
+    return set(re.findall(r"[a-z_][a-z0-9_]*", rhs)) - FORMULA_BUILTINS
+
+
+def build_signal_index(params: dict) -> dict[str, Any]:
+    """Build a single index over a parameters.json artifact.
+
+    Returns a dict with:
+      - ``ids``: set of every entry's ``id`` across SECTIONS_WITH_IDS
+      - ``output_names``: set of every entry's ``output_name`` (when
+        declared) across SECTIONS_WITH_OUTPUT_NAMES
+      - ``formula_tokens``: set of every snake_case token that appears
+        on a ``formula_hint`` RHS or in a ``depends_on`` list in
+        derived_questions / recommended_first_calculations
+      - ``id_to_section``: map from id to the prior section it lived in
+    """
+    ids: set[str] = set()
+    output_names: set[str] = set()
+    formula_tokens: set[str] = set()
+    id_to_section: dict[str, str] = {}
+    for section in SECTIONS_WITH_IDS:
+        for entry in params.get(section, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            eid = entry.get("id")
+            if isinstance(eid, str) and eid:
+                ids.add(eid)
+                id_to_section.setdefault(eid, section)
+    for section in SECTIONS_WITH_OUTPUT_NAMES:
+        for entry in params.get(section, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("output_name")
+            if isinstance(name, str) and name:
+                output_names.add(name)
+    for section in ("derived_questions", "recommended_first_calculations"):
+        for entry in params.get(section, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            formula = entry.get("formula_hint")
+            if isinstance(formula, str):
+                formula_tokens |= parse_rhs_tokens(formula)
+            for dep in entry.get("depends_on", []) or []:
+                if isinstance(dep, str) and dep:
+                    formula_tokens.add(dep)
+    return {
+        "ids": ids,
+        "output_names": output_names,
+        "formula_tokens": formula_tokens,
+        "id_to_section": id_to_section,
+    }
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def find_rename_candidates(
+    prior_id: str, current_ids: set[str]
+) -> list[tuple[str, float]]:
+    """Return up to MAX_RENAME_CANDIDATES candidate current ids whose
+    snake_case token Jaccard overlap with ``prior_id`` meets the rename
+    threshold. Sorted descending by overlap.
+    """
+    prior_tokens = set(prior_id.split("_"))
+    if not prior_tokens:
+        return []
+    scored: list[tuple[str, float]] = []
+    for cid in current_ids:
+        score = jaccard(prior_tokens, set(cid.split("_")))
+        if score >= RENAME_JACCARD_THRESHOLD:
+            scored.append((cid, score))
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:MAX_RENAME_CANDIDATES]
+
+
+def classify_prior_signal(
+    prior_id: str, current_index: dict[str, Any]
+) -> dict[str, Any]:
+    """Classify one prior id by what evidence the current artifact
+    provides for it.
+    """
+    if prior_id in current_index["ids"]:
+        return {"status": "preserved_by_id"}
+    if prior_id in current_index["output_names"]:
+        return {"status": "preserved_by_output_name"}
+    if prior_id in current_index["formula_tokens"]:
+        return {"status": "preserved_as_formula_dependency"}
+    candidates = find_rename_candidates(prior_id, current_index["ids"])
+    if candidates:
+        return {
+            "status": "likely_renamed",
+            "candidates": [
+                {"id": cid, "jaccard": round(score, 3)}
+                for cid, score in candidates
+            ],
+        }
+    return {"status": "absent_unexplained"}
+
+
+def audit(prior_params: dict, current_params: dict) -> dict[str, Any]:
+    """Run the Fork-B audit. Returns a structured report:
+
+    {
+      "summary": {
+        "prior_total": int,
+        "preserved_by_id": int,
+        "preserved_by_output_name": int,
+        "preserved_as_formula_dependency": int,
+        "likely_renamed": int,
+        "absent_unexplained": int,
+      },
+      "details": [
+        {"prior_id": str, "prior_section": str, "status": str, ...},
+        ...
+      ],
+    }
+    """
+    prior_index = build_signal_index(prior_params)
+    current_index = build_signal_index(current_params)
+    summary = {
+        "prior_total": len(prior_index["ids"]),
+        "preserved_by_id": 0,
+        "preserved_by_output_name": 0,
+        "preserved_as_formula_dependency": 0,
+        "likely_renamed": 0,
+        "absent_unexplained": 0,
+    }
+    details: list[dict[str, Any]] = []
+    for prior_id in sorted(prior_index["ids"]):
+        cls = classify_prior_signal(prior_id, current_index)
+        summary[cls["status"]] = summary[cls["status"]] + 1
+        details.append({
+            "prior_id": prior_id,
+            "prior_section": prior_index["id_to_section"].get(prior_id, "?"),
+            **cls,
+        })
+    return {"summary": summary, "details": details}
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    """Human-readable rendering of an audit report. Lists summary
+    counts, then enumerates every non-preserved-by-id signal so reviewers
+    can see what was lost or renamed without scrolling past noise.
+    """
+    s = report["summary"]
+    lines = [
+        "Source-preservation audit (Fork B): prior vs current parameters.json",
+        "",
+        f"  Prior signals total              : {s['prior_total']}",
+        f"  preserved_by_id                  : {s['preserved_by_id']}",
+        f"  preserved_by_output_name         : {s['preserved_by_output_name']}",
+        f"  preserved_as_formula_dependency  : {s['preserved_as_formula_dependency']}",
+        f"  likely_renamed                   : {s['likely_renamed']}",
+        f"  absent_unexplained               : {s['absent_unexplained']}",
+        "",
+    ]
+    renamed = [d for d in report["details"] if d["status"] == "likely_renamed"]
+    if renamed:
+        lines.append("LIKELY RENAMED:")
+        for d in renamed:
+            cand_str = ", ".join(
+                f"{c['id']} (j={c['jaccard']})" for c in d["candidates"]
+            )
+            lines.append(f"  {d['prior_id']} [{d['prior_section']}] → {cand_str}")
+        lines.append("")
+    absent = [d for d in report["details"] if d["status"] == "absent_unexplained"]
+    if absent:
+        lines.append("ABSENT UNEXPLAINED:")
+        for d in absent:
+            lines.append(f"  {d['prior_id']} [{d['prior_section']}]")
+        lines.append("")
+    by_output = [
+        d for d in report["details"] if d["status"] == "preserved_by_output_name"
+    ]
+    if by_output:
+        lines.append("PRESERVED BY OUTPUT_NAME (id-rename via formula LHS):")
+        for d in by_output:
+            lines.append(f"  {d['prior_id']} [{d['prior_section']}]")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--prior", type=Path, required=True)
+    p.add_argument("--current", type=Path, required=True)
+    p.add_argument(
+        "--report-json",
+        type=Path,
+        default=None,
+        help="If set, write the machine-readable JSON report to this path.",
+    )
+    args = p.parse_args()
+    try:
+        prior_params = json.loads(args.prior.read_text())
+        current_params = json.loads(args.current.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"audit_source_preservation: JSON parse error: {exc}", file=sys.stderr)
+        return 2
+    report = audit(prior_params, current_params)
+    print(render_text_report(report))
+    if args.report_json is not None:
+        args.report_json.write_text(json.dumps(report, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/napkin_math/audit_source_preservation.py
+++ b/experiments/napkin_math/audit_source_preservation.py
@@ -89,19 +89,29 @@ def parse_rhs_tokens(formula: str) -> set[str]:
 def build_signal_index(params: dict) -> dict[str, Any]:
     """Build a single index over a parameters.json artifact.
 
+    Both ``id`` values and ``output_name`` values are treated as
+    first-class signals — downstream consumers (calculations.py,
+    monte-carlo runner, summarize-assessment) bind by ``output_name``,
+    not by entry ``id``. A calc entry whose ``id`` survives but whose
+    ``output_name`` changes is a genuine signal regression even though
+    the entry id matches; tracking both names catches that case.
+
     Returns a dict with:
+      - ``signals``: ordered dict from name → ``{"kind": "id" |
+        "output_name", "section": str}``. First occurrence wins when a
+        name appears as both an id and an output_name (the id reading
+        is the more authoritative one).
       - ``ids``: set of every entry's ``id`` across SECTIONS_WITH_IDS
       - ``output_names``: set of every entry's ``output_name`` (when
         declared) across SECTIONS_WITH_OUTPUT_NAMES
       - ``formula_tokens``: set of every snake_case token that appears
         on a ``formula_hint`` RHS or in a ``depends_on`` list in
         derived_questions / recommended_first_calculations
-      - ``id_to_section``: map from id to the prior section it lived in
     """
+    signals: dict[str, dict[str, str]] = {}
     ids: set[str] = set()
     output_names: set[str] = set()
     formula_tokens: set[str] = set()
-    id_to_section: dict[str, str] = {}
     for section in SECTIONS_WITH_IDS:
         for entry in params.get(section, []) or []:
             if not isinstance(entry, dict):
@@ -109,7 +119,7 @@ def build_signal_index(params: dict) -> dict[str, Any]:
             eid = entry.get("id")
             if isinstance(eid, str) and eid:
                 ids.add(eid)
-                id_to_section.setdefault(eid, section)
+                signals.setdefault(eid, {"kind": "id", "section": section})
     for section in SECTIONS_WITH_OUTPUT_NAMES:
         for entry in params.get(section, []) or []:
             if not isinstance(entry, dict):
@@ -117,6 +127,7 @@ def build_signal_index(params: dict) -> dict[str, Any]:
             name = entry.get("output_name")
             if isinstance(name, str) and name:
                 output_names.add(name)
+                signals.setdefault(name, {"kind": "output_name", "section": section})
     for section in ("derived_questions", "recommended_first_calculations"):
         for entry in params.get(section, []) or []:
             if not isinstance(entry, dict):
@@ -128,10 +139,10 @@ def build_signal_index(params: dict) -> dict[str, Any]:
                 if isinstance(dep, str) and dep:
                     formula_tokens.add(dep)
     return {
+        "signals": signals,
         "ids": ids,
         "output_names": output_names,
         "formula_tokens": formula_tokens,
-        "id_to_section": id_to_section,
     }
 
 
@@ -142,17 +153,23 @@ def jaccard(a: set[str], b: set[str]) -> float:
 
 
 def find_rename_candidates(
-    prior_id: str, current_ids: set[str]
+    prior_name: str, current_candidate_pool: set[str]
 ) -> list[tuple[str, float]]:
-    """Return up to MAX_RENAME_CANDIDATES candidate current ids whose
-    snake_case token Jaccard overlap with ``prior_id`` meets the rename
-    threshold. Sorted descending by overlap.
+    """Return up to MAX_RENAME_CANDIDATES candidate current names whose
+    snake_case token Jaccard overlap with ``prior_name`` meets the
+    rename threshold. Sorted descending by overlap.
+
+    The candidate pool should be the union of current ids and current
+    output_names — a prior id can rename to either a current id (entry
+    rename) or a current output_name (signal-role move).
     """
-    prior_tokens = set(prior_id.split("_"))
+    prior_tokens = set(prior_name.split("_"))
     if not prior_tokens:
         return []
     scored: list[tuple[str, float]] = []
-    for cid in current_ids:
+    for cid in current_candidate_pool:
+        if cid == prior_name:
+            continue
         score = jaccard(prior_tokens, set(cid.split("_")))
         if score >= RENAME_JACCARD_THRESHOLD:
             scored.append((cid, score))
@@ -161,18 +178,19 @@ def find_rename_candidates(
 
 
 def classify_prior_signal(
-    prior_id: str, current_index: dict[str, Any]
+    prior_name: str, current_index: dict[str, Any]
 ) -> dict[str, Any]:
-    """Classify one prior id by what evidence the current artifact
-    provides for it.
+    """Classify one prior signal name by what evidence the current
+    artifact provides for it.
     """
-    if prior_id in current_index["ids"]:
+    if prior_name in current_index["ids"]:
         return {"status": "preserved_by_id"}
-    if prior_id in current_index["output_names"]:
+    if prior_name in current_index["output_names"]:
         return {"status": "preserved_by_output_name"}
-    if prior_id in current_index["formula_tokens"]:
+    if prior_name in current_index["formula_tokens"]:
         return {"status": "preserved_as_formula_dependency"}
-    candidates = find_rename_candidates(prior_id, current_index["ids"])
+    candidate_pool = current_index["ids"] | current_index["output_names"]
+    candidates = find_rename_candidates(prior_name, candidate_pool)
     if candidates:
         return {
             "status": "likely_renamed",
@@ -197,15 +215,21 @@ def audit(prior_params: dict, current_params: dict) -> dict[str, Any]:
         "absent_unexplained": int,
       },
       "details": [
-        {"prior_id": str, "prior_section": str, "status": str, ...},
+        {"prior_name": str, "prior_kind": "id" | "output_name",
+         "prior_section": str, "status": str, ...},
         ...
       ],
     }
+
+    Every prior name — both entry ``id`` values and entry ``output_name``
+    values — is treated as a first-class signal. A calc whose ``id``
+    survives but whose ``output_name`` changes is a genuine signal
+    regression because downstream binders bind by output_name.
     """
     prior_index = build_signal_index(prior_params)
     current_index = build_signal_index(current_params)
     summary = {
-        "prior_total": len(prior_index["ids"]),
+        "prior_total": len(prior_index["signals"]),
         "preserved_by_id": 0,
         "preserved_by_output_name": 0,
         "preserved_as_formula_dependency": 0,
@@ -213,21 +237,32 @@ def audit(prior_params: dict, current_params: dict) -> dict[str, Any]:
         "absent_unexplained": 0,
     }
     details: list[dict[str, Any]] = []
-    for prior_id in sorted(prior_index["ids"]):
-        cls = classify_prior_signal(prior_id, current_index)
+    for prior_name in sorted(prior_index["signals"]):
+        meta = prior_index["signals"][prior_name]
+        cls = classify_prior_signal(prior_name, current_index)
         summary[cls["status"]] = summary[cls["status"]] + 1
         details.append({
-            "prior_id": prior_id,
-            "prior_section": prior_index["id_to_section"].get(prior_id, "?"),
+            "prior_name": prior_name,
+            "prior_kind": meta["kind"],
+            "prior_section": meta["section"],
             **cls,
         })
     return {"summary": summary, "details": details}
 
 
+def _format_signal_label(detail: dict[str, Any]) -> str:
+    kind = detail["prior_kind"]
+    section = detail["prior_section"]
+    kind_tag = "output_name" if kind == "output_name" else "id"
+    return f"{detail['prior_name']} [{section}/{kind_tag}]"
+
+
 def render_text_report(report: dict[str, Any]) -> str:
     """Human-readable rendering of an audit report. Lists summary
     counts, then enumerates every non-preserved-by-id signal so reviewers
-    can see what was lost or renamed without scrolling past noise.
+    can see what was lost or renamed without scrolling past noise. Each
+    entry is tagged with ``[section/id]`` or ``[section/output_name]``
+    so reviewers can distinguish entry-id drift from output-name drift.
     """
     s = report["summary"]
     lines = [
@@ -248,21 +283,21 @@ def render_text_report(report: dict[str, Any]) -> str:
             cand_str = ", ".join(
                 f"{c['id']} (j={c['jaccard']})" for c in d["candidates"]
             )
-            lines.append(f"  {d['prior_id']} [{d['prior_section']}] → {cand_str}")
+            lines.append(f"  {_format_signal_label(d)} → {cand_str}")
         lines.append("")
     absent = [d for d in report["details"] if d["status"] == "absent_unexplained"]
     if absent:
         lines.append("ABSENT UNEXPLAINED:")
         for d in absent:
-            lines.append(f"  {d['prior_id']} [{d['prior_section']}]")
+            lines.append(f"  {_format_signal_label(d)}")
         lines.append("")
     by_output = [
         d for d in report["details"] if d["status"] == "preserved_by_output_name"
     ]
     if by_output:
-        lines.append("PRESERVED BY OUTPUT_NAME (id-rename via formula LHS):")
+        lines.append("PRESERVED BY OUTPUT_NAME (signal survives via formula LHS):")
         for d in by_output:
-            lines.append(f"  {d['prior_id']} [{d['prior_section']}]")
+            lines.append(f"  {_format_signal_label(d)}")
         lines.append("")
     return "\n".join(lines)
 

--- a/experiments/napkin_math/tests/test_audit_source_preservation.py
+++ b/experiments/napkin_math/tests/test_audit_source_preservation.py
@@ -1,0 +1,288 @@
+"""Focused unit tests for audit_source_preservation.py (Fork B advisory).
+
+Synthetic fixtures only — no corpus literals. Each test passes minimal
+in-memory parameters dicts to ``audit()`` and inspects the structured
+report.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+NAPKIN_DIR = Path(__file__).resolve().parent.parent
+AUDIT_PATH = NAPKIN_DIR / "audit_source_preservation.py"
+
+spec = importlib.util.spec_from_file_location("audit_source_preservation", AUDIT_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mod)
+
+
+def _kv(eid: str, **extra: object) -> dict[str, object]:
+    """Build a synthetic key_values entry with just the fields the audit
+    looks at."""
+    return {
+        "id": eid,
+        "label": extra.get("label", eid),
+        "category": extra.get("category", "test"),
+        "value_type": extra.get("value_type", "explicit"),
+        "unit": extra.get("unit", "test_unit"),
+        "value": extra.get("value", 1.0),
+        "comment": extra.get("comment", ""),
+        "formula_hint": extra.get("formula_hint"),
+        "output_name": extra.get("output_name"),
+        "output_unit": extra.get("output_unit"),
+        "depends_on": extra.get("depends_on", []),
+        "modelling_priority": extra.get("modelling_priority", "medium"),
+        "uncertainty": extra.get("uncertainty", "low"),
+        "source_text": extra.get("source_text", ""),
+    }
+
+
+def _mv(eid: str) -> dict[str, object]:
+    return {
+        "id": eid,
+        "label": eid,
+        "unit": "test_unit",
+        "why_needed": "test",
+        "suggested_estimation_method": "test",
+    }
+
+
+def _calc(eid: str, *, output_name: str, formula: str,
+          depends_on: list[str] | None = None) -> dict[str, object]:
+    return {
+        "id": eid,
+        "label": eid,
+        "formula_hint": formula,
+        "output_name": output_name,
+        "output_unit": "test_unit",
+        "depends_on": depends_on or [],
+        "why_first": "test",
+    }
+
+
+PLAN_SUMMARY = {
+    "plan_name": "synthetic",
+    "plan_type": "synthetic",
+    "primary_goal": "test",
+    "modelling_frame": "test",
+}
+
+
+def _build(**sections: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "plan_summary": PLAN_SUMMARY,
+        "key_values": [],
+        "derived_questions": [],
+        "missing_values_to_estimate": [],
+        "recommended_first_calculations": [],
+    }
+    base.update(sections)
+    return base
+
+
+# ─── preserved_by_id ──────────────────────────────────────────────────────
+
+def test_preserved_by_id_when_same_id_present_in_current() -> None:
+    prior = _build(key_values=[_kv("alpha"), _kv("beta")])
+    current = _build(key_values=[_kv("alpha"), _kv("beta"), _kv("gamma")])
+    report = mod.audit(prior, current)
+    assert report["summary"]["preserved_by_id"] == 2
+    assert report["summary"]["absent_unexplained"] == 0
+    statuses = {d["prior_id"]: d["status"] for d in report["details"]}
+    assert statuses == {"alpha": "preserved_by_id", "beta": "preserved_by_id"}
+
+
+# ─── preserved_by_output_name ─────────────────────────────────────────────
+
+def test_preserved_by_output_name_when_primitive_became_a_calculation() -> None:
+    """Rename pattern: a prior key_value (primitive) is removed and a
+    current calculation now produces the same name as its output_name.
+    Downstream binders look at output_name, so the signal IS preserved
+    — but now it is a computed quantity rather than a sampled input."""
+    prior = _build(key_values=[_kv("burn_rate_per_month")])
+    current = _build(
+        recommended_first_calculations=[
+            _calc(
+                "c_burn",
+                output_name="burn_rate_per_month",
+                formula="burn_rate_per_month = annual_burn / 12",
+                depends_on=["annual_burn"],
+            ),
+        ],
+    )
+    report = mod.audit(prior, current)
+    assert report["summary"]["preserved_by_output_name"] == 1
+    assert report["summary"]["preserved_by_id"] == 0
+    assert report["summary"]["absent_unexplained"] == 0
+
+
+# ─── preserved_as_formula_dependency ──────────────────────────────────────
+
+def test_preserved_as_formula_dependency_when_used_on_rhs() -> None:
+    """The prior key_value is no longer declared directly in the current
+    artifact, but a current formula RHS still references the same token.
+    The signal is alive as an input to a calculation."""
+    prior = _build(key_values=[_kv("burn_rate_per_month")])
+    current = _build(
+        recommended_first_calculations=[
+            _calc("c_holding", output_name="holding_cost",
+                  formula="holding_cost = burn_rate_per_month * months_delay",
+                  depends_on=["months_delay"]),
+        ],
+    )
+    report = mod.audit(prior, current)
+    assert report["summary"]["preserved_as_formula_dependency"] == 1
+
+
+def test_preserved_as_formula_dependency_when_in_depends_on() -> None:
+    prior = _build(key_values=[_kv("vendor_quote_eur")])
+    current = _build(
+        recommended_first_calculations=[
+            _calc("c_total", output_name="total_eur",
+                  formula="total_eur = some_other_var",
+                  depends_on=["vendor_quote_eur", "some_other_var"]),
+        ],
+    )
+    report = mod.audit(prior, current)
+    assert report["summary"]["preserved_as_formula_dependency"] == 1
+
+
+# ─── likely_renamed ───────────────────────────────────────────────────────
+
+def test_likely_renamed_when_token_overlap_above_threshold() -> None:
+    """``actual_outreach_contact_rate`` → ``outreach_contact_rate_target``:
+    3 of 5 tokens overlap (outreach, contact, rate). Jaccard = 3/5 = 0.6,
+    above the 0.4 threshold."""
+    prior = _build(key_values=[_kv("actual_outreach_contact_rate")])
+    current = _build(key_values=[_kv("outreach_contact_rate_target")])
+    report = mod.audit(prior, current)
+    assert report["summary"]["likely_renamed"] == 1
+    detail = next(d for d in report["details"] if d["status"] == "likely_renamed")
+    assert detail["prior_id"] == "actual_outreach_contact_rate"
+    cand_ids = [c["id"] for c in detail["candidates"]]
+    assert "outreach_contact_rate_target" in cand_ids
+
+
+def test_likely_renamed_ranks_multiple_candidates_descending() -> None:
+    """When multiple current ids overlap with the prior, the audit
+    returns up to MAX_RENAME_CANDIDATES candidates sorted by overlap."""
+    prior = _build(key_values=[_kv("alpha_beta_gamma")])
+    current = _build(
+        key_values=[
+            _kv("alpha_beta_gamma_delta"),  # 3/4 overlap
+            _kv("alpha_beta_epsilon"),       # 2/4 overlap = 0.5
+            _kv("unrelated"),                # 0 overlap
+        ],
+    )
+    report = mod.audit(prior, current)
+    detail = next(d for d in report["details"] if d["status"] == "likely_renamed")
+    cand_ids = [c["id"] for c in detail["candidates"]]
+    assert cand_ids[0] == "alpha_beta_gamma_delta"
+    assert cand_ids[1] == "alpha_beta_epsilon"
+    # The unrelated id falls below threshold and is excluded.
+    assert "unrelated" not in cand_ids
+
+
+# ─── absent_unexplained ───────────────────────────────────────────────────
+
+def test_absent_unexplained_when_no_overlap() -> None:
+    prior = _build(key_values=[_kv("orphan_alpha_token")])
+    current = _build(key_values=[_kv("completely_different_id")])
+    report = mod.audit(prior, current)
+    assert report["summary"]["absent_unexplained"] == 1
+    detail = next(d for d in report["details"]
+                  if d["status"] == "absent_unexplained")
+    assert detail["prior_id"] == "orphan_alpha_token"
+
+
+def test_absent_unexplained_when_current_is_empty() -> None:
+    prior = _build(
+        key_values=[_kv("alpha")],
+        missing_values_to_estimate=[_mv("beta")],
+    )
+    current = _build()
+    report = mod.audit(prior, current)
+    assert report["summary"]["prior_total"] == 2
+    assert report["summary"]["absent_unexplained"] == 2
+
+
+# ─── empty inputs ─────────────────────────────────────────────────────────
+
+def test_empty_prior_yields_zero_signals() -> None:
+    report = mod.audit(_build(), _build())
+    assert report["summary"]["prior_total"] == 0
+    assert report["details"] == []
+
+
+# ─── cross-section preservation ───────────────────────────────────────────
+
+def test_preserved_by_id_across_sections() -> None:
+    """A signal moved from key_values to unmodelled_gates is still
+    preserved_by_id — the audit looks across all five sections."""
+    prior = _build(key_values=[_kv("regulatory_floor_id")])
+    current = _build(
+        unmodelled_gates=[{
+            "id": "regulatory_floor_id",
+            "label": "Regulatory floor",
+            "why_it_matters": "test",
+            "source_anchor": "assumptions",
+            "consequence_if_false": "test",
+        }],
+    )
+    report = mod.audit(prior, current)
+    assert report["summary"]["preserved_by_id"] == 1
+
+
+# ─── render_text_report smoke ─────────────────────────────────────────────
+
+def test_text_report_renders_summary_and_sections() -> None:
+    prior = _build(
+        key_values=[
+            _kv("alpha"),                     # preserved_by_id
+            _kv("orphan_x"),                  # absent_unexplained
+            _kv("renamed_alpha_beta"),        # likely_renamed
+        ],
+    )
+    current = _build(
+        key_values=[
+            _kv("alpha"),
+            _kv("renamed_alpha_beta_delta"),  # likely_renamed target
+        ],
+    )
+    report = mod.audit(prior, current)
+    text = mod.render_text_report(report)
+    assert "Source-preservation audit" in text
+    assert "preserved_by_id" in text
+    assert "LIKELY RENAMED:" in text
+    assert "ABSENT UNEXPLAINED:" in text
+    assert "orphan_x" in text
+    assert "renamed_alpha_beta" in text
+
+
+# ─── jaccard primitive ────────────────────────────────────────────────────
+
+def test_jaccard_token_overlap_primitive() -> None:
+    assert mod.jaccard(set(), set()) == 0.0
+    assert mod.jaccard({"a"}, set()) == 0.0
+    assert mod.jaccard({"a", "b"}, {"a", "b"}) == 1.0
+    assert mod.jaccard({"a", "b"}, {"a", "c"}) == 1 / 3
+
+
+def test_parse_rhs_tokens_handles_assignment_and_builtins() -> None:
+    tokens = mod.parse_rhs_tokens("lhs = max(a, b) + c * 2")
+    # Builtins ``max`` filtered out; numeric literals are not snake_case
+    # identifiers and fall out naturally.
+    assert tokens == {"a", "b", "c"}
+
+
+def test_parse_rhs_tokens_handles_expression_without_assignment() -> None:
+    tokens = mod.parse_rhs_tokens("a + b - c")
+    assert tokens == {"a", "b", "c"}
+
+
+def test_parse_rhs_tokens_returns_empty_for_non_string() -> None:
+    assert mod.parse_rhs_tokens(None) == set()
+    assert mod.parse_rhs_tokens("") == set()

--- a/experiments/napkin_math/tests/test_audit_source_preservation.py
+++ b/experiments/napkin_math/tests/test_audit_source_preservation.py
@@ -91,7 +91,7 @@ def test_preserved_by_id_when_same_id_present_in_current() -> None:
     report = mod.audit(prior, current)
     assert report["summary"]["preserved_by_id"] == 2
     assert report["summary"]["absent_unexplained"] == 0
-    statuses = {d["prior_id"]: d["status"] for d in report["details"]}
+    statuses = {d["prior_name"]: d["status"] for d in report["details"]}
     assert statuses == {"alpha": "preserved_by_id", "beta": "preserved_by_id"}
 
 
@@ -161,7 +161,7 @@ def test_likely_renamed_when_token_overlap_above_threshold() -> None:
     report = mod.audit(prior, current)
     assert report["summary"]["likely_renamed"] == 1
     detail = next(d for d in report["details"] if d["status"] == "likely_renamed")
-    assert detail["prior_id"] == "actual_outreach_contact_rate"
+    assert detail["prior_name"] == "actual_outreach_contact_rate"
     cand_ids = [c["id"] for c in detail["candidates"]]
     assert "outreach_contact_rate_target" in cand_ids
 
@@ -195,7 +195,7 @@ def test_absent_unexplained_when_no_overlap() -> None:
     assert report["summary"]["absent_unexplained"] == 1
     detail = next(d for d in report["details"]
                   if d["status"] == "absent_unexplained")
-    assert detail["prior_id"] == "orphan_alpha_token"
+    assert detail["prior_name"] == "orphan_alpha_token"
 
 
 def test_absent_unexplained_when_current_is_empty() -> None:
@@ -260,6 +260,75 @@ def test_text_report_renders_summary_and_sections() -> None:
     assert "ABSENT UNEXPLAINED:" in text
     assert "orphan_x" in text
     assert "renamed_alpha_beta" in text
+
+
+# ─── output_name as first-class signal ────────────────────────────────────
+
+def test_output_name_drift_on_preserved_id_is_reported() -> None:
+    """Review feedback on PR #751 (first round): a calc whose entry id
+    survives but whose output_name changes is a genuine signal
+    regression — downstream binders bind by output_name, not by entry
+    id. The audit must report the lost prior output_name as a separate
+    signal, even though the id is preserved."""
+    prior = _build(
+        derived_questions=[{
+            "id": "q_margin",
+            "question": "What is the margin?",
+            "why_it_matters": "test",
+            "formula_hint": "old_margin = actual - threshold",
+            "output_name": "old_margin",
+            "output_unit": "test_unit",
+            "depends_on": ["actual", "threshold"],
+        }],
+    )
+    current = _build(
+        derived_questions=[{
+            "id": "q_margin",
+            "question": "What is the margin?",
+            "why_it_matters": "test",
+            "formula_hint": "new_margin = actual - threshold",
+            "output_name": "new_margin",
+            "output_unit": "test_unit",
+            "depends_on": ["actual", "threshold"],
+        }],
+    )
+    report = mod.audit(prior, current)
+    # Two prior signals: the entry id ``q_margin`` and the output_name
+    # ``old_margin``. The id survives; the output_name does not.
+    assert report["summary"]["prior_total"] == 2
+    statuses = {d["prior_name"]: d["status"] for d in report["details"]}
+    assert statuses["q_margin"] == "preserved_by_id"
+    assert statuses["old_margin"] == "absent_unexplained"
+    old_margin_detail = next(
+        d for d in report["details"] if d["prior_name"] == "old_margin"
+    )
+    assert old_margin_detail["prior_kind"] == "output_name"
+
+
+def test_rename_candidates_drawn_from_output_names_too() -> None:
+    """Mars-style restructures often rename a prior id to a new
+    output_name. Rename candidates must be searchable across both
+    current ids and current output_names so the audit can suggest the
+    output_name as a plausible target."""
+    prior = _build(key_values=[_kv("year1_revenue_surplus_usd")])
+    current = _build(
+        recommended_first_calculations=[
+            _calc(
+                "c_surplus",
+                output_name="year1_viability_surplus_usd",
+                formula="year1_viability_surplus_usd = revenue - cost",
+                depends_on=["revenue", "cost"],
+            ),
+        ],
+    )
+    report = mod.audit(prior, current)
+    detail = next(
+        d for d in report["details"]
+        if d["prior_name"] == "year1_revenue_surplus_usd"
+    )
+    assert detail["status"] == "likely_renamed"
+    cand_ids = [c["id"] for c in detail["candidates"]]
+    assert "year1_viability_surplus_usd" in cand_ids
 
 
 # ─── jaccard primitive ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Starts proposal 141 with the smallest useful slice: a deterministic advisory audit that diffs a prior `parameters.json` against a current `parameters.json` and classifies every prior signal as one of five outcomes. **No strict mode, no CI gating, no schema changes to extract prompts, no LLM rationale parsing** — those land in later proposal 141 PRs after this audit's findings (false-positive rate, useful catches) are measured on the corpus.

## What counts as a "prior signal"

Both entry `id` values AND entry `output_name` values across the five sections (`key_values`, `missing_values_to_estimate`, `derived_questions`, `recommended_first_calculations`, `unmodelled_gates`). Output_names are first-class because downstream consumers (calculations.py, monte-carlo, summarize-assessment) bind by output_name, not by entry id — a calc whose entry id survives but whose output_name changes is a genuine signal regression.

## Classification

Each prior signal name is classified by what evidence the current artifact provides:

| Status | Meaning |
|---|---|
| `preserved_by_id` | same name appears as a current entry id |
| `preserved_by_output_name` | name appears as a current `output_name` (downstream binders use output_name) |
| `preserved_as_formula_dependency` | name is on a current `formula_hint` RHS or in a current `depends_on` list |
| `likely_renamed` | snake_case token Jaccard overlap ≥ 0.4 with one or more candidates from current ids ∪ current output_names (advisory; top 3 candidates by overlap) |
| `absent_unexplained` | no preservation evidence at all |

Threshold calibration: `actual_X → X_target` overlaps at 0.6, `X_dkk → X_floor_dkk` at 0.75, `X_capex → X_capex_floor` at 0.83. Unrelated ids stay near 0. 0.4 is permissive enough to surface renames without flooding the report.

Detail entries carry `prior_kind` (`"id"` or `"output_name"`) so reviewers can distinguish entry-id drift from output-name drift. The text renderer tags each line with `[section/kind]`.

## Out of scope (later proposal 141 PRs)

- **Fork A**: source-digest regex scan against the current artifact.
- **`dropped_signals` schema**: optional field in extract prompts.
- **LLM rationale parsing** of `dropped_signals` entries.
- **Strict mode** / CI gating policy.

## Empirical findings on v49 → v51 (6 probes)

| Plan | Prior signals | by_id | by_output_name | renamed | absent |
|---|---|---|---|---|---|
| euro_adoption | 18 | 17 | 0 | 1 | 0 |
| yellowstone | 18 | 12 | 0 | 5 | 1 |
| crate | 23 | 11 | 2 | 7 | 3 |
| mars_gtld | 23 | 14 | 1 | 6 | 2 |
| datacenter | 25 | 0 | 0 | 11 | 14 |
| paperclip | 18 | 3 | 0 | 12 | 3 |

**Useful catches the audit surfaces mechanically:**
- **Paperclip latency-tripwire trio** all absent from v51: `actual_api_p99_latency_ms`, `api_latency_margin_ms`, `api_latency_p99_threshold_ms` — exactly the silent-regression failure mode the plan doc has been flagging as needing mechanical detection.
- **Yellowstone `public_compliance_threshold`** absent — documented v49→v51 regression in the plan's "Known limitations" section.
- **Crate `q_logistics_budget_margin`, `target_recovery_rate`, `annual_crate_loss_volume`** all absent.
- **Datacenter** wholesale restructure (0 ids preserved verbatim, 11 renamed, 14 absent) — useful diagnostic; reviewer can scan rename candidates.

**False-positive surface (called out honestly):**
- Some `likely_renamed` candidates at jaccard 0.4–0.5 are borderline. Example: paperclip's `manual_intervention_margin_hours → actual_manual_intervention_hours_per_week` (j=0.43) might be a different concept (margin variable vs realised variable), not a true rename.
- The token-only heuristic treats role changes (margin ↔ realised) as renames.
- No semantic check (label overlap, source_text overlap) — just snake_case token Jaccard. Adding semantic checks is a candidate refinement for PR 3 once we see how reviewers actually use the audit.

## Test plan
- [x] `pytest experiments/napkin_math/tests/test_audit_source_preservation.py` (17 synthetic unit tests pass — 15 + 2 for output_name drift and output_name-as-rename-candidate)
- [x] Audit run end-to-end on all 6 v49→v51 probes — output is sensible and surfaces the known absences
- [x] No hand-patching of parameters.json (the audit reads, never writes)
- [x] Output_name treated as a first-class audited signal (review feedback)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)