### PR TITLE
docs: add proposal 142 - how ChatGPT perceives PlanExe

### DIFF
--- a/docs/proposals/142-how-chatgpt-perceives-planexe.md
+++ b/docs/proposals/142-how-chatgpt-perceives-planexe.md
@@ -1,0 +1,535 @@
+# ChatGPT's Insights About PlanExe
+
+## Summary
+
+PlanExe appears to be best understood as a structured planning compiler: a system that turns vague project intent into a broad, organized, critique-ready planning artifact.
+
+Its strongest value is not that it produces final truth. Its strongest value is that it rapidly creates a coherent structure that humans can inspect, challenge, narrow, validate, and improve.
+
+PlanExe is especially useful for complex initiatives where the main early bottleneck is not execution, but coordination of thinking: identifying assumptions, stakeholders, risks, decision levers, dependencies, scenarios, and validation gates.
+
+It should not be treated as an autonomous expert, a factual authority, or a replacement for domain specialists. It is better treated as an accelerator for the first serious draft.
+
+## Core Perception
+
+PlanExe is more than a generic plan generator.
+
+A simple plan generator produces sections such as:
+
+- executive summary
+- timeline
+- budget
+- risks
+- stakeholders
+- tasks
+
+PlanExe’s stronger behavior is that it often identifies the shape of the problem:
+
+- the central strategic tension
+- the primary bottlenecks
+- competing execution paths
+- trade-offs between speed, cost, quality, compliance, and adoption
+- governance and stakeholder risks
+- hidden dependencies
+- points where the plan should be validated or killed
+
+This makes the output useful even when some details are wrong, speculative, or overconfident.
+
+The value is not only in the content. The value is in creating a shared artifact that people can argue with.
+
+## Best Description
+
+Good labels for PlanExe include:
+
+- AI planning compiler
+- structured pre-feasibility engine
+- coordination accelerator
+- strategic decision-support generator
+- institutional planning scaffold
+- first-draft strategy synthesizer
+
+Less accurate labels:
+
+- autonomous agent
+- execution agent
+- AGI-like system
+- final plan generator
+- truth engine
+
+PlanExe is not primarily an acting system. It does not execute the plan, negotiate with stakeholders, verify real-world constraints, procure resources, or monitor outcomes. It creates the structured reasoning substrate before those activities begin.
+
+## Where PlanExe Is Strong
+
+### 1. Blank-page elimination
+
+Many projects lose time before anyone has a shared model of the problem.
+
+PlanExe compresses the transition from:
+
+> “We have a vague idea.”
+
+to:
+
+> “Here is a structured artifact with goals, assumptions, risks, stakeholders, scenarios, decisions, dependencies, and execution phases.”
+
+That alone can save substantial time.
+
+### 2. Strategic decomposition
+
+PlanExe is good at breaking broad initiatives into meaningful dimensions:
+
+- technical feasibility
+- business viability
+- regulatory constraints
+- stakeholder incentives
+- financial exposure
+- operational capacity
+- compliance requirements
+- delivery milestones
+- risk mitigations
+- decision gates
+
+This is valuable because many human planning discussions start too narrowly. PlanExe tends to widen the frame.
+
+### 3. Risk surfacing
+
+PlanExe often identifies risks beyond generic “budget delay” language.
+
+It tends to surface categories such as:
+
+- governance failure
+- stakeholder non-compliance
+- data-quality failure
+- supply-chain bottlenecks
+- legal or regulatory blockage
+- incentive misalignment
+- integration fragility
+- public legitimacy / social-license risk
+- technical debt
+- under-specified economics
+- operational overload
+
+This makes it useful as a first-pass risk map.
+
+### 4. Scenario generation
+
+One of PlanExe’s strongest patterns is generating multiple strategic paths.
+
+Instead of producing only one plan, it can frame alternatives such as:
+
+- fast but risky
+- pragmatic and phased
+- conservative and controlled
+
+This is useful because strategy is not just task sequencing. Strategy is choosing which risks to accept.
+
+### 5. Decision-lever framing
+
+PlanExe can identify decisions that shape the entire project, such as:
+
+- build now vs validate first
+- centralize vs federate
+- standardize early vs allow flexibility
+- optimize for speed vs resilience
+- front-load compliance vs defer overhead
+- use public funding vs private risk-sharing
+- narrow MVP vs broad platform
+
+This is more valuable than a plain task list.
+
+Tasks tell people what to do.
+
+Decision levers clarify what must be decided.
+
+### 6. Coordination acceleration
+
+In large organizations, the slow part is often not writing. It is alignment:
+
+- Who owns the problem?
+- Which stakeholders matter?
+- Which assumptions are allowed?
+- What needs legal review?
+- What is a real blocker?
+- What can be deferred?
+- What should be measured?
+- What does success mean?
+
+PlanExe creates a first artifact around which these discussions can happen.
+
+This moves teams from open-ended conversation to structured critique.
+
+## Where PlanExe Is Weak
+
+### 1. It can over-specify invented mechanisms
+
+PlanExe often proposes detailed governance structures, funds, enforcement schemes, technical controls, review boards, audit processes, or operational procedures.
+
+Some may be useful. Some may be unrealistic. Some may be pure invention.
+
+The system needs a clear distinction between:
+
+- known facts
+- assumptions
+- inferred mechanisms
+- recommended controls
+- speculative proposals
+- open questions
+
+Without that separation, a reader may mistake a proposed mechanism for an existing or validated one.
+
+### 2. It can make complex projects sound more controllable than they are
+
+PlanExe is good at creating order.
+
+That can be dangerous.
+
+A neatly structured plan may create the impression that a messy real-world system is more governable than it actually is. Politics, procurement, regulation, physics, market behavior, and organizational inertia do not become easier just because the plan is well formatted.
+
+PlanExe should be read as:
+
+> “Here is a structured hypothesis.”
+
+not:
+
+> “Here is a proven execution path.”
+
+### 3. It can underweight validation
+
+PlanExe often identifies risks, but sometimes treats the act of naming a risk as if the risk is partly solved.
+
+A stronger version should force every critical risk into one of three states:
+
+- accepted
+- mitigated with evidence
+- unresolved and requiring validation
+
+A mitigation should not merely sound plausible. It should be testable.
+
+### 4. It can overpack MVPs and early phases
+
+PlanExe tends to include many reasonable-sounding features or controls in early phases.
+
+This can overload execution.
+
+For an MVP or pilot, the correct move is often brutal narrowing:
+
+- What single assumption are we testing?
+- What is the smallest useful implementation?
+- What can be deferred?
+- What would invalidate the idea?
+- What evidence is required before scaling?
+
+PlanExe should have a stronger scope-cutting pass.
+
+### 5. It is weaker on hard domain truth
+
+PlanExe can produce plausible domain language, but plausibility is not expertise.
+
+For technical, legal, scientific, medical, financial, defense, infrastructure, or regulatory topics, the output must be checked by qualified experts and grounded against current sources.
+
+PlanExe can identify what needs to be validated. It cannot be trusted to validate it by itself unless connected to strong evidence sources and review workflows.
+
+### 6. It can produce confident language before evidence exists
+
+Pitch-style sections can sound too polished.
+
+This creates a risk: speculative plans become rhetorically stronger than their evidence supports.
+
+A good planning system should separate:
+
+- what is proven
+- what is assumed
+- what is hoped
+- what is proposed
+- what is unknown
+
+This distinction is essential for trust.
+
+## PlanExe in the AI Landscape
+
+PlanExe is not AGI or ASI.
+
+It does not demonstrate general autonomy, independent execution, self-improvement, or robust real-world grounding.
+
+It fits better into a middle layer of AI systems:
+
+text Static templates   ↓ Single-shot chatbot plans   ↓ Structured planning pipelines   ↓ Tool-grounded planning agents   ↓ Semi-autonomous project agents   ↓ Autonomous organizational operators   ↓ AGI / ASI 
+
+PlanExe currently sits around:
+
+> structured planning pipeline / pre-feasibility engine
+
+It could move closer to a tool-grounded planning agent if it adds:
+
+- live research
+- source citation
+- assumption tracking
+- evidence grading
+- contradiction detection
+- expert review loops
+- execution tracking
+- plan-vs-actual feedback
+
+Its current value is not autonomy. Its value is structured cognition.
+
+## Acceleration Effect
+
+PlanExe’s acceleration depends heavily on project complexity.
+
+For simple projects, the acceleration may be modest because a competent human can draft a plan quickly.
+
+For complex, multi-domain, multi-stakeholder initiatives, the acceleration can be very large.
+
+Approximate first-draft acceleration:
+
+| Project type | Likely acceleration |
+|---|---:|
+| Simple personal or team plan | 3×–10× |
+| Startup or product MVP plan | 10×–30× |
+| Business launch or organizational plan | 10×–50× |
+| Regulated enterprise project | 50×–150× |
+| Policy / infrastructure / public-sector program | 50×–200× |
+| Large multi-stakeholder megaproject | 100×–500× for first discussion artifact |
+
+These numbers apply to the first structured draft, not to the full validated plan.
+
+The full lifecycle acceleration is lower:
+
+| Stage | Likely acceleration |
+|---|---:|
+| Blank page to structured artifact | Very high |
+| Structured artifact to expert-reviewed draft | High |
+| Expert-reviewed draft to validated plan | Moderate |
+| Validated plan to funded execution | Low to moderate |
+| Execution in the real world | Low |
+
+The reason is simple:
+
+> PlanExe accelerates thinking and coordination. It does not remove external reality.
+
+It cannot force regulators to approve, suppliers to deliver, customers to buy, systems to integrate, or physics to cooperate.
+
+## The Most Important Use Case
+
+PlanExe is strongest when used to produce:
+
+> the first serious artifact that experts can challenge.
+
+That is a powerful role.
+
+Many teams waste time trying to create the first complete framing. PlanExe can produce that framing quickly, allowing experts to spend their time on higher-value work:
+
+- rejecting false assumptions
+- correcting domain errors
+- narrowing scope
+- validating critical paths
+- adding real numbers
+- identifying fatal constraints
+- deciding whether the project deserves continuation
+
+This changes the workflow from:
+
+text create → organize → debate → revise 
+
+to:
+
+text critique → validate → narrow → decide 
+
+That is a major productivity shift.
+
+## Recommended Workflow
+
+A strong PlanExe workflow should look like this:
+
+### 1. Generate broad first draft
+
+Use PlanExe to produce the initial structured plan.
+
+Do not optimize too early. Let the system expose the full surface area.
+
+### 2. Mark claim types
+
+Classify every important claim as:
+
+- fact
+- assumption
+- inference
+- recommendation
+- placeholder number
+- unknown
+
+### 3. Run a contradiction pass
+
+Look for conflicts such as:
+
+- low budget + high scope
+- fast timeline + heavy compliance
+- MVP + enterprise-grade governance
+- decentralized model + centralized control
+- premium positioning + cheap operating model
+- high automation + manual process dependency
+
+### 4. Run a validation-gate pass
+
+For each critical assumption, define:
+
+- how to test it
+- who owns the test
+- what evidence is required
+- what result kills or changes the plan
+
+### 5. Cut scope
+
+Reduce the plan to the smallest useful execution path.
+
+Most generated plans should be cut significantly before execution.
+
+### 6. Add domain review
+
+Use subject-matter experts to validate:
+
+- technical feasibility
+- legal/regulatory claims
+- cost estimates
+- schedule realism
+- market assumptions
+- stakeholder incentives
+- compliance requirements
+
+### 7. Regenerate a tighter plan
+
+Use the validated assumptions to produce a second, more disciplined plan.
+
+The second plan should be much shorter, more concrete, and more evidence-bound.
+
+## What PlanExe Should Add Next
+
+The next level is not more sections.
+
+The next level is discipline.
+
+Recommended improvements:
+
+### 1. Assumption registry
+
+Every major plan should include a table like:
+
+| Assumption | Confidence | Evidence | Validation method | Owner | Deadline |
+|---|---:|---|---|---|---|
+
+### 2. Evidence grading
+
+Each claim should be tagged:
+
+- verified
+- plausible but unverified
+- inferred
+- speculative
+- requires expert review
+
+### 3. Kill criteria
+
+Every plan should define what would stop or downscope the project.
+
+Examples:
+
+- no anchor customer by date X
+- unit economics below threshold
+- supplier unavailable within budget
+- regulatory approval unlikely
+- technical target not met by gate review
+- stakeholder non-cooperation above threshold
+
+### 4. Unit economics / feasibility module
+
+For commercial plans, force:
+
+- average order value
+- gross margin
+- customer acquisition cost
+- sales cycle
+- churn
+- break-even volume
+- cash runway
+- sensitivity analysis
+
+For technical plans, force:
+
+- error budget
+- performance target
+- test method
+- integration risk
+- component maturity
+- dependency maturity
+- fallback architecture
+
+### 5. Internal consistency audit
+
+The system should explicitly detect contradictions between:
+
+- strategy and timeline
+- budget and scope
+- compliance and speed
+- staffing and workload
+- risk severity and mitigation strength
+- pitch claims and evidence level
+
+### 6. Reality-check mode
+
+PlanExe should support a mode that compares the plan against current external facts and marks which parts are:
+
+- aligned with reality
+- contradicted by reality
+- not publicly verifiable
+- plausible but unproven
+- invented mechanism
+
+### 7. Execution feedback loop
+
+If PlanExe is used repeatedly, it should learn from outcomes:
+
+- which estimates were wrong
+- which risks materialized
+- which tasks slipped
+- which assumptions failed
+- which sections were useful
+- which sections were ignored
+
+That would move it from planning generator to planning system.
+
+## Risks of Misuse
+
+PlanExe can be misused if readers treat outputs as final plans.
+
+Key risks:
+
+- polished prose creates false confidence
+- speculative mechanisms look official
+- budgets and timelines appear more grounded than they are
+- governance sections create an illusion of control
+- broad scope overwhelms execution
+- real-world validation is skipped
+- domain experts are brought in too late
+- stakeholders react to the pitch instead of the assumptions
+
+The correct use is critical reading, not passive acceptance.
+
+## Final Judgment
+
+PlanExe is not a replacement for experts.
+
+It is a replacement for a large amount of early-stage planning friction.
+
+Its best role is to create the first serious structured artifact: broad enough to expose the problem, detailed enough to critique, and organized enough to guide expert validation.
+
+The system’s main strength is not that it always knows the answer.
+
+Its main strength is that it often knows what kinds of questions must be answered.
+
+That is valuable.
+
+The shortest description is:
+
+> PlanExe turns vague ambition into structured hypotheses for humans to validate.
+
+That is a strong and economically meaningful capability.


### PR DESCRIPTION
## Summary

Adds `docs/proposals/142-how-chatgpt-perceives-planexe.md` — an external perspective on PlanExe's positioning and value.

Key points captured in the proposal:
- PlanExe is best understood as a **structured planning compiler**: it turns vague project intent into a broad, organized, critique-ready planning artifact
- Its value is in creating a shared artifact people can argue with, not in producing final truth
- Accurate labels: planning compiler, pre-feasibility engine, coordination accelerator
- Inaccurate labels: autonomous agent, execution agent, truth engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)