### PR TITLE
napkin-math: prior-signal ledger orchestration for extract skill (proposal 141 PR 3)

### DIFF
--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-digest/system-prompt.txt
@@ -907,6 +907,16 @@ Dropped-signal explanations (optional `dropped_signals` field):
 
 A separate top-level array `dropped_signals` documents prior-iteration or source-stated signals that the current artifact deliberately leaves out. The intent is to let a deterministic source-preservation audit distinguish a defensible cap-pressure drop from a silent regression. Each entry must name a structural reason and reference the current signal it was replaced by, made redundant with, or moved to.
 
+Prior Signal Ledger (when present in the input):
+
+The combined digest may end with a section titled `# Prior Signal Ledger (advisory)` listing the previous iteration's named signals (entry ids and output_names) with their section, kind, formula_hint, and depends_on. When this ledger is present:
+
+- Treat it as a preservation budget, NOT a target to copy. The compressed and raw sections above remain the authoritative source — the ledger is advisory metadata about the previous extraction, not source content.
+- If a prior signal is still source-supported and load-bearing, preserve it. The natural shape is to keep the same id, the same output_name, or use it as a formula dependency. Same id is the strongest signal of preservation; downstream consumers bind by output_name.
+- When a prior signal must be replaced, made redundant, moved to `unmodelled_gates`, dropped under cap pressure, or excluded as out of scope, record `dropped_signals` entry with `origin: "prior_baseline"` and a reference that resolves to a current id, output_name, or unmodelled_gates id. The audit rejects entries whose references do not resolve.
+- Do NOT invent `dropped_signals` entries for signals that are not in the ledger and are not stated in the source digest above. The ledger defines the universe of prior-baseline signals the audit will check; fabrications waste a confession slot and add noise.
+- When no Prior Signal Ledger is present, the artifact is a first-iteration extraction. Leave `dropped_signals` empty or omit the field.
+
 Use cases (corpus-agnostic):
 - A prior iteration declared a primitive that has now been computed from named constituents; record the old id with `reason: "replaced_by"` and `replacement_id` pointing at the current calculation's `output_name` or entry id.
 - A prior iteration's signal is mechanically equivalent to a current signal under a different name; record with `reason: "redundant_with"` and `redundant_with_id`.

--- a/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
+++ b/experiments/napkin_math/.claude/skills/extract-parameters-from-full/system-prompt.txt
@@ -866,6 +866,16 @@ Dropped-signal explanations (optional `dropped_signals` field):
 
 A separate top-level array `dropped_signals` documents prior-iteration or source-stated signals that the current artifact deliberately leaves out. The intent is to let a deterministic source-preservation audit distinguish a defensible cap-pressure drop from a silent regression. Each entry must name a structural reason and reference the current signal it was replaced by, made redundant with, or moved to.
 
+Prior Signal Ledger (when present in the input):
+
+The combined input may end with a section titled `# Prior Signal Ledger (advisory)` listing the previous iteration's named signals (entry ids and output_names) with their section, kind, formula_hint, and depends_on. When this ledger is present:
+
+- Treat it as a preservation budget, NOT a target to copy. The report content above remains the authoritative source — the ledger is advisory metadata about the previous extraction, not source content.
+- If a prior signal is still source-supported and load-bearing, preserve it. The natural shape is to keep the same id, the same output_name, or use it as a formula dependency. Same id is the strongest signal of preservation; downstream consumers bind by output_name.
+- When a prior signal must be replaced, made redundant, moved to `unmodelled_gates`, dropped under cap pressure, or excluded as out of scope, record `dropped_signals` entry with `origin: "prior_baseline"` and a reference that resolves to a current id, output_name, or unmodelled_gates id. The audit rejects entries whose references do not resolve.
+- Do NOT invent `dropped_signals` entries for signals that are not in the ledger and are not stated in the source report above. The ledger defines the universe of prior-baseline signals the audit will check; fabrications waste a confession slot and add noise.
+- When no Prior Signal Ledger is present, the artifact is a first-iteration extraction. Leave `dropped_signals` empty or omit the field.
+
 Use cases (corpus-agnostic):
 - A prior iteration declared a primitive that has now been computed from named constituents; record the old id with `reason: "replaced_by"` and `replacement_id` pointing at the current calculation's `output_name` or entry id.
 - A prior iteration's signal is mechanically equivalent to a current signal under a different name; record with `reason: "redundant_with"` and `redundant_with_id`.

--- a/experiments/napkin_math/prepare_extract_input.py
+++ b/experiments/napkin_math/prepare_extract_input.py
@@ -33,10 +33,12 @@ PROMPT> python experiments/napkin_math/prepare_extract_input.py \\
             --planexe-dir /Users/neoneye/git/PlanExe-web/20260215_nuuk_clay_workshop
 """
 import argparse
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKER_PLAN_DIR = REPO_ROOT / "worker_plan"
@@ -118,12 +120,114 @@ def run_compress(planexe_dir: Path, output_dir: Path, llm: str | None) -> None:
     subprocess.run(cmd, env=env, cwd=str(WORKER_PLAN_DIR), check=True)
 
 
-def build_combined_digest(planexe_dir: Path, output_dir: Path) -> Path:
+SECTIONS_WITH_IDS_FOR_LEDGER: tuple[str, ...] = (
+    "key_values",
+    "missing_values_to_estimate",
+    "derived_questions",
+    "recommended_first_calculations",
+    "unmodelled_gates",
+)
+
+SECTIONS_WITH_OUTPUT_NAMES_FOR_LEDGER: tuple[str, ...] = (
+    "key_values",
+    "derived_questions",
+    "recommended_first_calculations",
+)
+
+PRIOR_LEDGER_HEADER: str = """\
+# Prior Signal Ledger (advisory)
+
+This ledger lists the prior iteration's named signals — entry ids and
+output_names from a previous `parameters.json`. Treat it as a
+preservation budget, NOT a target to copy. The source digest above is
+the authoritative input.
+
+If a prior signal is still source-supported and load-bearing, preserve
+it: keep the same id, the same output_name, or use it as a formula
+dependency. When a prior signal must be replaced, made redundant, moved
+to `unmodelled_gates`, dropped under cap pressure, or excluded as out
+of scope, record the explanation in `dropped_signals` per the schema —
+with `origin: "prior_baseline"` and a reference that resolves to a
+current id / output_name / unmodelled_gates id.
+
+Do not invent `dropped_signals` entries for signals that are not in
+this ledger and are not stated in the source digest above. The ledger
+defines the universe of prior-baseline signals the audit will check.
+"""
+
+
+def build_prior_signal_ledger(prior_params: dict) -> str:
+    """Build a compact markdown ledger listing the prior baseline's
+    named signals — entry ids and output_names across the five sections
+    that carry them. Intentionally narrow: no source_text, no labels,
+    no comments. The LLM gets a preservation budget to compare against
+    the source digest, not a phrasing target to anchor on.
+
+    Each signal is listed with its section, kind (id or output_name),
+    formula_hint (when present), and depends_on (when non-empty) so
+    structural relationships survive. Signals are deduplicated: a name
+    that appears as both an id and an output_name is listed once with
+    kind = ``id`` (the more authoritative reading).
+    """
+    seen: dict[str, dict[str, Any]] = {}
+    for section in SECTIONS_WITH_IDS_FOR_LEDGER:
+        for entry in prior_params.get(section, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            eid = entry.get("id")
+            if not isinstance(eid, str) or not eid:
+                continue
+            seen.setdefault(eid, {
+                "kind": "id",
+                "section": section,
+                "formula_hint": entry.get("formula_hint"),
+                "depends_on": entry.get("depends_on") or [],
+            })
+    for section in SECTIONS_WITH_OUTPUT_NAMES_FOR_LEDGER:
+        for entry in prior_params.get(section, []) or []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("output_name")
+            if not isinstance(name, str) or not name:
+                continue
+            seen.setdefault(name, {
+                "kind": "output_name",
+                "section": section,
+                "formula_hint": entry.get("formula_hint"),
+                "depends_on": entry.get("depends_on") or [],
+            })
+    lines: list[str] = [PRIOR_LEDGER_HEADER.rstrip(), "", "## Signals", ""]
+    for name in sorted(seen):
+        meta = seen[name]
+        lines.append(f"- `{name}` [{meta['section']}/{meta['kind']}]")
+        formula = meta.get("formula_hint")
+        if isinstance(formula, str) and formula.strip():
+            lines.append(f"  - formula_hint: `{formula.strip()}`")
+        depends = meta.get("depends_on") or []
+        depends = [d for d in depends if isinstance(d, str) and d]
+        if depends:
+            lines.append(f"  - depends_on: {', '.join('`' + d + '`' for d in depends)}")
+    if not seen:
+        lines.append("(no prior signals — first-iteration baseline)")
+    return "\n".join(lines) + "\n"
+
+
+def build_combined_digest(
+    planexe_dir: Path, output_dir: Path, prior_params: dict | None = None,
+) -> Path:
     """Concatenate the 137-recommended extraction bundle, in 137's order, with
     a legend at the top. Compressed sections come from ``output_dir/compress_*.md``;
     raw sections come straight from ``planexe_dir``. Missing sections are
     skipped with a warning rather than aborting, so partial output is still
     usable.
+
+    When ``prior_params`` is provided (the parsed contents of a prior
+    ``parameters.json``), a compact prior-signal ledger is appended after
+    the regular bundle so the extract LLM can decide which prior signals
+    to preserve and which to record in ``dropped_signals``. The ledger is
+    intentionally narrow — names, sections, formula_hints and depends_on
+    only — so it acts as a preservation budget rather than a phrasing
+    target.
     """
     parts: list[str] = [LEGEND.rstrip(), "", "---", ""]
     found_any = False
@@ -153,6 +257,9 @@ def build_combined_digest(planexe_dir: Path, output_dir: Path) -> Path:
             f"run_compress_full output above for compression errors, and verify "
             f"that the raw section files exist under {planexe_dir}."
         )
+    if prior_params is not None:
+        parts.append(build_prior_signal_ledger(prior_params).rstrip())
+        parts.append("")
     combined = output_dir / "extract_parameters_input.md"
     combined.write_text("\n".join(parts).rstrip() + "\n", encoding="utf-8")
     return combined
@@ -182,6 +289,19 @@ def main() -> None:
         help="LLM name passed through to run_compress_full via "
         "COMPRESS_FULL_LLM. Default: run_compress_full's own default model.",
     )
+    ap.add_argument(
+        "--prior",
+        type=Path,
+        default=None,
+        help="Optional path to a prior iteration's parameters.json. When "
+        "provided, a compact Prior Signal Ledger is appended to the "
+        "combined digest so the extract LLM can decide which prior "
+        "signals to preserve and which to record in dropped_signals "
+        "(proposal 141 PR 3). The ledger contains only signal names, "
+        "sections, formula_hints, and depends_on — no source_text or "
+        "labels — so it acts as a preservation budget rather than a "
+        "phrasing target. Omit for first-iteration extractions.",
+    )
     args = ap.parse_args()
 
     planexe_dir: Path = args.planexe_dir.resolve()
@@ -199,11 +319,24 @@ def main() -> None:
     print(f"Output dir  : {output_dir}")
     print(f"LLM         : {args.llm or '(run_compress_full default)'}\n")
 
+    prior_params: dict | None = None
+    if args.prior is not None:
+        prior_path: Path = args.prior.resolve()
+        if not prior_path.is_file():
+            raise SystemExit(f"--prior not found or not a file: {prior_path}")
+        try:
+            prior_params = json.loads(prior_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"--prior is not valid JSON: {exc}") from exc
+        print(f"Prior        : {prior_path}\n")
+
     run_compress(planexe_dir, output_dir, args.llm)
-    combined = build_combined_digest(planexe_dir, output_dir)
+    combined = build_combined_digest(planexe_dir, output_dir, prior_params=prior_params)
 
     print(f"\nWrote combined digest: {combined}")
     print("Feed this file to the extract-parameters-from-digest skill.")
+    if prior_params is not None:
+        print("Includes a Prior Signal Ledger appended after the bundle.")
 
 
 if __name__ == "__main__":

--- a/experiments/napkin_math/tests/test_prepare_extract_input_prior_ledger.py
+++ b/experiments/napkin_math/tests/test_prepare_extract_input_prior_ledger.py
@@ -1,0 +1,248 @@
+"""Focused unit tests for the Prior Signal Ledger builder added in
+proposal 141 PR 3. Tests use synthetic in-memory parameters dicts and
+hermetic tmpdirs for the end-to-end ``build_combined_digest`` path.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+NAPKIN_DIR = Path(__file__).resolve().parent.parent
+PREPARE_PATH = NAPKIN_DIR / "prepare_extract_input.py"
+
+spec = importlib.util.spec_from_file_location("prepare_extract_input", PREPARE_PATH)
+prepare = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules.setdefault("prepare_extract_input", prepare)
+spec.loader.exec_module(prepare)
+
+
+def _kv(eid: str, **extra: object) -> dict[str, object]:
+    return {
+        "id": eid,
+        "label": extra.get("label", eid),
+        "category": extra.get("category", "test"),
+        "value_type": extra.get("value_type", "explicit"),
+        "unit": extra.get("unit", "test_unit"),
+        "value": extra.get("value", 1.0),
+        "comment": extra.get("comment", ""),
+        "formula_hint": extra.get("formula_hint"),
+        "output_name": extra.get("output_name"),
+        "output_unit": extra.get("output_unit"),
+        "depends_on": extra.get("depends_on", []),
+        "modelling_priority": extra.get("modelling_priority", "medium"),
+        "uncertainty": extra.get("uncertainty", "low"),
+        "source_text": extra.get("source_text", ""),
+    }
+
+
+def _calc(eid: str, *, output_name: str, formula: str,
+          depends_on: list[str] | None = None) -> dict[str, object]:
+    return {
+        "id": eid,
+        "label": eid,
+        "formula_hint": formula,
+        "output_name": output_name,
+        "output_unit": "test_unit",
+        "depends_on": depends_on or [],
+        "why_first": "test",
+    }
+
+
+def _build_params(**sections: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "plan_summary": {
+            "plan_name": "synthetic",
+            "plan_type": "synthetic",
+            "primary_goal": "test",
+            "modelling_frame": "test",
+        },
+        "key_values": [],
+        "derived_questions": [],
+        "missing_values_to_estimate": [],
+        "recommended_first_calculations": [],
+    }
+    base.update(sections)
+    return base
+
+
+# ─── build_prior_signal_ledger ────────────────────────────────────────────
+
+def test_ledger_lists_key_value_ids_with_section_and_kind() -> None:
+    params = _build_params(key_values=[_kv("alpha"), _kv("beta")])
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "# Prior Signal Ledger" in ledger
+    assert "`alpha` [key_values/id]" in ledger
+    assert "`beta` [key_values/id]" in ledger
+
+
+def test_ledger_lists_output_name_with_section_and_kind() -> None:
+    """A calc entry's output_name is tracked separately when it differs
+    from its entry id (typical for q_* derived_questions producing a
+    named margin)."""
+    params = _build_params(
+        derived_questions=[{
+            "id": "q_margin",
+            "question": "What is the margin?",
+            "why_it_matters": "test",
+            "formula_hint": "buildable_area_surplus = actual - required",
+            "output_name": "buildable_area_surplus",
+            "output_unit": "km2",
+            "depends_on": ["actual", "required"],
+        }],
+    )
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "`q_margin` [derived_questions/id]" in ledger
+    assert "`buildable_area_surplus` [derived_questions/output_name]" in ledger
+
+
+def test_ledger_includes_formula_hint_when_present() -> None:
+    params = _build_params(
+        recommended_first_calculations=[
+            _calc("calc_total", output_name="total_budget",
+                  formula="total_budget = a + b", depends_on=["a", "b"]),
+        ],
+    )
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "formula_hint: `total_budget = a + b`" in ledger
+
+
+def test_ledger_includes_depends_on_when_non_empty() -> None:
+    params = _build_params(
+        recommended_first_calculations=[
+            _calc("calc_total", output_name="total_budget",
+                  formula="total_budget = a + b", depends_on=["a", "b"]),
+        ],
+    )
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "depends_on: `a`, `b`" in ledger
+
+
+def test_ledger_omits_formula_hint_when_null() -> None:
+    """key_value entries usually have formula_hint=None; the ledger
+    should not emit a 'formula_hint: None' line for them."""
+    params = _build_params(key_values=[_kv("alpha")])
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "formula_hint" not in ledger
+
+
+def test_ledger_dedupes_when_id_equals_output_name() -> None:
+    """A calc whose entry id equals its output_name is listed once with
+    kind=id (the more authoritative reading)."""
+    params = _build_params(
+        recommended_first_calculations=[
+            _calc("burn_rate", output_name="burn_rate",
+                  formula="burn_rate = annual / 12", depends_on=["annual"]),
+        ],
+    )
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert ledger.count("`burn_rate`") == 1
+    assert "[recommended_first_calculations/id]" in ledger
+    assert "[recommended_first_calculations/output_name]" not in ledger
+
+
+def test_ledger_includes_unmodelled_gate_ids() -> None:
+    params = _build_params(
+        unmodelled_gates=[{
+            "id": "regulatory_floor_gate",
+            "label": "Regulatory floor",
+            "why_it_matters": "test",
+            "source_anchor": "assumptions",
+            "consequence_if_false": "test",
+        }],
+    )
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "`regulatory_floor_gate` [unmodelled_gates/id]" in ledger
+
+
+def test_ledger_lists_no_corpus_literals_for_empty_prior() -> None:
+    """Empty prior → first-iteration baseline message. No invented
+    signals."""
+    ledger = prepare.build_prior_signal_ledger(_build_params())
+    assert "first-iteration baseline" in ledger
+    assert "`alpha`" not in ledger
+
+
+def test_ledger_does_not_include_source_text_or_label() -> None:
+    """The ledger is a preservation budget, NOT a phrasing target.
+    label, source_text, comment, and value are intentionally excluded
+    so the LLM cannot copy old wording or anchor on old framings."""
+    params = _build_params(
+        key_values=[_kv(
+            "alpha",
+            label="Some descriptive label",
+            source_text="A long source quote about alpha and its meaning",
+            comment="A long comment about alpha's role",
+        )],
+    )
+    ledger = prepare.build_prior_signal_ledger(params)
+    assert "Some descriptive label" not in ledger
+    assert "long source quote" not in ledger
+    assert "long comment" not in ledger
+    # value is also excluded.
+    assert "1.0" not in ledger
+
+
+# ─── build_combined_digest end-to-end ─────────────────────────────────────
+
+def _make_minimal_planexe_dir(planexe_dir: Path) -> None:
+    """Write the raw .md / .csv files build_combined_digest expects, so
+    the BUNDLE iteration finds at least one section."""
+    (planexe_dir / "executive_summary.md").write_text("Executive summary text.\n")
+    (planexe_dir / "project_plan.md").write_text("Project plan text.\n")
+    (planexe_dir / "consolidate_assumptions_short.md").write_text("Assumptions text.\n")
+    (planexe_dir / "data_collection.md").write_text("Data collection text.\n")
+
+
+def test_build_combined_digest_omits_ledger_when_no_prior_provided() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmpdir = Path(td)
+        planexe = tmpdir / "planexe"
+        planexe.mkdir()
+        _make_minimal_planexe_dir(planexe)
+        outdir = tmpdir / "out"
+        outdir.mkdir()
+        combined = prepare.build_combined_digest(planexe, outdir)
+        text = combined.read_text(encoding="utf-8")
+    assert "Prior Signal Ledger" not in text
+    assert "Executive summary text" in text
+
+
+def test_build_combined_digest_appends_ledger_when_prior_provided() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmpdir = Path(td)
+        planexe = tmpdir / "planexe"
+        planexe.mkdir()
+        _make_minimal_planexe_dir(planexe)
+        outdir = tmpdir / "out"
+        outdir.mkdir()
+        prior = _build_params(key_values=[_kv("alpha")])
+        combined = prepare.build_combined_digest(planexe, outdir, prior_params=prior)
+        text = combined.read_text(encoding="utf-8")
+    assert "Prior Signal Ledger" in text
+    assert "`alpha` [key_values/id]" in text
+    # Ledger comes AFTER the bundle so the source remains authoritative.
+    ledger_idx = text.index("Prior Signal Ledger")
+    summary_idx = text.index("Executive summary text")
+    assert summary_idx < ledger_idx
+
+
+def test_build_combined_digest_ledger_section_uses_authoritative_framing() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmpdir = Path(td)
+        planexe = tmpdir / "planexe"
+        planexe.mkdir()
+        _make_minimal_planexe_dir(planexe)
+        outdir = tmpdir / "out"
+        outdir.mkdir()
+        prior = _build_params(key_values=[_kv("alpha")])
+        combined = prepare.build_combined_digest(planexe, outdir, prior_params=prior)
+        text = combined.read_text(encoding="utf-8")
+    # Required posture: ledger is advisory, source is authoritative.
+    assert "advisory" in text.lower()
+    assert "preservation budget" in text.lower()
+    assert "not a target to copy" in text.lower()


### PR DESCRIPTION
## Summary

Builds on PR #751 (Fork B audit) and PR #752 (`dropped_signals` schema + strict consumption) by closing the **prior_baseline loop**: the extract skill now has a way to see what the previous iteration emitted, so it can decide what to preserve and what to explain-drop.

Per review direction, the orchestration is intentionally **narrow**: the full prior `parameters.json` is **not** passed in. Instead, `prepare_extract_input.py` builds a compact Prior Signal Ledger and appends it to the combined digest at the end.

## What the ledger contains (and doesn't)

**Included** — just enough for the LLM to recognise prior signals and reason about structural relationships:
- Signal name (entry id or output_name)
- Section (`key_values`, `missing_values_to_estimate`, ...) and kind (`id` or `output_name`)
- `formula_hint` when present
- `depends_on` when non-empty

**Intentionally excluded** — these would anchor the LLM on old phrasings/framings, undermining the "preservation budget, not target" posture:
- `label`, `source_text`, `comment`, `value`

## Changes

1. **`prepare_extract_input.py`** gains a `--prior` CLI flag. When omitted (first-iteration extraction), no ledger is appended and behaviour is unchanged. When provided, `build_prior_signal_ledger` emits a compact markdown section appended **after** the bundle so the source remains authoritative.
2. **Both extract prompts** (`from-digest` and `from-full`) gain a `Prior Signal Ledger` subsection in the `dropped_signals` rules. Posture: ledger is advisory metadata, source remains authoritative; preserve when source-supported, record `dropped_signals` when not; do **not** invent `dropped_signals` for signals not in the ledger or source.
3. **12 synthetic unit tests** cover ledger construction (kv ids with section/kind, output_names tracked separately, formula_hint inclusion, formula_hint omission when null, id-equals-output_name dedupe, unmodelled_gates inclusion, first-iteration empty-ledger message, explicit exclusion of label/source_text/comment/value) plus end-to-end `build_combined_digest` with and without `--prior`.

## End-to-end empirical check

Ran `prepare_extract_input.py --prior` on paperclip's v49 `parameters.json`. The ledger lands at the end of the digest with all **18 prior signals** — matching `audit_source_preservation.build_signal_index` one-for-one. The latency-tripwire trio (`api_latency_p99_threshold_ms`, `api_latency_margin_ms`, `actual_api_p99_latency_ms`) that v51 silently dropped per the v49→v51 audit is present in the ledger. Infrastructure is now in place for the LLM extract skill to see these prior signals and either preserve them OR record `dropped_signals`.

## What this PR explicitly does NOT do

- **Does not re-run the LLM extract skill end-to-end.** That is the user's next step via the standard skill workflow — re-run `extract-parameters-from-digest` with the new digest, then `audit_source_preservation.py` against v49, then inspect whether `absent_unexplained` moves to `explained_drop` honestly (without hiding invalid drops via the PR #752 strict consumption).
- **Does not pass the full prior `parameters.json`** (per review direction — anchoring risk).
- **Does not change strict mode, CI gating, or Fork A scope.**
- **Does not bundle Phase 5 verify-bounds-citations or different-LLM validation.**

## Test plan
- [x] `pytest experiments/napkin_math/tests/test_prepare_extract_input_prior_ledger.py` (12 pass)
- [x] `python3 experiments/napkin_math/tests/run_smoke.py` (9/9 pass)
- [x] End-to-end smoke: `prepare_extract_input.py --prior` produces a digest with the ledger correctly appended (verified on paperclip v49 — 18 signals, matches the audit's signal universe one-for-one)
- [x] No `label` / `source_text` / `comment` / `value` leaks into the ledger (covered by `test_ledger_does_not_include_source_text_or_label`)
- [x] CI green on latest head

🤖 Generated with [Claude Code](https://claude.com/claude-code)